### PR TITLE
Forward port not-in-official-CMSSW mkFit developments to 11_2_0_pre8

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -286,11 +286,14 @@ upgradeWFs['pixelTrackingOnly'].step3 = {
 
 class UpgradeWorkflow_trackingMkFit(UpgradeWorkflowTracking):
     def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Digi' in step: stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
     def condition_(self, fragment, stepList, key, hasHarvest):
         return '2017' in key or '2021' in key
 upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
     steps = [
+        'Digi',
+        'DigiTrigger',
         'Reco',
         'RecoGlobal',
     ],
@@ -298,6 +301,9 @@ upgradeWFs['trackingMkFit'] = UpgradeWorkflow_trackingMkFit(
     suffix = '_trackingMkFit',
     offset = 0.7,
 )
+upgradeWFs['trackingMkFit'].step2 = {
+    '--customise': 'RecoTracker/MkFit/customizeHLTIter0ToMkFit.customizeHLTIter0ToMkFit'
+}
 upgradeWFs['trackingMkFit'].step3 = {
     '--procModifiers': 'trackingMkFit'
 }

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -224,6 +224,7 @@ initialStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTr
 )
 
 from Configuration.ProcessModifiers.trackingMkFit_cff import trackingMkFit
+from RecoTracker.MkFit.mkFitGeometryESProducer_cfi import mkFitGeometryESProducer
 import RecoTracker.MkFit.mkFitInputConverter_cfi as mkFitInputConverter_cfi
 import RecoTracker.MkFit.mkFitProducer_cfi as mkFitProducer_cfi
 import RecoTracker.MkFit.mkFitOutputConverter_cfi as mkFitOutputConverter_cfi
@@ -416,7 +417,7 @@ InitialStepTask = cms.Task(initialStepSeedLayers,
 InitialStep = cms.Sequence(InitialStepTask)
 
 _InitialStepTask_trackingMkFit = InitialStepTask.copy()
-_InitialStepTask_trackingMkFit.add(initialStepTrackCandidatesMkFitInput, initialStepTrackCandidatesMkFit)
+_InitialStepTask_trackingMkFit.add(initialStepTrackCandidatesMkFitInput, initialStepTrackCandidatesMkFit, mkFitGeometryESProducer)
 trackingMkFit.toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFit)
 
 _InitialStepTask_LowPU = InitialStepTask.copyAndExclude([firstStepPrimaryVerticesUnsorted, initialStepTrackRefsForJets, caloJetsForTrkTask, firstStepPrimaryVertices, initialStepClassifier1, initialStepClassifier2, initialStepClassifier3])

--- a/RecoTracker/MkFit/BuildFile.xml
+++ b/RecoTracker/MkFit/BuildFile.xml
@@ -1,5 +1,8 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Provenance"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="RecoTracker/TkDetLayers"/>
 <use name="mkfit"/>
 <use name="rootcore"/>
 <export>

--- a/RecoTracker/MkFit/interface/MkFitGeometry.h
+++ b/RecoTracker/MkFit/interface/MkFitGeometry.h
@@ -2,6 +2,7 @@
 #define RecoTracker_MkFit_MkFitGeometry_h
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace mkfit {
@@ -25,10 +26,12 @@ public:
 
   mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
   const std::vector<const DetLayer*>& detLayers() const { return dets_; }
+  unsigned int uniqueIdInLayer(unsigned int detId) const { return detIdToShortId_.at(detId); }
 
 private:
   std::unique_ptr<mkfit::LayerNumberConverter> lnc_;  // for pimpl pattern
   std::vector<const DetLayer*> dets_;
+  std::unordered_map<unsigned int, unsigned int> detIdToShortId_;
 };
 
 #endif

--- a/RecoTracker/MkFit/interface/MkFitGeometry.h
+++ b/RecoTracker/MkFit/interface/MkFitGeometry.h
@@ -1,0 +1,34 @@
+#ifndef RecoTracker_MkFit_MkFitGeometry_h
+#define RecoTracker_MkFit_MkFitGeometry_h
+
+#include <memory>
+#include <vector>
+
+namespace mkfit {
+  class LayerNumberConverter;
+}
+
+class DetLayer;
+class GeometricSearchTracker;
+class TrackerGeometry;
+class TrackerTopology;
+
+/**
+ * Collection of geometry-related objects for mkFit
+ */
+class MkFitGeometry {
+public:
+  explicit MkFitGeometry(const TrackerGeometry& geom,
+                         const GeometricSearchTracker& tracker,
+                         const TrackerTopology& ttopo);
+  ~MkFitGeometry();
+
+  mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
+  const std::vector<const DetLayer*>& detLayers() const { return dets_; }
+
+private:
+  std::unique_ptr<mkfit::LayerNumberConverter> lnc_;  // for pimpl pattern
+  std::vector<const DetLayer*> dets_;
+};
+
+#endif

--- a/RecoTracker/MkFit/interface/MkFitGeometry.h
+++ b/RecoTracker/MkFit/interface/MkFitGeometry.h
@@ -26,12 +26,12 @@ public:
 
   mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
   const std::vector<const DetLayer*>& detLayers() const { return dets_; }
-  unsigned int uniqueIdInLayer(unsigned int detId) const { return detIdToShortId_.at(detId); }
+  unsigned int uniqueIdInLayer(int layer, unsigned int detId) const { return detIdToShortId_.at(layer).at(detId); }
 
 private:
   std::unique_ptr<mkfit::LayerNumberConverter> lnc_;  // for pimpl pattern
   std::vector<const DetLayer*> dets_;
-  std::unordered_map<unsigned int, unsigned int> detIdToShortId_;
+  std::vector<std::unordered_map<unsigned int, unsigned int>> detIdToShortId_;
 };
 
 #endif

--- a/RecoTracker/MkFit/interface/MkFitInputWrapper.h
+++ b/RecoTracker/MkFit/interface/MkFitInputWrapper.h
@@ -17,10 +17,7 @@ namespace mkfit {
 class MkFitInputWrapper {
 public:
   MkFitInputWrapper();
-  MkFitInputWrapper(MkFitHitIndexMap hitIndexMap,
-                    std::vector<mkfit::HitVec> hits,
-                    mkfit::TrackVec seeds,
-                    mkfit::LayerNumberConverter const& lnc);
+  MkFitInputWrapper(MkFitHitIndexMap hitIndexMap, std::vector<mkfit::HitVec> hits, mkfit::TrackVec seeds);
   ~MkFitInputWrapper();
 
   MkFitInputWrapper(MkFitInputWrapper const&) = delete;
@@ -31,14 +28,11 @@ public:
   MkFitHitIndexMap const& hitIndexMap() const { return hitIndexMap_; }
   mkfit::TrackVec const& seeds() const { return *seeds_; }
   std::vector<mkfit::HitVec> const& hits() const { return hits_; }
-  mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
-  unsigned int nlayers() const;
 
 private:
   MkFitHitIndexMap hitIndexMap_;
   std::vector<mkfit::HitVec> hits_;
-  std::unique_ptr<mkfit::TrackVec> seeds_;            // for pimpl pattern
-  std::unique_ptr<mkfit::LayerNumberConverter> lnc_;  // for pimpl pattern
+  std::unique_ptr<mkfit::TrackVec> seeds_;  // for pimpl pattern
 };
 
 #endif

--- a/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
@@ -1,0 +1,48 @@
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+
+// mkFit includes
+#include "ConfigWrapper.h"
+
+#include <atomic>
+
+class MkFitGeometryESProducer : public edm::ESProducer {
+public:
+  MkFitGeometryESProducer(const edm::ParameterSet& iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  std::unique_ptr<MkFitGeometry> produce(const TrackerRecoGeometryRecord& iRecord);
+
+private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> trackerToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+};
+
+MkFitGeometryESProducer::MkFitGeometryESProducer(const edm::ParameterSet& iConfig) {
+  auto cc = setWhatProduced(this);
+  geomToken_ = cc.consumes();
+  trackerToken_ = cc.consumes();
+  ttopoToken_ = cc.consumes();
+}
+
+void MkFitGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<MkFitGeometry> MkFitGeometryESProducer::produce(const TrackerRecoGeometryRecord& iRecord) {
+  return std::make_unique<MkFitGeometry>(iRecord.get(geomToken_), iRecord.get(trackerToken_), iRecord.get(ttopoToken_));
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(MkFitGeometryESProducer);

--- a/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
@@ -181,9 +181,9 @@ void MkFitInputConverter::convertHits(const HitCollection& hits,
     const auto subdet = detid.subdetId();
     const auto layer = ttopo.layer(detid);
     const auto isStereo = ttopo.isStereo(detid);
-    const auto uniqueIdInLayer = mkFitGeom.uniqueIdInLayer(detid.rawId());
     const auto ilay =
         mkFitGeom.layerNumberConverter().convertLayerNumber(subdet, layer, false, isStereo, isPlusSide(detid));
+    const auto uniqueIdInLayer = mkFitGeom.uniqueIdInLayer(ilay, detid.rawId());
     hitIndexMap.increaseLayerSize(ilay, detset.size());  // to minimize memory allocations
 
     for (const auto& hit : detset) {

--- a/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitInputConverter.cc
@@ -53,11 +53,14 @@ private:
                    const TransientTrackingRecHitBuilder& ttrhBuilder,
                    const MkFitGeometry& mkFitGeom) const;
 
-  bool passCCC(const SiStripRecHit2D& hit, const DetId hitId) const;
-  bool passCCC(const SiPixelRecHit& hit, const DetId hitId) const;
+  float clusterCharge(const SiStripRecHit2D& hit, DetId hitId) const;
+  nullptr_t clusterCharge(const SiPixelRecHit& hit, DetId hitId) const;
 
-  void setDetails(mkfit::Hit& mhit, const SiPixelRecHit& hit, const DetId hitId, const int shortId) const;
-  void setDetails(mkfit::Hit& mhit, const SiStripRecHit2D& hit, const DetId hitId, const int shortId) const;
+  bool passCCC(float charge) const;
+  bool passCCC(nullptr_t) const;  //pixel
+
+  void setDetails(mkfit::Hit& mhit, const SiPixelCluster& cluster, const int shortId, nullptr_t) const;
+  void setDetails(mkfit::Hit& mhit, const SiStripCluster& cluster, const int shortId, float charge) const;
 
   mkfit::TrackVec convertSeeds(const edm::View<TrajectorySeed>& seeds,
                                const MkFitHitIndexMap& hitIndexMap,
@@ -132,26 +135,21 @@ void MkFitInputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const e
   iEvent.emplace(putToken_, std::move(hitIndexMap), std::move(mkFitHits), std::move(mkFitSeeds));
 }
 
-bool MkFitInputConverter::passCCC(const SiStripRecHit2D& hit, const DetId hitId) const {
-  return (siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster()) > minGoodStripCharge_);
+float MkFitInputConverter::clusterCharge(const SiStripRecHit2D& hit, DetId hitId) const {
+  return siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster());
+}
+nullptr_t MkFitInputConverter::clusterCharge(const SiPixelRecHit& hit, DetId hitId) const { return nullptr; }
+
+bool MkFitInputConverter::passCCC(float charge) const { return charge > minGoodStripCharge_; }
+
+bool MkFitInputConverter::passCCC(nullptr_t) const { return true; }
+
+void MkFitInputConverter::setDetails(mkfit::Hit& mhit, const SiPixelCluster& cluster, int shortId, nullptr_t) const {
+  mhit.setupAsPixel(shortId, cluster.sizeX(), cluster.sizeY());
 }
 
-bool MkFitInputConverter::passCCC(const SiPixelRecHit& hit, const DetId hitId) const { return true; }
-
-void MkFitInputConverter::setDetails(mkfit::Hit& mhit,
-                                     const SiPixelRecHit& hit,
-                                     const DetId hitId,
-                                     const int shortId) const {
-  mhit.setupAsPixel(shortId, hit.cluster()->sizeX(), hit.cluster()->sizeY());
-}
-
-void MkFitInputConverter::setDetails(mkfit::Hit& mhit,
-                                     const SiStripRecHit2D& hit,
-                                     const DetId hitId,
-                                     const int shortId) const {
-  mhit.setupAsStrip(shortId,
-                    siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster()),
-                    hit.cluster()->amplitudes().size());
+void MkFitInputConverter::setDetails(mkfit::Hit& mhit, const SiStripCluster& cluster, int shortId, float charge) const {
+  mhit.setupAsStrip(shortId, charge, cluster.amplitudes().size());
 }
 
 template <typename HitCollection>
@@ -183,12 +181,14 @@ void MkFitInputConverter::convertHits(const HitCollection& hits,
     const auto subdet = detid.subdetId();
     const auto layer = ttopo.layer(detid);
     const auto isStereo = ttopo.isStereo(detid);
+    const auto uniqueIdInLayer = mkFitGeom.uniqueIdInLayer(detid.rawId());
     const auto ilay =
         mkFitGeom.layerNumberConverter().convertLayerNumber(subdet, layer, false, isStereo, isPlusSide(detid));
     hitIndexMap.increaseLayerSize(ilay, detset.size());  // to minimize memory allocations
 
     for (const auto& hit : detset) {
-      if (!passCCC(hit, detid))
+      const auto charge = clusterCharge(hit, detid);
+      if (!passCCC(charge))
         continue;
 
       const auto& gpos = hit.globalPosition();
@@ -211,7 +211,7 @@ void MkFitInputConverter::convertHits(const HitCollection& hits,
                          MkFitHitIndexMap::MkFitHit{static_cast<int>(mkFitHits[ilay].size()), ilay},
                          &hit);
       mkFitHits[ilay].emplace_back(pos, err, totalHits);
-      setDetails(mkFitHits[ilay].back(), hit, detid, mkFitGeom.uniqueIdInLayer(detid.rawId()));
+      setDetails(mkFitHits[ilay].back(), *(hit.cluster()), uniqueIdInLayer, charge);
       ++totalHits;
     }
   }

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -12,12 +12,6 @@
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 #include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
@@ -34,11 +28,10 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/MaterialEffects/src/PropagatorWithMaterial.cc"
 
-#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
-#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-
 #include "RecoTracker/MkFit/interface/MkFitInputWrapper.h"
 #include "RecoTracker/MkFit/interface/MkFitOutputWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
 // mkFit indludes
 #include "LayerNumberConverter.h"
@@ -68,14 +61,9 @@ public:
 private:
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
-  std::vector<const DetLayer*> createDetLayers(const mkfit::LayerNumberConverter& lnc,
-                                               const GeometricSearchTracker& tracker,
-                                               const TrackerTopology& ttopo) const;
-
   TrackCandidateCollection convertCandidates(const MkFitOutputWrapper& mkFitOutput,
                                              const MkFitHitIndexMap& hitIndexMap,
                                              const edm::View<TrajectorySeed>& seeds,
-                                             const TrackerGeometry& geom,
                                              const MagneticField& mf,
                                              const Propagator& propagatorAlong,
                                              const Propagator& propagatorOpposite,
@@ -99,13 +87,11 @@ private:
   edm::EDGetTokenT<MkFitInputWrapper> hitsSeedsToken_;
   edm::EDGetTokenT<MkFitOutputWrapper> tracksToken_;
   edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
-  edm::EDGetTokenT<MeasurementTrackerEvent> mteToken_;
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
   edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
   edm::EDPutTokenT<TrackCandidateCollection> putTrackCandidateToken_;
   edm::EDPutTokenT<std::vector<SeedStopInfo>> putSeedStopInfoToken_;
   std::string ttrhBuilderName_;
@@ -118,16 +104,14 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
     : hitsSeedsToken_{consumes<MkFitInputWrapper>(iConfig.getParameter<edm::InputTag>("hitsSeeds"))},
       tracksToken_{consumes<MkFitOutputWrapper>(iConfig.getParameter<edm::InputTag>("tracks"))},
       seedToken_{consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("seeds"))},
-      mteToken_{consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("measurementTrackerEvent"))},
-      geomToken_{esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()},
       propagatorAlongToken_{
           esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
       propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
           iConfig.getParameter<edm::ESInputTag>("propagatorOpposite"))},
-      ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
       mfToken_{esConsumes<MagneticField, IdealMagneticFieldRecord>()},
       ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
           iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
+      mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
       putTrackCandidateToken_{produces<TrackCandidateCollection>()},
       putSeedStopInfoToken_{produces<std::vector<SeedStopInfo>>()},
       backwardFitInCMSSW_{iConfig.getParameter<bool>("backwardFitInCMSSW")} {}
@@ -138,7 +122,6 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add("hitsSeeds", edm::InputTag{"mkFitInputConverter"});
   desc.add("tracks", edm::InputTag{"mkFitProducer"});
   desc.add("seeds", edm::InputTag{"initialStepSeeds"});
-  desc.add("measurementTrackerEvent", edm::InputTag{"MeasurementTrackerEvent"});
   desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
   desc.add("propagatorAlong", edm::ESInputTag{"", "PropagatorWithMaterial"});
   desc.add("propagatorOpposite", edm::ESInputTag{"", "PropagatorWithMaterialOpposite"});
@@ -151,78 +134,33 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
 void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   const auto& seeds = iEvent.get(seedToken_);
   const auto& hitsSeeds = iEvent.get(hitsSeedsToken_);
-  const auto& mte = iEvent.get(mteToken_);
 
   const auto& ttrhBuilder = iSetup.getData(ttrhBuilderToken_);
   const auto* tkBuilder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(&ttrhBuilder);
   if (!tkBuilder) {
     throw cms::Exception("LogicError") << "TTRHBuilder must be of type TkTransientTrackingRecHitBuilder";
   }
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
 
   // Convert mkfit presentation back to CMSSW
-  const auto detlayers =
-      createDetLayers(hitsSeeds.layerNumberConverter(), *(mte.geometricSearchTracker()), iSetup.getData(ttopoToken_));
   iEvent.emplace(putTrackCandidateToken_,
                  convertCandidates(iEvent.get(tracksToken_),
                                    hitsSeeds.hitIndexMap(),
                                    seeds,
-                                   iSetup.getData(geomToken_),
                                    iSetup.getData(mfToken_),
                                    iSetup.getData(propagatorAlongToken_),
                                    iSetup.getData(propagatorOppositeToken_),
                                    tkBuilder->cloner(),
-                                   detlayers,
+                                   mkFitGeom.detLayers(),
                                    hitsSeeds.seeds()));
 
   // TODO: SeedStopInfo is currently unfilled
   iEvent.emplace(putSeedStopInfoToken_, seeds.size());
 }
 
-std::vector<const DetLayer*> MkFitOutputConverter::createDetLayers(const mkfit::LayerNumberConverter& lnc,
-                                                                   const GeometricSearchTracker& tracker,
-                                                                   const TrackerTopology& ttopo) const {
-  std::vector<const DetLayer*> dets(lnc.nLayers(), nullptr);
-
-  auto isPlusSide = [&ttopo](const DetId& detid) {
-    return ttopo.side(detid) == static_cast<unsigned>(TrackerDetSide::PosEndcap);
-  };
-  auto setDet = [&lnc, &dets, &isPlusSide](
-                    const int subdet, const int layer, const int isStereo, const DetId& detId, const DetLayer* lay) {
-    const int index = lnc.convertLayerNumber(subdet, layer, false, isStereo, isPlusSide(detId));
-    if (index < 0 or static_cast<unsigned>(index) >= dets.size()) {
-      throw cms::Exception("LogicError") << "Invalid mkFit layer index " << index << " for DetId " << detId
-                                         << " subdet " << subdet << " layer " << layer << " isStereo " << isStereo;
-    }
-    dets[index] = lay;
-  };
-  constexpr int monoLayer = 0;
-  constexpr int stereoLayer = 1;
-  for (const DetLayer* lay : tracker.allLayers()) {
-    const auto& comp = lay->basicComponents();
-    if (UNLIKELY(comp.empty())) {
-      throw cms::Exception("LogicError") << "Got a tracker layer (subdet " << lay->subDetector()
-                                         << ") with empty basicComponents.";
-    }
-    // First component is enough for layer and side information
-    const auto& detId = comp.front()->geographicalId();
-    const auto subdet = detId.subdetId();
-    const auto layer = ttopo.layer(detId);
-
-    // TODO: mono/stereo structure is still hardcoded for phase0/1 strip tracker
-    setDet(subdet, layer, monoLayer, detId, lay);
-    if (((subdet == StripSubdetector::TIB or subdet == StripSubdetector::TOB) and (layer == 1 or layer == 2)) or
-        subdet == StripSubdetector::TID or subdet == StripSubdetector::TEC) {
-      setDet(subdet, layer, stereoLayer, detId, lay);
-    }
-  }
-
-  return dets;
-}
-
 TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutputWrapper& mkFitOutput,
                                                                  const MkFitHitIndexMap& hitIndexMap,
                                                                  const edm::View<TrajectorySeed>& seeds,
-                                                                 const TrackerGeometry& geom,
                                                                  const MagneticField& mf,
                                                                  const Propagator& propagatorAlong,
                                                                  const Propagator& propagatorOpposite,

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -8,15 +8,15 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-
 #include "RecoTracker/MkFit/interface/MkFitInputWrapper.h"
 #include "RecoTracker/MkFit/interface/MkFitOutputWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
 // mkFit includes
 #include "ConfigWrapper.h"
 #include "Event.h"
+#include "LayerNumberConverter.h"
 #include "mkFit/buildtestMPlex.h"
 #include "mkFit/MkBuilderWrapper.h"
 
@@ -39,7 +39,7 @@ private:
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   edm::EDGetTokenT<MkFitInputWrapper> hitsSeedsToken_;
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
   edm::EDPutTokenT<MkFitOutputWrapper> putToken_;
   std::function<double(mkfit::Event&, mkfit::MkBuilder&)> buildFunction_;
   bool backwardFitInCMSSW_;
@@ -48,7 +48,7 @@ private:
 
 MkFitProducer::MkFitProducer(edm::ParameterSet const& iConfig)
     : hitsSeedsToken_{consumes<MkFitInputWrapper>(iConfig.getParameter<edm::InputTag>("hitsSeeds"))},
-      geomToken_{esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()},
+      mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
       putToken_{produces<MkFitOutputWrapper>()},
       backwardFitInCMSSW_{iConfig.getParameter<bool>("backwardFitInCMSSW")},
       mkFitSilent_{iConfig.getUntrackedParameter<bool>("mkFitSilent")} {
@@ -112,17 +112,19 @@ namespace {
 }
 void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   const auto& hitsSeeds = iEvent.get(hitsSeedsToken_);
-  const auto& geom = iSetup.getData(geomToken_);
-
-  if (geom.numberOfLayers(PixelSubdetector::PixelBarrel) != 4 ||
-      geom.numberOfLayers(PixelSubdetector::PixelEndcap) != 3) {
-    throw cms::Exception("Assert") << "For now this code works only with phase1 tracker, you have something else";
-  }
+  // This producer does not strictly speaking need the MkFitGeometry,
+  // but the ESProducer sets global variables (yes, that "feature"
+  // should be removed), so getting the MkFitGeometry makes it
+  // sure that the ESProducer is called even if the input/output
+  // converters
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
 
   // Initialize the number of layers, has to be done exactly once in
   // the whole program.
   // TODO: the mechanism needs to be improved...
-  std::call_once(geometryFlag, [nlayers = hitsSeeds.nlayers()]() { mkfit::ConfigWrapper::setNTotalLayers(nlayers); });
+  std::call_once(geometryFlag, [nlayers = mkFitGeom.layerNumberConverter().nLayers()]() {
+    mkfit::ConfigWrapper::setNTotalLayers(nlayers);
+  });
 
   // CMSSW event ID (64-bit unsigned) does not fit in int
   // In addition, unique ID requires also lumi and run

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -85,6 +85,7 @@ MkFitProducer::MkFitProducer(edm::ParameterSet const& iConfig)
   // TODO: what to do when we have multiple instances of MkFitProducer in a job?
   mkfit::MkBuilderWrapper::populate(isFV);
   mkfit::ConfigWrapper::initializeForCMSSW(seedCleanOpt, backwardFitOpt, mkFitSilent_);
+  mkfit::ConfigWrapper::setRemoveDuplicates(iConfig.getParameter<bool>("removeDuplicates"));
 }
 
 void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -94,6 +95,7 @@ void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<std::string>("buildingRoutine", "cloneEngine")
       ->setComment("Valid values are: 'bestHit', 'standard', 'cloneEngine', 'fullVector'");
   desc.add<std::string>("seedCleaning", "N2")->setComment("Valid values are: 'none', 'N2'");
+  desc.add("removeDuplicates", true)->setComment("Run duplicate removal within mkFit");
   desc.add("backwardFitInCMSSW", false)
       ->setComment("Do backward fit (to innermost hit) in CMSSW (true) or mkFit (false)");
   desc.addUntracked("mkFitSilent", true)->setComment("Allows to enables printouts from mkFit with 'False'");

--- a/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
+++ b/RecoTracker/MkFit/python/customizeHLTIter0ToMkFit.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+import RecoTracker.MkFit.mkFitGeometryESProducer_cfi as mkFitGeometryESProducer_cfi
+import RecoTracker.MkFit.mkFitInputConverter_cfi as mkFitInputConverter_cfi
+import RecoTracker.MkFit.mkFitProducer_cfi as mkFitProducer_cfi
+import RecoTracker.MkFit.mkFitOutputConverter_cfi as mkFitOutputConverter_cfi
+import RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitConverter_cfi as SiStripRecHitConverter_cfi
+
+def customizeHLTIter0ToMkFit(process):
+    # mkFit needs all clusters, so switch off the on-demand mode
+    process.hltSiStripRawToClustersFacility.onDemand = False
+
+    process.hltSiStripRecHits = SiStripRecHitConverter_cfi.siStripMatchedRecHits.clone(
+        ClusterProducer = "hltSiStripRawToClustersFacility",
+        StripCPE = "hltESPStripCPEfromTrackAngle:hltESPStripCPEfromTrackAngle",
+        doMatching = False,
+    )
+
+    # Use fourth hit if one is available
+    process.hltIter0PFLowPixelSeedsFromPixelTracks.includeFourthHit = cms.bool(True)
+
+    process.hltMkFitGeometryESProducer = mkFitGeometryESProducer_cfi.mkFitGeometryESProducer.clone()
+
+    process.hltIter0PFlowCkfTrackCandidatesMkFitInput = mkFitInputConverter_cfi.mkFitInputConverter.clone(
+        pixelRecHits = "hltSiPixelRecHits",
+        stripRphiRecHits = "hltSiStripRecHits:rphiRecHit",
+        stripStereoRecHits = "hltSiStripRecHits:stereoRecHit",
+        seeds = "hltIter0PFLowPixelSeedsFromPixelTracks",
+        ttrhBuilder = ":hltESPTTRHBWithTrackAngle",
+        minGoodStripCharge = dict(refToPSet_ = 'HLTSiStripClusterChargeCutLoose'),
+    )
+    process.hltIter0PFlowCkfTrackCandidatesMkFit = mkFitProducer_cfi.mkFitProducer.clone(
+        hitsSeeds = "hltIter0PFlowCkfTrackCandidatesMkFitInput",
+    )
+    process.hltIter0PFlowCkfTrackCandidates = mkFitOutputConverter_cfi.mkFitOutputConverter.clone(
+        seeds = "hltIter0PFLowPixelSeedsFromPixelTracks",
+        hitsSeeds = "hltIter0PFlowCkfTrackCandidatesMkFitInput",
+        tracks = "hltIter0PFlowCkfTrackCandidatesMkFit",
+        ttrhBuilder = ":hltESPTTRHBWithTrackAngle",
+        propagatorAlong = ":PropagatorWithMaterialParabolicMf",
+        propagatorOpposite = ":PropagatorWithMaterialParabolicMfOpposite",
+    )
+
+    process.HLTDoLocalStripSequence += process.hltSiStripRecHits
+    process.HLTIterativeTrackingIteration0.replace(process.hltIter0PFlowCkfTrackCandidates,
+                                                   process.hltIter0PFlowCkfTrackCandidatesMkFitInput+process.hltIter0PFlowCkfTrackCandidatesMkFit+process.hltIter0PFlowCkfTrackCandidates)
+
+    return process

--- a/RecoTracker/MkFit/python/customizeInitialStepOnly.py
+++ b/RecoTracker/MkFit/python/customizeInitialStepOnly.py
@@ -12,11 +12,9 @@ def customizeInitialStepOnly(process):
     process.initialStepSeedLayers.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
     process.initialStepHitQuadruplets.SeedComparitorPSet.clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
     process.initialStepSeeds.SeedComparitorPSet.ClusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
-    if hasattr(process.initialStepTrackCandidates, "measurementTrackerEvent"):
-        # mkFit case
-        process.initialStepTrackCandidates.measurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
+    if hasattr(process, "initialStepTrackCandidatesMkFitInput"):
         process.initialStepTrackCandidatesMkFitInput.pixelRecHits = "siPixelRecHitsPreSplitting"
-    else:
+    if hasattr(process.initialStepTrackCandidates, "MeasurementTrackerEvent"):
         process.initialStepTrackCandidates.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
     process.initialStepTracks.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
     process.iterTrackingTask = cms.Task(process.trackerClusterCheck,

--- a/RecoTracker/MkFit/src/ES_MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/ES_MkFitGeometry.cc
@@ -1,0 +1,3 @@
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(MkFitGeometry);

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -1,0 +1,57 @@
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+
+#include "LayerNumberConverter.h"
+
+MkFitGeometry::MkFitGeometry(const TrackerGeometry& geom,
+                             const GeometricSearchTracker& tracker,
+                             const TrackerTopology& ttopo)
+    : lnc_{std::make_unique<mkfit::LayerNumberConverter>(mkfit::TkLayout::phase1)} {
+  if (geom.numberOfLayers(PixelSubdetector::PixelBarrel) != 4 ||
+      geom.numberOfLayers(PixelSubdetector::PixelEndcap) != 3) {
+    throw cms::Exception("Assert") << "For now this code works only with phase1 tracker, you have something else";
+  }
+
+  // Create DetLayer structure
+  dets_.resize(lnc_->nLayers(), nullptr);
+  auto isPlusSide = [&ttopo](const DetId& detid) {
+    return ttopo.side(detid) == static_cast<unsigned>(TrackerDetSide::PosEndcap);
+  };
+  auto setDet = [this, &isPlusSide](
+                    const int subdet, const int layer, const int isStereo, const DetId& detId, const DetLayer* lay) {
+    const int index = lnc_->convertLayerNumber(subdet, layer, false, isStereo, isPlusSide(detId));
+    if (index < 0 or static_cast<unsigned>(index) >= dets_.size()) {
+      throw cms::Exception("LogicError") << "Invalid mkFit layer index " << index << " for DetId " << detId.rawId()
+                                         << " subdet " << subdet << " layer " << layer << " isStereo " << isStereo;
+    }
+    dets_[index] = lay;
+  };
+  constexpr int monoLayer = 0;
+  constexpr int stereoLayer = 1;
+  for (const DetLayer* lay : tracker.allLayers()) {
+    const auto& comp = lay->basicComponents();
+    if (UNLIKELY(comp.empty())) {
+      throw cms::Exception("LogicError") << "Got a tracker layer (subdet " << lay->subDetector()
+                                         << ") with empty basicComponents.";
+    }
+    // First component is enough for layer and side information
+    const auto& detId = comp.front()->geographicalId();
+    const auto subdet = detId.subdetId();
+    const auto layer = ttopo.layer(detId);
+
+    // TODO: mono/stereo structure is still hardcoded for phase0/1 strip tracker
+    setDet(subdet, layer, monoLayer, detId, lay);
+    if (((subdet == StripSubdetector::TIB or subdet == StripSubdetector::TOB) and (layer == 1 or layer == 2)) or
+        subdet == StripSubdetector::TID or subdet == StripSubdetector::TEC) {
+      setDet(subdet, layer, stereoLayer, detId, lay);
+    }
+  }
+}
+
+// Explicit out-of-line because of the mkfit::LayerNumberConverter is
+// only forward declared in the header
+MkFitGeometry::~MkFitGeometry() {}

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -52,13 +52,15 @@ MkFitGeometry::MkFitGeometry(const TrackerGeometry& geom,
   }
 
   // Create "short id" aka "unique id within layer"
-  std::vector<unsigned int> idInLayer(lnc_->nLayers(), 0);
+  detIdToShortId_.resize(lnc_->nLayers());
   for (const auto& detId : geom.detIds()) {
     const auto ilay =
         lnc_->convertLayerNumber(detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
-    detIdToShortId_[detId.rawId()] = idInLayer[ilay]++;
+    auto& map = detIdToShortId_[ilay];
+    const unsigned int ind = map.size();
     // Make sure the short id fits in the 12 bits...
-    assert(idInLayer[ilay] < (int)1 << 11);
+    assert(ind < (int)1 << 11);
+    map[detId.rawId()] = ind;
   }
 }
 

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -50,6 +50,16 @@ MkFitGeometry::MkFitGeometry(const TrackerGeometry& geom,
       setDet(subdet, layer, stereoLayer, detId, lay);
     }
   }
+
+  // Create "short id" aka "unique id within layer"
+  std::vector<unsigned int> idInLayer(lnc_->nLayers(), 0);
+  for (const auto& detId : geom.detIds()) {
+    const auto ilay =
+        lnc_->convertLayerNumber(detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
+    detIdToShortId_[detId.rawId()] = idInLayer[ilay]++;
+    // Make sure the short id fits in the 12 bits...
+    assert(idInLayer[ilay] < (int)1 << 11);
+  }
 }
 
 // Explicit out-of-line because of the mkfit::LayerNumberConverter is

--- a/RecoTracker/MkFit/src/MkFitInputWrapper.cc
+++ b/RecoTracker/MkFit/src/MkFitInputWrapper.cc
@@ -9,16 +9,12 @@ MkFitInputWrapper::MkFitInputWrapper() = default;
 
 MkFitInputWrapper::MkFitInputWrapper(MkFitHitIndexMap hitIndexMap,
                                      std::vector<mkfit::HitVec> hits,
-                                     mkfit::TrackVec seeds,
-                                     mkfit::LayerNumberConverter const& lnc)
+                                     mkfit::TrackVec seeds)
     : hitIndexMap_{std::move(hitIndexMap)},
       hits_{std::move(hits)},
-      seeds_{std::make_unique<mkfit::TrackVec>(std::move(seeds))},
-      lnc_{std::make_unique<mkfit::LayerNumberConverter>(lnc)} {}
+      seeds_{std::make_unique<mkfit::TrackVec>(std::move(seeds))} {}
 
 MkFitInputWrapper::~MkFitInputWrapper() = default;
 
 MkFitInputWrapper::MkFitInputWrapper(MkFitInputWrapper&&) = default;
 MkFitInputWrapper& MkFitInputWrapper::operator=(MkFitInputWrapper&&) = default;
-
-unsigned int MkFitInputWrapper::nlayers() const { return lnc_->nLayers(); }


### PR DESCRIPTION
#### PR description:

Should cover https://github.com/trackreco/cmssw/pull/3 plus a customize function to customize HLT iter0 to use mkFit and its use in 11634.7 step2.

The included reco and HLT test files (in `RecoTracker/MkFit/test`) are directly from 10_4_0_patch1, and therefore could be broken. I did not test them. I'm not sure if it is worth to do anything for them before we have new common samples in 11_2.

#### PR validation:

`runTheMatrix.py -l 11634.7` runs in CMSSW_11_2_0_pre8.