### PR TITLE
tracking ntuple setup for hlt iterative tracking

### DIFF
--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2975,6 +2975,10 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     label.ReplaceAll("seedTracks", "");
     label.ReplaceAll("Seeds","");
     label.ReplaceAll("muonSeeded","muonSeededStep");
+    //for HLT seeds
+    label.ReplaceAll("FromPixelTracks", "");
+    label.ReplaceAll("PFLowPixel", "");
+    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");//random choice
     int algo = reco::TrackBase::algoByName(label.Data());
 
     edm::ProductID id = seedTracks[0].seedRef().id();

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -113,7 +113,7 @@ def customiseTrackingNtupleHLT(process):
         #make sure that all iter tracking is done before running the ntuple-related modules
         process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
 
-    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.tracks = "hltMergedTracks"
     process.trackingNtuple.seedTracks = _seedSelectors
     process.trackingNtuple.trackCandidates = _candidatesProducers
     process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
@@ -127,8 +127,15 @@ def customiseTrackingNtupleHLT(process):
     process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
     process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
     process.trackingNtuple.includeMVA = False
+
+    return process
+
+def extendedContent(process):
+    process.trackingParticlesIntime.intimeOnly = False
+    process.trackingNtuple.includeOOT = True
+    process.trackingNtuple.keepEleSimHits = True
+
     process.trackingNtuple.saveSimHitsP3 = True
     process.trackingNtuple.addSeedCartesianCov = True
 
-    process.trackingNtupleSequence
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -8,15 +8,19 @@ def _label(tag):
         t = cms.InputTag(tag)
     return t.getModuleLabel()+t.getProductInstanceLabel()
 
-def customiseTrackingNtuple(process):
+def customiseTrackingNtupleTool(process, isRECO = True):
     process.load("Validation.RecoTrack.trackingNtuple_cff")
     process.TFileService = cms.Service("TFileService",
         fileName = cms.string('trackingNtuple.root')
     )
 
     if process.trackingNtuple.includeSeeds.value():
-        if not hasattr(process, "reconstruction_step"):
-            raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        if isRECO:
+            if not hasattr(process, "reconstruction_step"):
+                raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        else: #assumes HLT with PF iter
+            if not hasattr(process, "HLTIterativeTrackingIter02"):
+                raise Exception("TrackingNtuple includeSeeds=True needs HLTIterativeTrackingIter02 which is missing")
 
     # Replace validation_step with ntuplePath
     if not hasattr(process, "validation_step"):
@@ -27,7 +31,21 @@ def customiseTrackingNtuple(process):
     usePileupSimHits = hasattr(process, "mix") and hasattr(process.mix, "input") and len(process.mix.input.fileNames) > 0
 #    process.eda = cms.EDAnalyzer("EventContentAnalyzer")
 
+    if not isRECO:
+        if not hasattr(process,"hltMultiTrackValidation"):
+            process.load("Validation.RecoTrack.HLTmultiTrackValidator_cff")
+        process.trackingNtupleSequence = process.hltMultiTrackValidation.copy()
+        import RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitConverter_cfi as SiStripRecHitConverter_cfi
+        process.hltSiStripRecHits = SiStripRecHitConverter_cfi.siStripMatchedRecHits.clone(
+            ClusterProducer = "hltSiStripRawToClustersFacility",
+            StripCPE = "hltESPStripCPEfromTrackAngle:hltESPStripCPEfromTrackAngle"
+        )
+        process.trackingNtupleSequence.insert(0,process.trackingParticlesIntime+process.simHitTPAssocProducer)
+        process.trackingNtupleSequence.remove(process.hltTrackValidator)
+        process.trackingNtupleSequence += process.hltSiStripRecHits + process.trackingNtuple
+
     ntuplePath = cms.Path(process.trackingNtupleSequence)
+
     if process.trackingNtuple.includeAllHits and process.trackingNtuple.includeTrackingParticles and usePileupSimHits:
         ntuplePath.insert(0, cms.SequencePlaceholder("mix"))
 
@@ -61,4 +79,56 @@ def customiseTrackingNtuple(process):
             path.remove(outputModule)
         
 
+    return process
+
+def customiseTrackingNtuple(process):
+    customiseTrackingNtupleTool(process, isRECO = True)
+    return process
+
+def customiseTrackingNtupleHLT(process):
+    import Validation.RecoTrack.TrackValidation_cff as _TrackValidation_cff
+    _seedProducers = [
+        "hltIter0PFLowPixelSeedsFromPixelTracks",
+        "hltIter1PFLowPixelSeedsFromPixelTracks",
+        "hltIter2PFlowPixelSeeds",
+        "hltDoubletRecoveryPFlowPixelSeeds"
+    ]
+    _candidatesProducers = [ 
+        "hltIter0PFlowCkfTrackCandidates",
+        "hltIter1PFlowCkfTrackCandidates",
+        "hltIter2PFlowCkfTrackCandidates",
+        "hltDoubletRecoveryPFlowCkfTrackCandidates"
+    ]
+    (_seedSelectors, _tmpTask) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
+    _seedSelectorsTask = cms.Task()
+    for modName in _seedSelectors:
+        if not hasattr(process, modName):
+            setattr(process,modName, globals()[modName].clone(beamSpot = "hltOnlineBeamSpot"))
+        _seedSelectorsTask.add(getattr(process, modName))
+
+    customiseTrackingNtupleTool(process, isRECO = False)
+
+    process.trackingNtupleSequence.insert(0,cms.Sequence(_seedSelectorsTask))
+    if process.hltSiStripRawToClustersFacility.onDemand.value():
+        #make sure that all iter tracking is done before running the ntuple-related modules
+        process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
+
+    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.seedTracks = _seedSelectors
+    process.trackingNtuple.trackCandidates = _candidatesProducers
+    process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
+    process.trackingNtuple.trackAssociator = "hltTrackAssociatorByHits"
+    process.trackingNtuple.beamSpot = "hltOnlineBeamSpot"
+    process.trackingNtuple.pixelRecHits = "hltSiPixelRecHits"
+    process.trackingNtuple.stripRphiRecHits = "hltSiStripRecHits:rphiRecHit"
+    process.trackingNtuple.stripStereoRecHits = "hltSiStripRecHits:stereoRecHit"
+    process.trackingNtuple.stripMatchedRecHits = "hltSiStripRecHits:matchedRecHit"
+    process.trackingNtuple.vertices = "hltPixelVertices"
+    process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
+    process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
+    process.trackingNtuple.includeMVA = False
+    process.trackingNtuple.saveSimHitsP3 = True
+    process.trackingNtuple.addSeedCartesianCov = True
+
+    process.trackingNtupleSequence
     return process


### PR DESCRIPTION
this was tested on a muon sample

The steps to reproduce from "scratch" (a "step2" file input with RAW and sim/digi info is required):
- get an HLT config fragment
    - ```git cms-addpkg HLTrigger/Configuration```
```
hltGetConfiguration --cff --mc --type GRun \
--paths HLTriggerFirstPath,MC_ReducedIterativeTracking_v12,HLTriggerFinalPath\
 --unprescale --globaltag auto:run2_mc_GRun /dev/CMSSW_10_3_0/GRun\
 >& HLTrigger/Configuration/python/HLT_ReducedIterativeTracking_cff.py
```

- rerun HLT with trackingNtuple
```
cmsDriver.py stepHLT --process reHLT --conditions auto:run2_mc_GRun\
 -s HLT:ReducedIterativeTracking,VALIDATION:@baseValidation \
--datatier GEN-SIM-DIGI-RAW --geometry DB:Extended --era Run2_2018\
 --eventcontent FEVTDEBUGHLT -n 100 --filein file:step2.root --fileout file:stepHLT.root \
--nThreads 8 --inputCommands='keep *','drop *_hlt*_*_HLT' \
--customise Validation/RecoTrack/customiseTrackingNtuple.customiseTrackingNtupleHLT 
```

This is still a work in progress, since I didn't check yet if everything works down to the mkFit conversion and validation.
@makortel please take a look and let me know if changes are reasonable
