### PR TITLE
updates in trackingNtuple for using in standalone tracking (e.g. mkFit or line segment tracking); ported from local devs in 10_4_0_patch1

### DIFF
--- a/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
@@ -1,0 +1,8 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CommonTools/UtilAlgos/interface/Merger.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+typedef Merger<reco::TrackCollection> TrackSimpleMerger;
+
+DEFINE_FWK_MODULE(TrackSimpleMerger);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1087,6 +1087,8 @@ private:
   std::vector<float>
       pix_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> pix_bbxi;
+  std::vector<int> pix_clustSizeCol;
+  std::vector<int> pix_clustSizeRow;
   ////////////////////
   // strip hits
   // (first) index runs through hits
@@ -1111,6 +1113,7 @@ private:
       str_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi;
   std::vector<float> str_chargePerCM;
+  std::vector<int> str_clustSize;
   ////////////////////
   // strip matched hits
   // (first) index runs through hits
@@ -1132,6 +1135,8 @@ private:
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
   std::vector<float> glu_chargePerCM ;
+  std::vector<int> glu_clustSizeMono;
+  std::vector<int> glu_clustSizeStereo;
   ////////////////////
   // phase2 Outer Tracker hits
   // (first) index runs through hits
@@ -1552,6 +1557,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_zx", &pix_zx);
     t->Branch("pix_radL", &pix_radL);
     t->Branch("pix_bbxi", &pix_bbxi);
+    t->Branch("pix_clustSizeCol", &pix_clustSizeCol);
+    t->Branch("pix_clustSizeRow", &pix_clustSizeRow);
     //strips
     if (includeStripHits_) {
       t->Branch("str_isBarrel", &str_isBarrel);
@@ -1580,6 +1587,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_radL", &str_radL);
       t->Branch("str_bbxi", &str_bbxi);
       t->Branch("str_chargePerCM", &str_chargePerCM);
+      t->Branch("str_clustSize", &str_clustSize);
       //matched hits
       t->Branch("glu_isBarrel", &glu_isBarrel);
       glu_detId.book("glu", t);
@@ -1600,6 +1608,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("glu_radL", &glu_radL);
       t->Branch("glu_bbxi", &glu_bbxi);
       t->Branch("glu_chargePerCM", &glu_chargePerCM);
+      t->Branch("glu_clustSizeMono", &glu_clustSizeMono);
+      t->Branch("glu_clustSizeStereo", &glu_clustSizeStereo);
     }
     //phase2 OT
     if (includePhase2OTHits_) {
@@ -1921,6 +1931,8 @@ void TrackingNtuple::clearVariables() {
   pix_zx.clear();
   pix_radL.clear();
   pix_bbxi.clear();
+  pix_clustSizeCol.clear();
+  pix_clustSizeRow.clear();
   //strips
   str_isBarrel.clear();
   str_detId.clear();
@@ -1942,6 +1954,7 @@ void TrackingNtuple::clearVariables() {
   str_radL.clear();
   str_bbxi.clear();
   str_chargePerCM.clear();
+  str_clustSize.clear();
   //matched hits
   glu_isBarrel.clear();
   glu_detId.clear();
@@ -1960,6 +1973,8 @@ void TrackingNtuple::clearVariables() {
   glu_radL.clear();
   glu_bbxi.clear();
   glu_chargePerCM.clear();
+  glu_clustSizeMono.clear();
+  glu_clustSizeStereo.clear();
   //phase2 OT
   ph2_isBarrel.clear();
   ph2_detId.clear();
@@ -2727,6 +2742,8 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_zx.push_back(ttrh->globalPositionError().czx());
       pix_radL.push_back(ttrh->surface()->mediumProperties().radLen());
       pix_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
+      pix_clustSizeCol.push_back(hit->cluster()->sizeY());
+      pix_clustSizeRow.push_back(hit->cluster()->sizeX());
 
       LogTrace("TrackingNtuple") << "pixHit cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                  << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
@@ -2797,6 +2814,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_radL.resize(totalStripHits);
   str_bbxi.resize(totalStripHits);
   str_chargePerCM.resize(totalStripHits);
+  str_clustSize.resize(totalStripHits);
 
   auto fill = [&](const SiStripRecHit2DCollection& hits, const char* name) {
     for (const auto& detset : hits) {
@@ -2822,6 +2840,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
         str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
+        str_clustSize[key] = hit.cluster()->amplitudes().size();
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                    << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
 
@@ -2887,6 +2906,8 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
   glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
+  glu_clustSizeMono.push_back(hit.monoHit().cluster()->amplitudes().size());
+  glu_clustSizeStereo.push_back(hit.stereoHit().cluster()->amplitudes().size());
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1145,7 +1145,7 @@ private:
   std::vector<float>
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
-  std::vector<float> glu_chargePerCM ;
+  std::vector<float> glu_chargePerCM;
   std::vector<int> glu_clustSizeMono;
   std::vector<int> glu_clustSizeStereo;
   std::vector<uint64_t> glu_usedMaskMono;
@@ -1155,10 +1155,10 @@ private:
   // (first) index runs through hits
   std::vector<short> ph2_isBarrel;
   DetIdPhase2OT ph2_detId;
-  std::vector<std::vector<int>> ph2_trkIdx;     // second index runs through tracks containing this hit
-  std::vector<std::vector<int>> ph2_seeIdx;     // second index runs through seeds containing this hit
-  std::vector<std::vector<int>> ph2_simHitIdx;  // second index runs through SimHits inducing this hit
-  std::vector<std::vector<float>> ph2_xySignificance; // second index runs through SimHits inducing this hit
+  std::vector<std::vector<int>> ph2_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<int>> ph2_seeIdx;            // second index runs through seeds containing this hit
+  std::vector<std::vector<int>> ph2_simHitIdx;         // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float>> ph2_xySignificance;  // second index runs through SimHits inducing this hit
   //std::vector<std::vector<float>> ph2_chargeFraction; // Not supported at the moment for Phase2
   std::vector<unsigned short> ph2_simType;
   std::vector<float> ph2_x;
@@ -1390,11 +1390,12 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     for (auto const& mask : maskVPset) {
       auto index = mask.getUntrackedParameter<unsigned int>("index");
       assert(index < 64);
-      pixelUseMaskTokens_.emplace_back(index, consumes<PixelMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+      pixelUseMaskTokens_.emplace_back(index,
+                                       consumes<PixelMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
       if (includeStripHits_)
-        stripUseMaskTokens_.emplace_back(index, consumes<StripMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
+        stripUseMaskTokens_.emplace_back(
+            index, consumes<StripMaskContainer>(mask.getUntrackedParameter<edm::InputTag>("src")));
     }
-
   }
 
   const bool tpRef = iConfig.getUntrackedParameter<bool>("trackingParticlesRef");
@@ -1684,7 +1685,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("simhit_x", &simhit_x);
       t->Branch("simhit_y", &simhit_y);
       t->Branch("simhit_z", &simhit_z);
-      if (saveSimHitsP3_){
+      if (saveSimHitsP3_) {
         t->Branch("simhit_px", &simhit_px);
         t->Branch("simhit_py", &simhit_py);
         t->Branch("simhit_pz", &simhit_pz);
@@ -1734,7 +1735,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
     t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
     t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
-    if (addSeedCartesianCov_){
+    if (addSeedCartesianCov_) {
       t->Branch("see_stateCcov00", &see_stateCcov00);
       t->Branch("see_stateCcov01", &see_stateCcov01);
       t->Branch("see_stateCcov02", &see_stateCcov02);
@@ -2451,9 +2452,9 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
   else
     simTrackIdToChargeFraction = chargeFraction(GetCluster<SimLink>::call(cluster), hitId, digiSimLinks);
 
-  float h_x=0, h_y=0;
-  float h_xx=0, h_xy=0, h_yy=0;
-  if (simHitBySignificance_){
+  float h_x = 0, h_y = 0;
+  float h_xx = 0, h_xy = 0, h_yy = 0;
+  if (simHitBySignificance_) {
     h_x = ttrh->localPosition().x();
     h_y = ttrh->localPosition().y();
     h_xx = ttrh->localPositionError().xx();
@@ -2473,7 +2474,8 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       HitSimType type = HitSimType::OOTPileup;
       if (bx == 0) {
         type = (event == 0 ? HitSimType::Signal : HitSimType::ITPileup);
-      } else type = HitSimType::OOTPileup;
+      } else
+        type = HitSimType::OOTPileup;
       ret.type = static_cast<HitSimType>(std::min(static_cast<int>(ret.type), static_cast<int>(type)));
 
       // Limit to only input TrackingParticles (usually signal+ITPU)
@@ -2492,56 +2494,57 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       bool foundElectron = false;
       int foundElectrons = 0;
       int foundNonElectrons = 0;
-      for(auto ip = range.first; ip != range.second; ++ip) {
+      for (auto ip = range.first; ip != range.second; ++ip) {
         TrackPSimHitRef TPhit = ip->second;
         DetId dId = DetId(TPhit->detUnitId());
-        if (dId.rawId()==hitId.rawId()) {
+        if (dId.rawId() == hitId.rawId()) {
           // skip electron SimHits for non-electron TPs also here
-          if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
-	    foundElectrons++;
+          if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+            foundElectrons++;
           } else {
-	    foundNonElectrons++;
-	  }
+            foundNonElectrons++;
+          }
         }
       }
 
       float minSignificance = 1e12;
-      if (simHitBySignificance_){//save the best matching hit
-	
+      if (simHitBySignificance_) {  //save the best matching hit
+
         int simHitKey = -1;
         edm::ProductID simHitID;
-	for(auto ip = range.first; ip != range.second; ++ip) {
-	  TrackPSimHitRef TPhit = ip->second;
-	  DetId dId = DetId(TPhit->detUnitId());
-	  if (dId.rawId()==hitId.rawId()) {
-	    // skip electron SimHits for non-electron TPs also here
-	    if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
-	      foundElectron = true;
-	      if (!keepEleSimHits_) continue;
-	    }
-	    
-	    float sx = TPhit->localPosition().x();
-	    float sy = TPhit->localPosition().y();
-	    float dx = sx - h_x;
-	    float dy = sy - h_y;
-	    float sig = (dx*dx*h_yy - 2*dx*dy*h_xy + dy*dy*h_xx)/(h_xx*h_yy - h_xy*h_xy);
-	    
-	    if (sig < minSignificance){
-	      minSignificance = sig;
+        for (auto ip = range.first; ip != range.second; ++ip) {
+          TrackPSimHitRef TPhit = ip->second;
+          DetId dId = DetId(TPhit->detUnitId());
+          if (dId.rawId() == hitId.rawId()) {
+            // skip electron SimHits for non-electron TPs also here
+            if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+              foundElectron = true;
+              if (!keepEleSimHits_)
+                continue;
+            }
+
+            float sx = TPhit->localPosition().x();
+            float sy = TPhit->localPosition().y();
+            float dx = sx - h_x;
+            float dy = sy - h_y;
+            float sig = (dx * dx * h_yy - 2 * dx * dy * h_xy + dy * dy * h_xx) / (h_xx * h_yy - h_xy * h_xy);
+
+            if (sig < minSignificance) {
+              minSignificance = sig;
               foundSimHit = true;
-	      simHitKey = TPhit.key();
-	      simHitID = TPhit.id();
-	    }
-	  }
-	}//loop over matching hits
+              simHitKey = TPhit.key();
+              simHitID = TPhit.id();
+            }
+          }
+        }  //loop over matching hits
 
         auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
         ret.matchingSimHit.push_back(simHitIndex);
 
         double chargeFraction = 0.;
-        for(const SimTrack& simtrk: trackingParticle->g4Tracks()) {
+        for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
           auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
-          if(found != simTrackIdToChargeFraction.end()) {
+          if (found != simTrackIdToChargeFraction.end()) {
             chargeFraction += found->second;
           }
         }
@@ -2554,8 +2557,8 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
 
         simhit_hitIdx[simHitIndex].push_back(clusterKey);
         simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
-	
-      } else {//save all matching hits
+
+      } else {  //save all matching hits
         for (auto ip = range.first; ip != range.second; ++ip) {
           TrackPSimHitRef TPhit = ip->second;
           DetId dId = DetId(TPhit->detUnitId());
@@ -2563,17 +2566,19 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
             // skip electron SimHits for non-electron TPs also here
             if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
               foundElectron = true;
-              if (!keepEleSimHits_) continue;
-              if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
+              if (!keepEleSimHits_)
+                continue;
+              if (foundNonElectrons > 0)
+                continue;  //prioritize: skip electrons if non-electrons are present
             }
-            
+
             foundSimHit = true;
             auto simHitKey = TPhit.key();
             auto simHitID = TPhit.id();
-            
+
             auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
             ret.matchingSimHit.push_back(simHitIndex);
-            
+
             double chargeFraction = 0.;
             for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
               auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
@@ -2583,17 +2588,17 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
             }
             ret.xySignificance.push_back(minSignificance);
             ret.chargeFraction.push_back(chargeFraction);
-            
+
             // only for debug prints
             ret.bunchCrossing.push_back(bx);
             ret.event.push_back(event);
-            
+
             simhit_hitIdx[simHitIndex].push_back(clusterKey);
             simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
           }
         }
-      }//if/else simHitBySignificance_
-      if(!foundSimHit) {
+      }  //if/else simHitBySignificance_
+      if (!foundSimHit) {
         // In case we didn't find a simhit because of filtered-out
         // electron SimHit, just ignore the missing SimHit.
         if (foundElectron && !keepEleSimHits_)
@@ -2617,7 +2622,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       }
     }
   }
-  
+
   return ret;
 }
 
@@ -2718,7 +2723,7 @@ void TrackingNtuple::fillSimHits(const TrackerGeometry& tracker,
     simhit_x.push_back(pos.x());
     simhit_y.push_back(pos.y());
     simhit_z.push_back(pos.z());
-    if (saveSimHitsP3_){
+    if (saveSimHitsP3_) {
       const auto mom = det->surface().toGlobal(simhit.momentumAtEntry());
       simhit_px.push_back(mom.x());
       simhit_py.push_back(mom.y());
@@ -2755,7 +2760,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
     iEvent.getByToken(itoken.second, aH);
     pixelMasks.emplace_back(1 << itoken.first, aH.product());
   }
-  auto pixUsedMask = [&pixelMasks] (size_t key) {
+  auto pixUsedMask = [&pixelMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : pixelMasks) {
       if (m.second->mask(key))
@@ -2844,7 +2849,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
     iEvent.getByToken(itoken.second, aH);
     stripMasks.emplace_back(1 << itoken.first, aH.product());
   }
-  auto strUsedMask = [&stripMasks] (size_t key) {
+  auto strUsedMask = [&stripMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : stripMasks) {
       if (m.second->mask(key))
@@ -2906,7 +2911,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_zx[key] = ttrh->globalPositionError().czx();
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
-        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
+        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster());
         str_clustSize[key] = hit.cluster()->amplitudes().size();
         str_usedMask[key] = strUsedMask(key);
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
@@ -2954,7 +2959,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
                                           const TrackerTopology& tTopo,
                                           const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
-  auto strUsedMask = [&stripMasks] (size_t key) {
+  auto strUsedMask = [&stripMasks](size_t key) {
     uint64_t mask = 0;
     for (auto const& m : stripMasks) {
       if (m.second->mask(key))
@@ -2983,7 +2988,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_zx.push_back(ttrh->globalPositionError().czx());
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
-  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
+  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId, hit.firstClusterRef().stripCluster()));
   glu_clustSizeMono.push_back(hit.monoHit().cluster()->amplitudes().size());
   glu_clustSizeStereo.push_back(hit.stereoHit().cluster()->amplitudes().size());
   glu_usedMaskMono.push_back(strUsedMask(hit.monoHit().cluster().key()));
@@ -3011,7 +3016,7 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
   iEvent.getByToken(stripMatchedRecHitToken_, matchedHits);
   for (auto it = matchedHits->begin(); it != matchedHits->end(); it++) {
     for (auto hit = it->begin(); hit != it->end(); hit++) {
-      addStripMatchedHit(*hit, theTTRHBuilder, tTopo, monoStereoClusterList);
+      addStripMatchedHit(*hit, theTTRHBuilder, tTopo, stripMasks, monoStereoClusterList);
     }
   }
 }
@@ -3149,7 +3154,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     //for HLT seeds
     label.ReplaceAll("FromPixelTracks", "");
     label.ReplaceAll("PFLowPixel", "");
-    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");//random choice
+    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");  //random choice
     int algo = reco::TrackBase::algoByName(label.Data());
 
     edm::ProductID id = seedTracks[0].seedRef().id();
@@ -3244,10 +3249,10 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajPy.push_back(mom.y());
       see_stateTrajPz.push_back(mom.z());
 
-      ///the following is useful for analysis in global coords at seed hit surface      
-      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
-      TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(seed.startingState(),
-                                                                               lastRecHit->surface(), &theMF);
+      ///the following is useful for analysis in global coords at seed hit surface
+      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().end() - 1));
+      TrajectoryStateOnSurface tsos =
+          trajectoryStateTransform::transientState(seed.startingState(), lastRecHit->surface(), &theMF);
       auto const& stateGlobal = tsos.globalParameters();
       see_stateTrajGlbX.push_back(stateGlobal.position().x());
       see_stateTrajGlbY.push_back(stateGlobal.position().y());
@@ -3255,29 +3260,29 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
-      if (addSeedCartesianCov_){
-	auto const& stateCcov = tsos.cartesianError().matrix();
-	see_stateCcov00.push_back( stateCcov[0][0] );
-	see_stateCcov01.push_back( stateCcov[0][1] );
-	see_stateCcov02.push_back( stateCcov[0][2] );
-	see_stateCcov03.push_back( stateCcov[0][3] );
-	see_stateCcov04.push_back( stateCcov[0][4] );
-	see_stateCcov05.push_back( stateCcov[0][5] );
-	see_stateCcov11.push_back( stateCcov[1][1] );
-	see_stateCcov12.push_back( stateCcov[1][2] );
-	see_stateCcov13.push_back( stateCcov[1][3] );
-	see_stateCcov14.push_back( stateCcov[1][4] );
-	see_stateCcov15.push_back( stateCcov[1][5] );
-	see_stateCcov22.push_back( stateCcov[2][2] );
-	see_stateCcov23.push_back( stateCcov[2][3] );
-	see_stateCcov24.push_back( stateCcov[2][4] );
-	see_stateCcov25.push_back( stateCcov[2][5] );
-	see_stateCcov33.push_back( stateCcov[3][3] );
-	see_stateCcov34.push_back( stateCcov[3][4] );
-	see_stateCcov35.push_back( stateCcov[3][5] );
-	see_stateCcov44.push_back( stateCcov[4][4] );
-	see_stateCcov45.push_back( stateCcov[4][5] );
-	see_stateCcov55.push_back( stateCcov[5][5] );
+      if (addSeedCartesianCov_) {
+        auto const& stateCcov = tsos.cartesianError().matrix();
+        see_stateCcov00.push_back(stateCcov[0][0]);
+        see_stateCcov01.push_back(stateCcov[0][1]);
+        see_stateCcov02.push_back(stateCcov[0][2]);
+        see_stateCcov03.push_back(stateCcov[0][3]);
+        see_stateCcov04.push_back(stateCcov[0][4]);
+        see_stateCcov05.push_back(stateCcov[0][5]);
+        see_stateCcov11.push_back(stateCcov[1][1]);
+        see_stateCcov12.push_back(stateCcov[1][2]);
+        see_stateCcov13.push_back(stateCcov[1][3]);
+        see_stateCcov14.push_back(stateCcov[1][4]);
+        see_stateCcov15.push_back(stateCcov[1][5]);
+        see_stateCcov22.push_back(stateCcov[2][2]);
+        see_stateCcov23.push_back(stateCcov[2][3]);
+        see_stateCcov24.push_back(stateCcov[2][4]);
+        see_stateCcov25.push_back(stateCcov[2][5]);
+        see_stateCcov33.push_back(stateCcov[3][3]);
+        see_stateCcov34.push_back(stateCcov[3][4]);
+        see_stateCcov35.push_back(stateCcov[3][5]);
+        see_stateCcov44.push_back(stateCcov[4][4]);
+        see_stateCcov45.push_back(stateCcov[4][5]);
+        see_stateCcov55.push_back(stateCcov[5][5]);
       }
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
@@ -4036,10 +4041,10 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   cMaskDesc.addUntracked<unsigned int>("index");
   cMaskDesc.addUntracked<edm::InputTag>("src");
   std::vector<edm::ParameterSet> cMasks;
-  auto addMask = [&cMasks](reco::Track::TrackAlgorithm algo){
+  auto addMask = [&cMasks](reco::Track::TrackAlgorithm algo) {
     edm::ParameterSet ps;
     ps.addUntrackedParameter<unsigned int>("index", static_cast<unsigned int>(algo));
-    ps.addUntrackedParameter<edm::InputTag>("src", {reco::Track::algoName(algo)+"Clusters"});
+    ps.addUntrackedParameter<edm::InputTag>("src", {reco::Track::algoName(algo) + "Clusters"});
     cMasks.push_back(ps);
   };
   addMask(reco::Track::detachedQuadStep);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1504,7 +1504,6 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_zx", &pix_zx);
     t->Branch("pix_radL", &pix_radL);
     t->Branch("pix_bbxi", &pix_bbxi);
-    t->Branch("pix_bbxi", &pix_bbxi);
     //strips
     if (includeStripHits_) {
       t->Branch("str_isBarrel", &str_isBarrel);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -1205,6 +1205,12 @@ private:
   std::vector<float> see_stateTrajPx;
   std::vector<float> see_stateTrajPy;
   std::vector<float> see_stateTrajPz;
+  std::vector<float> see_stateTrajGlbX;
+  std::vector<float> see_stateTrajGlbY;
+  std::vector<float> see_stateTrajGlbZ;
+  std::vector<float> see_stateTrajGlbPx;
+  std::vector<float> see_stateTrajGlbPy;
+  std::vector<float> see_stateTrajGlbPz;
   std::vector<int> see_q;
   std::vector<unsigned int> see_nValid;
   std::vector<unsigned int> see_nPixel;
@@ -1640,6 +1646,12 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajPx", &see_stateTrajPx);
     t->Branch("see_stateTrajPy", &see_stateTrajPy);
     t->Branch("see_stateTrajPz", &see_stateTrajPz);
+    t->Branch("see_stateTrajGlbX", &see_stateTrajGlbX);
+    t->Branch("see_stateTrajGlbY", &see_stateTrajGlbY);
+    t->Branch("see_stateTrajGlbZ", &see_stateTrajGlbZ);
+    t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
+    t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
+    t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
     t->Branch("see_q", &see_q);
     t->Branch("see_nValid", &see_nValid);
     t->Branch("see_nPixel", &see_nPixel);
@@ -1947,6 +1959,12 @@ void TrackingNtuple::clearVariables() {
   see_stateTrajPx.clear();
   see_stateTrajPy.clear();
   see_stateTrajPz.clear();
+  see_stateTrajGlbX.clear();
+  see_stateTrajGlbY.clear();
+  see_stateTrajGlbZ.clear();
+  see_stateTrajGlbPx.clear();
+  see_stateTrajGlbPy.clear();
+  see_stateTrajGlbPz.clear();
   see_q.clear();
   see_nValid.clear();
   see_nPixel.clear();
@@ -2364,7 +2382,9 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
 
         auto ex = cms::Exception("LogicError")
                   << "Did not find SimHit for reco hit DetId " << hitId.rawId() << " for TP " << trackingParticle.key()
-                  << " bx:event " << bx << ":" << event << ".\nFound SimHits from detectors ";
+                  << " bx:event " << bx << ":" << event << " PDGid " << trackingParticle->pdgId() << " q "
+                  << trackingParticle->charge() << " p4 " << trackingParticle->p4() << " nG4 "
+                  << trackingParticle->g4Tracks().size() << ".\nFound SimHits from detectors ";
         for (auto ip = range.first; ip != range.second; ++ip) {
           TrackPSimHitRef TPhit = ip->second;
           DetId dId = DetId(TPhit->detUnitId());
@@ -2923,6 +2943,18 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajPx.push_back(mom.x());
       see_stateTrajPy.push_back(mom.y());
       see_stateTrajPz.push_back(mom.z());
+
+      ///the following is useful for analysis in global coords at seed hit surface      
+      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
+      TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(seed.startingState(),
+                                                                               lastRecHit->surface(), theMF);
+      auto const& stateGlobal = tsos.globalParameters();
+      see_stateTrajGlbX.push_back(stateGlobal.position().x());
+      see_stateTrajGlbY.push_back(stateGlobal.position().y());
+      see_stateTrajGlbZ.push_back(stateGlobal.position().z());
+      see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
+      see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
+      see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
       if (includeTrackingParticles_) {

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2407,6 +2407,21 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
                                     SimHitTPAssociationProducer::simHitTPAssociationListGreater);
       bool foundSimHit = false;
       bool foundElectron = false;
+      int foundElectrons = 0;
+      int foundNonElectrons = 0;
+      edm::ProductID simHitID;
+      for(auto ip = range.first; ip != range.second; ++ip) {
+        TrackPSimHitRef TPhit = ip->second;
+        DetId dId = DetId(TPhit->detUnitId());
+        if (dId.rawId()==hitId.rawId()) {
+          // skip electron SimHits for non-electron TPs also here
+          if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+	    foundElectrons++;
+          } else {
+	    foundNonElectrons++;
+	  }
+        }
+      }
       for (auto ip = range.first; ip != range.second; ++ip) {
         TrackPSimHitRef TPhit = ip->second;
         DetId dId = DetId(TPhit->detUnitId());
@@ -2415,6 +2430,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
           if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
             foundElectron = true;
             if (!keepEleSimHits_) continue;
+	    if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
           }
 
           foundSimHit = true;

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -608,6 +608,7 @@ private:
   struct SimHitData {
     std::vector<int> matchingSimHit;
     std::vector<float> chargeFraction;
+    std::vector<float> xySignificance;
     std::vector<int> bunchCrossing;
     std::vector<int> event;
     HitSimType type = HitSimType::Unknown;
@@ -661,6 +662,7 @@ private:
   const bool includeOOT_;
   const bool keepEleSimHits_;
   const bool saveSimHitsP3_;
+  const bool simHitBySignificance_;
 
   HistoryBase tracer_;
 
@@ -1069,6 +1071,7 @@ private:
   std::vector<std::vector<int>> pix_trkIdx;            // second index runs through tracks containing this hit
   std::vector<std::vector<int>> pix_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> pix_simHitIdx;         // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float>> pix_xySignificance;  // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> pix_chargeFraction;  // second index runs through SimHits inducing this hit
   std::vector<unsigned short> pix_simType;
   std::vector<float> pix_x;
@@ -1091,6 +1094,7 @@ private:
   std::vector<std::vector<int>> str_trkIdx;            // second index runs through tracks containing this hit
   std::vector<std::vector<int>> str_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> str_simHitIdx;         // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float>> str_xySignificance;  // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> str_chargeFraction;  // second index runs through SimHits inducing this hit
   std::vector<unsigned short> str_simType;
   std::vector<float> str_x;
@@ -1133,6 +1137,7 @@ private:
   std::vector<std::vector<int>> ph2_trkIdx;     // second index runs through tracks containing this hit
   std::vector<std::vector<int>> ph2_seeIdx;     // second index runs through seeds containing this hit
   std::vector<std::vector<int>> ph2_simHitIdx;  // second index runs through SimHits inducing this hit
+  std::vector<std::vector<float>> ph2_xySignificance; // second index runs through SimHits inducing this hit
   //std::vector<std::vector<float> > ph2_chargeFraction; // Not supported at the moment for Phase2
   std::vector<unsigned short> ph2_simType;
   std::vector<float> ph2_x;
@@ -1332,7 +1337,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
       includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")),
       keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")),
-      saveSimHitsP3_(iConfig.getUntrackedParameter<bool>("saveSimHitsP3")) {
+      saveSimHitsP3_(iConfig.getUntrackedParameter<bool>("saveSimHitsP3")),
+      simHitBySignificance_(iConfig.getUntrackedParameter<bool>("simHitBySignificance")) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -1526,6 +1532,9 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     }
     if (includeTrackingParticles_) {
       t->Branch("pix_simHitIdx", &pix_simHitIdx);
+      if (simHitBySignificance_) {
+        t->Branch("pix_xySignificance", &pix_xySignificance);
+      }
       t->Branch("pix_chargeFraction", &pix_chargeFraction);
       t->Branch("pix_simType", &pix_simType);
     }
@@ -1550,6 +1559,9 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       }
       if (includeTrackingParticles_) {
         t->Branch("str_simHitIdx", &str_simHitIdx);
+        if (simHitBySignificance_) {
+          t->Branch("str_xySignificance", &str_xySignificance);
+        }
         t->Branch("str_chargeFraction", &str_chargeFraction);
         t->Branch("str_simType", &str_simType);
       }
@@ -1594,6 +1606,9 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       }
       if (includeTrackingParticles_) {
         t->Branch("ph2_simHitIdx", &ph2_simHitIdx);
+        if (simHitBySignificance_) {
+          t->Branch("ph2_xySignificance", &ph2_xySignificance);
+        }
         t->Branch("ph2_simType", &ph2_simType);
       }
       t->Branch("ph2_x", &ph2_x);
@@ -1887,6 +1902,7 @@ void TrackingNtuple::clearVariables() {
   pix_trkIdx.clear();
   pix_seeIdx.clear();
   pix_simHitIdx.clear();
+  pix_xySignificance.clear();
   pix_chargeFraction.clear();
   pix_simType.clear();
   pix_x.clear();
@@ -1906,6 +1922,7 @@ void TrackingNtuple::clearVariables() {
   str_trkIdx.clear();
   str_seeIdx.clear();
   str_simHitIdx.clear();
+  str_xySignificance.clear();
   str_chargeFraction.clear();
   str_simType.clear();
   str_x.clear();
@@ -1941,6 +1958,7 @@ void TrackingNtuple::clearVariables() {
   ph2_detId.clear();
   ph2_trkIdx.clear();
   ph2_seeIdx.clear();
+  ph2_xySignificance.clear();
   ph2_simHitIdx.clear();
   ph2_simType.clear();
   ph2_x.clear();
@@ -2378,6 +2396,16 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
   else
     simTrackIdToChargeFraction = chargeFraction(GetCluster<SimLink>::call(cluster), hitId, digiSimLinks);
 
+  float h_x=0, h_y=0;
+  float h_xx=0, h_xy=0, h_yy=0;
+  if (simHitBySignificance_){
+    h_x = ttrh->localPosition().x();
+    h_y = ttrh->localPosition().y();
+    h_xx = ttrh->localPositionError().xx();
+    h_xy = ttrh->localPositionError().xy();
+    h_yy = ttrh->localPositionError().yy();
+  }
+
   ret.type = HitSimType::Noise;
   auto range = clusterToTPMap.equal_range(cluster);
   if (range.first != range.second) {
@@ -2422,42 +2450,73 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
 	  }
         }
       }
-      for (auto ip = range.first; ip != range.second; ++ip) {
-        TrackPSimHitRef TPhit = ip->second;
-        DetId dId = DetId(TPhit->detUnitId());
-        if (dId.rawId() == hitId.rawId()) {
-          // skip electron SimHits for non-electron TPs also here
-          if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
-            foundElectron = true;
-            if (!keepEleSimHits_) continue;
-	    if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
-          }
 
-          foundSimHit = true;
-          auto simHitKey = TPhit.key();
-          auto simHitID = TPhit.id();
-
-          auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
-          ret.matchingSimHit.push_back(simHitIndex);
-
-          double chargeFraction = 0.;
-          for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
-            auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
-            if (found != simTrackIdToChargeFraction.end()) {
-              chargeFraction += found->second;
+      float minSignificance = 1e12;
+      if (simHitBySignificance_){
+	
+	for(auto ip = range.first; ip != range.second; ++ip) {
+	  TrackPSimHitRef TPhit = ip->second;
+	  DetId dId = DetId(TPhit->detUnitId());
+	  if (dId.rawId()==hitId.rawId()) {
+	    // skip electron SimHits for non-electron TPs also here
+	    if(std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+	      foundElectron = true;
+	      if (!keepEleSimHits_) continue;
+	    }
+	    
+	    float sx = TPhit->localPosition().x();
+	    float sy = TPhit->localPosition().y();
+	    float dx = sx - h_x;
+	    float dy = sy - h_y;
+	    float sig = (dx*dx*h_yy - 2*dx*dy*h_xy + dy*dy*h_xx)/(h_xx*h_yy - h_xy*h_xy);
+	    
+	    if (sig < minSignificance){
+	      minSignificance = sig;
+              foundSimHit = true;
+	      simHitKey = TPhit.key();
+	      simHitID = TPhit.id();
+	    }
+	  }
+	}
+	
+      } else {
+        for (auto ip = range.first; ip != range.second; ++ip) {
+          TrackPSimHitRef TPhit = ip->second;
+          DetId dId = DetId(TPhit->detUnitId());
+          if (dId.rawId() == hitId.rawId()) {
+            // skip electron SimHits for non-electron TPs also here
+            if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
+              foundElectron = true;
+              if (!keepEleSimHits_) continue;
+              if (foundNonElectrons > 0) continue;//prioritize: skip electrons if non-electrons are present
             }
+            
+            foundSimHit = true;
+            auto simHitKey = TPhit.key();
+            auto simHitID = TPhit.id();
+            
+            auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
+            ret.matchingSimHit.push_back(simHitIndex);
+            
+            double chargeFraction = 0.;
+            for (const SimTrack& simtrk : trackingParticle->g4Tracks()) {
+              auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
+              if (found != simTrackIdToChargeFraction.end()) {
+                chargeFraction += found->second;
+              }
+            }
+            ret.chargeFraction.push_back(chargeFraction);
+            
+            // only for debug prints
+            ret.bunchCrossing.push_back(bx);
+            ret.event.push_back(event);
+            
+            simhit_hitIdx[simHitIndex].push_back(clusterKey);
+            simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
           }
-          ret.chargeFraction.push_back(chargeFraction);
-
-          // only for debug prints
-          ret.bunchCrossing.push_back(bx);
-          ret.event.push_back(event);
-
-          simhit_hitIdx[simHitIndex].push_back(clusterKey);
-          simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
         }
-      }
-      if (!foundSimHit) {
+      }//if/else simHitBySignificance_
+      if(!foundSimHit) {
         // In case we didn't find a simhit because of filtered-out
         // electron SimHit, just ignore the missing SimHit.
         if (foundElectron && !keepEleSimHits_)
@@ -2479,6 +2538,25 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
         }
         throw ex;
       }
+      ret.xySignificance.push_back(minSignificance);
+      auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
+      ret.matchingSimHit.push_back(simHitIndex);
+
+      double chargeFraction = 0.;
+      for(const SimTrack& simtrk: trackingParticle->g4Tracks()) {
+        auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
+        if(found != simTrackIdToChargeFraction.end()) {
+          chargeFraction += found->second;
+        }
+      }
+      ret.chargeFraction.push_back(chargeFraction);
+
+      // only for debug prints
+      ret.bunchCrossing.push_back(bx);
+      ret.event.push_back(event);
+
+      simhit_hitIdx[simHitIndex].push_back(clusterKey);
+      simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
     }
   }
 
@@ -2637,6 +2715,8 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_yz.push_back(ttrh->globalPositionError().czy());
       pix_zz.push_back(ttrh->globalPositionError().czz());
       pix_zx.push_back(ttrh->globalPositionError().czx());
+      pix_xySignificance.push_back(simHitData.xySignificance);
+      pix_chargeFraction.push_back(simHitData.chargeFraction);
       pix_radL.push_back(ttrh->surface()->mediumProperties().radLen());
       pix_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
 
@@ -2703,6 +2783,8 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_yz.resize(totalStripHits);
   str_zz.resize(totalStripHits);
   str_zx.resize(totalStripHits);
+  str_xySignificance.resize(totalStripHits);
+  str_chargeFraction.resize(totalStripHits);
   str_radL.resize(totalStripHits);
   str_bbxi.resize(totalStripHits);
 
@@ -2727,6 +2809,8 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_yz[key] = ttrh->globalPositionError().czy();
         str_zz[key] = ttrh->globalPositionError().czz();
         str_zx[key] = ttrh->globalPositionError().czx();
+        str_xySignificance[key] = simHitData.xySignificance;
+        str_chargeFraction[key] = simHitData.chargeFraction;
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
@@ -2837,6 +2921,9 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
       ph2_detId.push_back(tTopo, hitId);
       ph2_trkIdx.emplace_back();  // filled in fillTracks
       ph2_seeIdx.emplace_back();  // filled in fillSeeds
+      ph2_xySignificance.push_back(simHitData.xySignificance);
+      ph2_simHitIdx.push_back(simHitData.matchingSimHit);
+      ph2_simType.push_back(static_cast<int>(simHitData.type));
       ph2_x.push_back(ttrh->globalPosition().x());
       ph2_y.push_back(ttrh->globalPosition().y());
       ph2_z.push_back(ttrh->globalPosition().z());
@@ -3846,6 +3933,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeOOT", false);
   desc.addUntracked<bool>("keepEleSimHits", false);
   desc.addUntracked<bool>("saveSimHitsP3", false);
+  desc.addUntracked<bool>("simHitBySignificance", false);
   descriptions.add("trackingNtuple", desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -659,6 +659,7 @@ private:
   const bool includeTrackingParticles_;
   const bool includeOOT_;
   const bool keepEleSimHits_;
+  const bool saveSimHitsP3_;
 
   HistoryBase tracer_;
 
@@ -1161,6 +1162,9 @@ private:
   std::vector<float> simhit_x;
   std::vector<float> simhit_y;
   std::vector<float> simhit_z;
+  std::vector<float> simhit_px;
+  std::vector<float> simhit_py;
+  std::vector<float> simhit_pz;
   std::vector<int> simhit_particle;
   std::vector<short> simhit_process;
   std::vector<float> simhit_eloss;
@@ -1298,7 +1302,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
       includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")),
-      keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")) {
+      keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")),
+      saveSimHitsP3_(iConfig.getUntrackedParameter<bool>("saveSimHitsP3")) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -1591,6 +1596,11 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("simhit_x", &simhit_x);
       t->Branch("simhit_y", &simhit_y);
       t->Branch("simhit_z", &simhit_z);
+      if (saveSimHitsP3_){
+        t->Branch("simhit_px", &simhit_px);
+        t->Branch("simhit_py", &simhit_py);
+        t->Branch("simhit_pz", &simhit_pz);
+      }
       t->Branch("simhit_particle", &simhit_particle);
       t->Branch("simhit_process", &simhit_process);
       t->Branch("simhit_eloss", &simhit_eloss);
@@ -1897,6 +1907,9 @@ void TrackingNtuple::clearVariables() {
   simhit_x.clear();
   simhit_y.clear();
   simhit_z.clear();
+  simhit_px.clear();
+  simhit_py.clear();
+  simhit_pz.clear();
   simhit_particle.clear();
   simhit_process.clear();
   simhit_eloss.clear();
@@ -2466,6 +2479,12 @@ void TrackingNtuple::fillSimHits(const TrackerGeometry& tracker,
     simhit_x.push_back(pos.x());
     simhit_y.push_back(pos.y());
     simhit_z.push_back(pos.z());
+    if (saveSimHitsP3_){
+      const auto mom = det->surface().toGlobal(simhit.momentumAtEntry());
+      simhit_px.push_back(mom.x());
+      simhit_py.push_back(mom.y());
+      simhit_pz.push_back(mom.z());
+    }
     simhit_particle.push_back(simhit.particleType());
     simhit_process.push_back(simhit.processType());
     simhit_eloss.push_back(simhit.energyLoss());
@@ -3686,6 +3705,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeTrackingParticles", true);
   desc.addUntracked<bool>("includeOOT", false);
   desc.addUntracked<bool>("keepEleSimHits", false);
+  desc.addUntracked<bool>("saveSimHitsP3", false);
   descriptions.add("trackingNtuple", desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -658,6 +658,7 @@ private:
   const bool includeMVA_;
   const bool includeTrackingParticles_;
   const bool includeOOT_;
+  const bool keepEleSimHits_;
 
   HistoryBase tracer_;
 
@@ -1296,7 +1297,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
-      includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")) {
+      includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")),
+      keepEleSimHits_(iConfig.getUntrackedParameter<bool>("keepEleSimHits")) {
   if (includeSeeds_) {
     seedTokens_ =
         edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
@@ -2314,7 +2316,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
           // skip electron SimHits for non-electron TPs also here
           if (std::abs(TPhit->particleType()) == 11 && std::abs(trackingParticle->pdgId()) != 11) {
             foundElectron = true;
-            continue;
+            if (!keepEleSimHits_) continue;
           }
 
           foundSimHit = true;
@@ -2344,7 +2346,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       if (!foundSimHit) {
         // In case we didn't find a simhit because of filtered-out
         // electron SimHit, just ignore the missing SimHit.
-        if (foundElectron)
+        if (foundElectron && !keepEleSimHits_)
           continue;
 
         auto ex = cms::Exception("LogicError")
@@ -2394,7 +2396,7 @@ void TrackingNtuple::fillSimHits(const TrackerGeometry& tracker,
     // need them later, let's add them as a separate "collection" of
     // hits of a TP
     const TrackingParticle& tp = *(assoc.first);
-    if (std::abs(simhit.particleType()) == 11 && std::abs(tp.pdgId()) != 11)
+    if (!keepEleSimHits_ && std::abs(simhit.particleType()) == 11 && std::abs(tp.pdgId()) != 11)
       continue;
 
     auto simHitKey = std::make_pair(assoc.second.key(), assoc.second.id());
@@ -3683,6 +3685,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);
   desc.addUntracked<bool>("includeOOT", false);
+  desc.addUntracked<bool>("keepEleSimHits", false);
   descriptions.add("trackingNtuple", desc);
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -3050,6 +3050,10 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     label.ReplaceAll("seedTracks", "");
     label.ReplaceAll("Seeds", "");
     label.ReplaceAll("muonSeeded", "muonSeededStep");
+    //for HLT seeds
+    label.ReplaceAll("FromPixelTracks", "");
+    label.ReplaceAll("PFLowPixel", "");
+    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");//random choice
     int algo = reco::TrackBase::algoByName(label.Data());
 
     edm::ProductID id = seedTracks[0].seedRef().id();

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -2444,7 +2444,6 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       bool foundElectron = false;
       int foundElectrons = 0;
       int foundNonElectrons = 0;
-      edm::ProductID simHitID;
       for(auto ip = range.first; ip != range.second; ++ip) {
         TrackPSimHitRef TPhit = ip->second;
         DetId dId = DetId(TPhit->detUnitId());
@@ -2459,8 +2458,10 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
       }
 
       float minSignificance = 1e12;
-      if (simHitBySignificance_){
+      if (simHitBySignificance_){//save the best matching hit
 	
+        int simHitKey = -1;
+        edm::ProductID simHitID;
 	for(auto ip = range.first; ip != range.second; ++ip) {
 	  TrackPSimHitRef TPhit = ip->second;
 	  DetId dId = DetId(TPhit->detUnitId());
@@ -2484,9 +2485,29 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
 	      simHitID = TPhit.id();
 	    }
 	  }
-	}
+	}//loop over matching hits
+
+        auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
+        ret.matchingSimHit.push_back(simHitIndex);
+
+        double chargeFraction = 0.;
+        for(const SimTrack& simtrk: trackingParticle->g4Tracks()) {
+          auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
+          if(found != simTrackIdToChargeFraction.end()) {
+            chargeFraction += found->second;
+          }
+        }
+        ret.xySignificance.push_back(minSignificance);
+        ret.chargeFraction.push_back(chargeFraction);
+
+        // only for debug prints
+        ret.bunchCrossing.push_back(bx);
+        ret.event.push_back(event);
+
+        simhit_hitIdx[simHitIndex].push_back(clusterKey);
+        simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
 	
-      } else {
+      } else {//save all matching hits
         for (auto ip = range.first; ip != range.second; ++ip) {
           TrackPSimHitRef TPhit = ip->second;
           DetId dId = DetId(TPhit->detUnitId());
@@ -2512,6 +2533,7 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
                 chargeFraction += found->second;
               }
             }
+            ret.xySignificance.push_back(minSignificance);
             ret.chargeFraction.push_back(chargeFraction);
             
             // only for debug prints
@@ -2545,28 +2567,9 @@ TrackingNtuple::SimHitData TrackingNtuple::matchCluster(
         }
         throw ex;
       }
-      ret.xySignificance.push_back(minSignificance);
-      auto simHitIndex = simHitRefKeyToIndex.at(std::make_pair(simHitKey, simHitID));
-      ret.matchingSimHit.push_back(simHitIndex);
-
-      double chargeFraction = 0.;
-      for(const SimTrack& simtrk: trackingParticle->g4Tracks()) {
-        auto found = simTrackIdToChargeFraction.find(simtrk.trackId());
-        if(found != simTrackIdToChargeFraction.end()) {
-          chargeFraction += found->second;
-        }
-      }
-      ret.chargeFraction.push_back(chargeFraction);
-
-      // only for debug prints
-      ret.bunchCrossing.push_back(bx);
-      ret.event.push_back(event);
-
-      simhit_hitIdx[simHitIndex].push_back(clusterKey);
-      simhit_hitType[simHitIndex].push_back(static_cast<int>(hitType));
     }
   }
-
+  
   return ret;
 }
 
@@ -2722,8 +2725,6 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
       pix_yz.push_back(ttrh->globalPositionError().czy());
       pix_zz.push_back(ttrh->globalPositionError().czz());
       pix_zx.push_back(ttrh->globalPositionError().czx());
-      pix_xySignificance.push_back(simHitData.xySignificance);
-      pix_chargeFraction.push_back(simHitData.chargeFraction);
       pix_radL.push_back(ttrh->surface()->mediumProperties().radLen());
       pix_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
 
@@ -2742,6 +2743,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
                                              HitType::Pixel);
         pix_simHitIdx.push_back(simHitData.matchingSimHit);
         pix_simType.push_back(static_cast<int>(simHitData.type));
+        pix_xySignificance.push_back(simHitData.xySignificance);
         pix_chargeFraction.push_back(simHitData.chargeFraction);
         LogTrace("TrackingNtuple") << " nMatchingSimHit=" << simHitData.matchingSimHit.size();
         if (!simHitData.matchingSimHit.empty()) {
@@ -2817,8 +2819,6 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_yz[key] = ttrh->globalPositionError().czy();
         str_zz[key] = ttrh->globalPositionError().czz();
         str_zx[key] = ttrh->globalPositionError().czx();
-        str_xySignificance[key] = simHitData.xySignificance;
-        str_chargeFraction[key] = simHitData.chargeFraction;
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
         str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
@@ -2838,6 +2838,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
                                                HitType::Strip);
           str_simHitIdx[key] = simHitData.matchingSimHit;
           str_simType[key] = static_cast<int>(simHitData.type);
+          str_xySignificance[key] = simHitData.xySignificance;
           str_chargeFraction[key] = simHitData.chargeFraction;
           LogTrace("TrackingNtuple") << " nMatchingSimHit=" << simHitData.matchingSimHit.size();
           if (!simHitData.matchingSimHit.empty()) {
@@ -2885,7 +2886,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_zx.push_back(ttrh->globalPositionError().czx());
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
-  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit->firstClusterRef().stripCluster()));
+  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster()));
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()
@@ -2931,9 +2932,6 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
       ph2_detId.push_back(tTopo, hitId);
       ph2_trkIdx.emplace_back();  // filled in fillTracks
       ph2_seeIdx.emplace_back();  // filled in fillSeeds
-      ph2_xySignificance.push_back(simHitData.xySignificance);
-      ph2_simHitIdx.push_back(simHitData.matchingSimHit);
-      ph2_simType.push_back(static_cast<int>(simHitData.type));
       ph2_x.push_back(ttrh->globalPosition().x());
       ph2_y.push_back(ttrh->globalPosition().y());
       ph2_z.push_back(ttrh->globalPosition().z());
@@ -2960,6 +2958,7 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
                                              digiSimLink,
                                              simHitRefKeyToIndex,
                                              HitType::Phase2OT);
+        ph2_xySignificance.push_back(simHitData.xySignificance);
         ph2_simHitIdx.push_back(simHitData.matchingSimHit);
         ph2_simType.push_back(static_cast<int>(simHitData.type));
         LogTrace("TrackingNtuple") << " nMatchingSimHit=" << simHitData.matchingSimHit.size();
@@ -3127,7 +3126,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       ///the following is useful for analysis in global coords at seed hit surface      
       TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
       TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(seed.startingState(),
-                                                                               lastRecHit->surface(), theMF);
+                                                                               lastRecHit->surface(), &theMF);
       auto const& stateGlobal = tsos.globalParameters();
       see_stateTrajGlbX.push_back(stateGlobal.position().x());
       see_stateTrajGlbY.push_back(stateGlobal.position().y());

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -654,6 +654,7 @@ private:
   std::string builderName_;
   std::string parametersDefinerName_;
   const bool includeSeeds_;
+  const bool addSeedCartesianCov_;
   const bool includeAllHits_;
   const bool includeMVA_;
   const bool includeTrackingParticles_;
@@ -1211,6 +1212,27 @@ private:
   std::vector<float> see_stateTrajGlbPx;
   std::vector<float> see_stateTrajGlbPy;
   std::vector<float> see_stateTrajGlbPz;
+  std::vector<float> see_stateCcov00;
+  std::vector<float> see_stateCcov01;
+  std::vector<float> see_stateCcov02;
+  std::vector<float> see_stateCcov03;
+  std::vector<float> see_stateCcov04;
+  std::vector<float> see_stateCcov05;
+  std::vector<float> see_stateCcov11;
+  std::vector<float> see_stateCcov12;
+  std::vector<float> see_stateCcov13;
+  std::vector<float> see_stateCcov14;
+  std::vector<float> see_stateCcov15;
+  std::vector<float> see_stateCcov22;
+  std::vector<float> see_stateCcov23;
+  std::vector<float> see_stateCcov24;
+  std::vector<float> see_stateCcov25;
+  std::vector<float> see_stateCcov33;
+  std::vector<float> see_stateCcov34;
+  std::vector<float> see_stateCcov35;
+  std::vector<float> see_stateCcov44;
+  std::vector<float> see_stateCcov45;
+  std::vector<float> see_stateCcov55;
   std::vector<int> see_q;
   std::vector<unsigned int> see_nValid;
   std::vector<unsigned int> see_nPixel;
@@ -1304,6 +1326,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       builderName_(iConfig.getUntrackedParameter<std::string>("TTRHBuilder")),
       parametersDefinerName_(iConfig.getUntrackedParameter<std::string>("parametersDefiner")),
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
+      addSeedCartesianCov_(iConfig.getUntrackedParameter<bool>("addSeedCartesianCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
@@ -1652,6 +1675,29 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stateTrajGlbPx", &see_stateTrajGlbPx);
     t->Branch("see_stateTrajGlbPy", &see_stateTrajGlbPy);
     t->Branch("see_stateTrajGlbPz", &see_stateTrajGlbPz);
+    if (addSeedCartesianCov_){
+      t->Branch("see_stateCcov00", &see_stateCcov00);
+      t->Branch("see_stateCcov01", &see_stateCcov01);
+      t->Branch("see_stateCcov02", &see_stateCcov02);
+      t->Branch("see_stateCcov03", &see_stateCcov03);
+      t->Branch("see_stateCcov04", &see_stateCcov04);
+      t->Branch("see_stateCcov05", &see_stateCcov05);
+      t->Branch("see_stateCcov11", &see_stateCcov11);
+      t->Branch("see_stateCcov12", &see_stateCcov12);
+      t->Branch("see_stateCcov13", &see_stateCcov13);
+      t->Branch("see_stateCcov14", &see_stateCcov14);
+      t->Branch("see_stateCcov15", &see_stateCcov15);
+      t->Branch("see_stateCcov22", &see_stateCcov22);
+      t->Branch("see_stateCcov23", &see_stateCcov23);
+      t->Branch("see_stateCcov24", &see_stateCcov24);
+      t->Branch("see_stateCcov25", &see_stateCcov25);
+      t->Branch("see_stateCcov33", &see_stateCcov33);
+      t->Branch("see_stateCcov34", &see_stateCcov34);
+      t->Branch("see_stateCcov35", &see_stateCcov35);
+      t->Branch("see_stateCcov44", &see_stateCcov44);
+      t->Branch("see_stateCcov45", &see_stateCcov45);
+      t->Branch("see_stateCcov55", &see_stateCcov55);
+    }
     t->Branch("see_q", &see_q);
     t->Branch("see_nValid", &see_nValid);
     t->Branch("see_nPixel", &see_nPixel);
@@ -1965,6 +2011,27 @@ void TrackingNtuple::clearVariables() {
   see_stateTrajGlbPx.clear();
   see_stateTrajGlbPy.clear();
   see_stateTrajGlbPz.clear();
+  see_stateCcov00.clear();
+  see_stateCcov01.clear();
+  see_stateCcov02.clear();
+  see_stateCcov03.clear();
+  see_stateCcov04.clear();
+  see_stateCcov05.clear();
+  see_stateCcov11.clear();
+  see_stateCcov12.clear();
+  see_stateCcov13.clear();
+  see_stateCcov14.clear();
+  see_stateCcov15.clear();
+  see_stateCcov22.clear();
+  see_stateCcov23.clear();
+  see_stateCcov24.clear();
+  see_stateCcov25.clear();
+  see_stateCcov33.clear();
+  see_stateCcov34.clear();
+  see_stateCcov35.clear();
+  see_stateCcov44.clear();
+  see_stateCcov45.clear();
+  see_stateCcov55.clear();
   see_q.clear();
   see_nValid.clear();
   see_nPixel.clear();
@@ -2955,6 +3022,30 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajGlbPx.push_back(stateGlobal.momentum().x());
       see_stateTrajGlbPy.push_back(stateGlobal.momentum().y());
       see_stateTrajGlbPz.push_back(stateGlobal.momentum().z());
+      if (addSeedCartesianCov_){
+	auto const& stateCcov = tsos.cartesianError().matrix();
+	see_stateCcov00.push_back( stateCcov[0][0] );
+	see_stateCcov01.push_back( stateCcov[0][1] );
+	see_stateCcov02.push_back( stateCcov[0][2] );
+	see_stateCcov03.push_back( stateCcov[0][3] );
+	see_stateCcov04.push_back( stateCcov[0][4] );
+	see_stateCcov05.push_back( stateCcov[0][5] );
+	see_stateCcov11.push_back( stateCcov[1][1] );
+	see_stateCcov12.push_back( stateCcov[1][2] );
+	see_stateCcov13.push_back( stateCcov[1][3] );
+	see_stateCcov14.push_back( stateCcov[1][4] );
+	see_stateCcov15.push_back( stateCcov[1][5] );
+	see_stateCcov22.push_back( stateCcov[2][2] );
+	see_stateCcov23.push_back( stateCcov[2][3] );
+	see_stateCcov24.push_back( stateCcov[2][4] );
+	see_stateCcov25.push_back( stateCcov[2][5] );
+	see_stateCcov33.push_back( stateCcov[3][3] );
+	see_stateCcov34.push_back( stateCcov[3][4] );
+	see_stateCcov35.push_back( stateCcov[3][5] );
+	see_stateCcov44.push_back( stateCcov[4][4] );
+	see_stateCcov45.push_back( stateCcov[4][5] );
+	see_stateCcov55.push_back( stateCcov[5][5] );
+      }
 
       see_trkIdx.push_back(-1);  // to be set correctly in fillTracks
       if (includeTrackingParticles_) {
@@ -3732,6 +3823,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.addUntracked<std::string>("parametersDefiner", "LhcParametersDefinerForTP");
   desc.addUntracked<bool>("includeSeeds", false);
+  desc.addUntracked<bool>("addSeedCartesianCov", false);
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -55,6 +55,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
@@ -1109,6 +1110,7 @@ private:
   std::vector<float>
       str_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> str_bbxi;
+  std::vector<float> str_chargePerCM;
   ////////////////////
   // strip matched hits
   // (first) index runs through hits
@@ -1129,6 +1131,7 @@ private:
   std::vector<float>
       glu_radL;  //http://cmslxr.fnal.gov/lxr/source/DataFormats/GeometrySurface/interface/MediumProperties.h
   std::vector<float> glu_bbxi;
+  std::vector<float> glu_chargePerCM ;
   ////////////////////
   // phase2 Outer Tracker hits
   // (first) index runs through hits
@@ -1576,6 +1579,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_zx", &str_zx);
       t->Branch("str_radL", &str_radL);
       t->Branch("str_bbxi", &str_bbxi);
+      t->Branch("str_chargePerCM", &str_chargePerCM);
       //matched hits
       t->Branch("glu_isBarrel", &glu_isBarrel);
       glu_detId.book("glu", t);
@@ -1595,6 +1599,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("glu_zx", &glu_zx);
       t->Branch("glu_radL", &glu_radL);
       t->Branch("glu_bbxi", &glu_bbxi);
+      t->Branch("glu_chargePerCM", &glu_chargePerCM);
     }
     //phase2 OT
     if (includePhase2OTHits_) {
@@ -1936,6 +1941,7 @@ void TrackingNtuple::clearVariables() {
   str_zx.clear();
   str_radL.clear();
   str_bbxi.clear();
+  str_chargePerCM.clear();
   //matched hits
   glu_isBarrel.clear();
   glu_detId.clear();
@@ -1953,6 +1959,7 @@ void TrackingNtuple::clearVariables() {
   glu_zx.clear();
   glu_radL.clear();
   glu_bbxi.clear();
+  glu_chargePerCM.clear();
   //phase2 OT
   ph2_isBarrel.clear();
   ph2_detId.clear();
@@ -2787,6 +2794,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   str_chargeFraction.resize(totalStripHits);
   str_radL.resize(totalStripHits);
   str_bbxi.resize(totalStripHits);
+  str_chargePerCM.resize(totalStripHits);
 
   auto fill = [&](const SiStripRecHit2DCollection& hits, const char* name) {
     for (const auto& detset : hits) {
@@ -2813,6 +2821,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
         str_chargeFraction[key] = simHitData.chargeFraction;
         str_radL[key] = ttrh->surface()->mediumProperties().radLen();
         str_bbxi[key] = ttrh->surface()->mediumProperties().xi();
+        str_chargePerCM[key] = siStripClusterTools::chargePerCM(hitId,hit.firstClusterRef().stripCluster());
         LogTrace("TrackingNtuple") << name << " cluster=" << key << " subdId=" << hitId.subdetId() << " lay=" << lay
                                    << " rawId=" << hitId.rawId() << " pos =" << ttrh->globalPosition();
 
@@ -2876,6 +2885,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
   glu_zx.push_back(ttrh->globalPositionError().czx());
   glu_radL.push_back(ttrh->surface()->mediumProperties().radLen());
   glu_bbxi.push_back(ttrh->surface()->mediumProperties().xi());
+  glu_chargePerCM.push_back(siStripClusterTools::chargePerCM(hitId,hit->firstClusterRef().stripCluster()));
   LogTrace("TrackingNtuple") << "stripMatchedHit"
                              << " cluster0=" << hit.stereoHit().cluster().key()
                              << " cluster1=" << hit.monoHit().cluster().key() << " subdId=" << hitId.subdetId()

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -113,7 +113,7 @@ def customiseTrackingNtupleHLT(process):
         #make sure that all iter tracking is done before running the ntuple-related modules
         process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
 
-    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.tracks = "hltMergedTracks"
     process.trackingNtuple.seedTracks = _seedSelectors
     process.trackingNtuple.trackCandidates = _candidatesProducers
     process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
@@ -127,8 +127,15 @@ def customiseTrackingNtupleHLT(process):
     process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
     process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
     process.trackingNtuple.includeMVA = False
+
+    return process
+
+def extendedContent(process):
+    process.trackingParticlesIntime.intimeOnly = False
+    process.trackingNtuple.includeOOT = True
+    process.trackingNtuple.keepEleSimHits = True
+
     process.trackingNtuple.saveSimHitsP3 = True
     process.trackingNtuple.addSeedCartesianCov = True
 
-    process.trackingNtupleSequence
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -8,15 +8,19 @@ def _label(tag):
         t = cms.InputTag(tag)
     return t.getModuleLabel()+t.getProductInstanceLabel()
 
-def customiseTrackingNtuple(process):
+def customiseTrackingNtupleTool(process, isRECO = True):
     process.load("Validation.RecoTrack.trackingNtuple_cff")
     process.TFileService = cms.Service("TFileService",
         fileName = cms.string('trackingNtuple.root')
     )
 
     if process.trackingNtuple.includeSeeds.value():
-        if not hasattr(process, "reconstruction_step"):
-            raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        if isRECO:
+            if not hasattr(process, "reconstruction_step"):
+                raise Exception("TrackingNtuple includeSeeds=True needs reconstruction which is missing")
+        else: #assumes HLT with PF iter
+            if not hasattr(process, "HLTIterativeTrackingIter02"):
+                raise Exception("TrackingNtuple includeSeeds=True needs HLTIterativeTrackingIter02 which is missing")
 
     # Replace validation_step with ntuplePath
     if not hasattr(process, "validation_step"):
@@ -27,7 +31,21 @@ def customiseTrackingNtuple(process):
     usePileupSimHits = hasattr(process, "mix") and hasattr(process.mix, "input") and len(process.mix.input.fileNames) > 0
 #    process.eda = cms.EDAnalyzer("EventContentAnalyzer")
 
+    if not isRECO:
+        if not hasattr(process,"hltMultiTrackValidation"):
+            process.load("Validation.RecoTrack.HLTmultiTrackValidator_cff")
+        process.trackingNtupleSequence = process.hltMultiTrackValidation.copy()
+        import RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitConverter_cfi as SiStripRecHitConverter_cfi
+        process.hltSiStripRecHits = SiStripRecHitConverter_cfi.siStripMatchedRecHits.clone(
+            ClusterProducer = "hltSiStripRawToClustersFacility",
+            StripCPE = "hltESPStripCPEfromTrackAngle:hltESPStripCPEfromTrackAngle"
+        )
+        process.trackingNtupleSequence.insert(0,process.trackingParticlesIntime+process.simHitTPAssocProducer)
+        process.trackingNtupleSequence.remove(process.hltTrackValidator)
+        process.trackingNtupleSequence += process.hltSiStripRecHits + process.trackingNtuple
+
     ntuplePath = cms.Path(process.trackingNtupleSequence)
+
     if process.trackingNtuple.includeAllHits and process.trackingNtuple.includeTrackingParticles and usePileupSimHits:
         ntuplePath.insert(0, cms.SequencePlaceholder("mix"))
 
@@ -61,4 +79,56 @@ def customiseTrackingNtuple(process):
             path.remove(outputModule)
         
 
+    return process
+
+def customiseTrackingNtuple(process):
+    customiseTrackingNtupleTool(process, isRECO = True)
+    return process
+
+def customiseTrackingNtupleHLT(process):
+    import Validation.RecoTrack.TrackValidation_cff as _TrackValidation_cff
+    _seedProducers = [
+        "hltIter0PFLowPixelSeedsFromPixelTracks",
+        "hltIter1PFLowPixelSeedsFromPixelTracks",
+        "hltIter2PFlowPixelSeeds",
+        "hltDoubletRecoveryPFlowPixelSeeds"
+    ]
+    _candidatesProducers = [ 
+        "hltIter0PFlowCkfTrackCandidates",
+        "hltIter1PFlowCkfTrackCandidates",
+        "hltIter2PFlowCkfTrackCandidates",
+        "hltDoubletRecoveryPFlowCkfTrackCandidates"
+    ]
+    (_seedSelectors, _tmpTask) = _TrackValidation_cff._addSeedToTrackProducers(_seedProducers, globals())
+    _seedSelectorsTask = cms.Task()
+    for modName in _seedSelectors:
+        if not hasattr(process, modName):
+            setattr(process,modName, globals()[modName].clone(beamSpot = "hltOnlineBeamSpot"))
+        _seedSelectorsTask.add(getattr(process, modName))
+
+    customiseTrackingNtupleTool(process, isRECO = False)
+
+    process.trackingNtupleSequence.insert(0,cms.Sequence(_seedSelectorsTask))
+    if process.hltSiStripRawToClustersFacility.onDemand.value():
+        #make sure that all iter tracking is done before running the ntuple-related modules
+        process.trackingNtupleSequence.insert(0,process.hltMergedTracks)
+
+    process.trackingNtuple.tracks = "hltIter0PFlowCtfWithMaterialTracks"
+    process.trackingNtuple.seedTracks = _seedSelectors
+    process.trackingNtuple.trackCandidates = _candidatesProducers
+    process.trackingNtuple.clusterTPMap = "hltTPClusterProducer"
+    process.trackingNtuple.trackAssociator = "hltTrackAssociatorByHits"
+    process.trackingNtuple.beamSpot = "hltOnlineBeamSpot"
+    process.trackingNtuple.pixelRecHits = "hltSiPixelRecHits"
+    process.trackingNtuple.stripRphiRecHits = "hltSiStripRecHits:rphiRecHit"
+    process.trackingNtuple.stripStereoRecHits = "hltSiStripRecHits:stereoRecHit"
+    process.trackingNtuple.stripMatchedRecHits = "hltSiStripRecHits:matchedRecHit"
+    process.trackingNtuple.vertices = "hltPixelVertices"
+    process.trackingNtuple.TTRHBuilder = "hltESPTTRHBWithTrackAngle"
+    process.trackingNtuple.parametersDefiner = "hltLhcParametersDefinerForTP"
+    process.trackingNtuple.includeMVA = False
+    process.trackingNtuple.saveSimHitsP3 = True
+    process.trackingNtuple.addSeedCartesianCov = True
+
+    process.trackingNtupleSequence
     return process


### PR DESCRIPTION
I'm leaving this in a "Draft" stage until some minor validation. 

Summary of changes relative to the upstream in TrackingNtuple
- optional for simhits info:
    - can add OOT hits with `includeOOT`
    - can keep (secondary) electron simhits with `keepEleSimHits`
    - can save simhit momentum px,py,pz with `saveSimHitsP3`
    - can enable saving only the closest simhit based on significance sorting with `simHitBySignificance`
- optional for seed details:
    - can save Cartesian 6x6 covariance with `addSeedCartesianCov`
- added by default
    - bitmask of cluster masking used per iteration; configurable via `clusterMasks`
    - cluster charge per CM
    - cluster size 
    - seed state parameters in global coordinates (x,y,z and px,py,pz)
- config tools now have `customiseTrackingNtupleHLT` 

Also, add `TrackSimpleMerger` which can concatenate a set of reco::Track collections.