### PR TITLE
Fix customizeInitialStepOnly in 11_2_0

### DIFF
--- a/RecoTracker/MkFit/python/customizeInitialStepOnly.py
+++ b/RecoTracker/MkFit/python/customizeInitialStepOnly.py
@@ -12,8 +12,6 @@ def customizeInitialStepOnly(process):
     process.initialStepSeedLayers.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
     process.initialStepHitQuadruplets.SeedComparitorPSet.clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
     process.initialStepSeeds.SeedComparitorPSet.ClusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
-    #if hasattr(process, "initialStepTrackCandidatesMkFitInput"):
-    #    process.initialStepTrackCandidatesMkFitInput.pixelRecHits = "siPixelRecHitsPreSplitting"
     if hasattr(process, "initialStepTrackCandidatesMkFitHits"):
         process.initialStepTrackCandidatesMkFitHits.pixelRecHits = "siPixelRecHitsPreSplitting"
     if hasattr(process.initialStepTrackCandidates, "MeasurementTrackerEvent"):

--- a/RecoTracker/MkFit/python/customizeInitialStepOnly.py
+++ b/RecoTracker/MkFit/python/customizeInitialStepOnly.py
@@ -12,8 +12,10 @@ def customizeInitialStepOnly(process):
     process.initialStepSeedLayers.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
     process.initialStepHitQuadruplets.SeedComparitorPSet.clusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
     process.initialStepSeeds.SeedComparitorPSet.ClusterShapeCacheSrc = "siPixelClusterShapeCachePreSplitting"
-    if hasattr(process, "initialStepTrackCandidatesMkFitInput"):
-        process.initialStepTrackCandidatesMkFitInput.pixelRecHits = "siPixelRecHitsPreSplitting"
+    #if hasattr(process, "initialStepTrackCandidatesMkFitInput"):
+    #    process.initialStepTrackCandidatesMkFitInput.pixelRecHits = "siPixelRecHitsPreSplitting"
+    if hasattr(process, "initialStepTrackCandidatesMkFitHits"):
+        process.initialStepTrackCandidatesMkFitHits.pixelRecHits = "siPixelRecHitsPreSplitting"
     if hasattr(process.initialStepTrackCandidates, "MeasurementTrackerEvent"):
         process.initialStepTrackCandidates.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
     process.initialStepTracks.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
@@ -55,10 +57,10 @@ def customizeInitialStepOnly(process):
             mod.dodEdxPlots = False
             mod.doResolutionPlotsForLabels = []
 
-    setInput(["trackValidatorTrackingOnly", "trackValidatorAllTPEfficStandalone",
-              "trackValidatorTPPtLess09Standalone", "trackValidatorBHadronTrackingOnly"],
+    setInput(["trackValidatorTrackingOnly", "trackValidatorAllTPEfficTrackingOnly",
+              "trackValidatorTPPtLess09TrackingOnly", "trackValidatorBHadronTrackingOnly"],
              ["cutsRecoTracksInitialStep", "cutsRecoTracksPt09InitialStep"])
-    setInput(["trackValidatorFromPVStandalone", "trackValidatorFromPVAllTPStandalone"],
+    setInput(["trackValidatorFromPVTrackingOnly", "trackValidatorFromPVAllTPTrackingOnly"],
              ["cutsRecoTracksFromPVInitialStep", "cutsRecoTracksFromPVPt09InitialStep"])
     setInput(["trackValidatorSeedingTrackingOnly"], ["seedTracksinitialStepSeeds"])
     setInput(["trackValidatorBuilding"], ["initialStepTracks"])


### PR DESCRIPTION
Aimed at enabling customizeInitialStepOnly in 11_2_0:
(i) initialStepTrackCandidatesMkFitHits vs deprecated initialStepTrackCandidatesMkFitInput
(ii) fix naming for MTV in 112X


