### PR TITLE
add dead strips from strip quality

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitHitConverter.cc
@@ -97,9 +97,8 @@ MkFitHitConverter::MkFitHitConverter(edm::ParameterSet const& iConfig)
       mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
       wrapperPutToken_{produces<MkFitHitWrapper>()},
       clusterIndexPutToken_{produces<MkFitClusterIndexToHit>()},
-      //qualityToken_{esConsumes<edm::Transition::BeginRun>()},
-      qualityToken_{esConsumes<edm::Transition::Event>()},
-      geomToken_{esConsumes<edm::Transition::Event>()},
+      qualityToken_{esConsumes()},
+      geomToken_{esConsumes()},
       minGoodStripCharge_{static_cast<float>(
           iConfig.getParameter<edm::ParameterSet>("minGoodStripCharge").getParameter<double>("value"))} {}
 


### PR DESCRIPTION
#### PR description:

Gets input of dead modules from StripQuality event setup record to mkFit.

Notes / limitations:
* this done in MkFitHitConverter.cc, so once per event - ideally it should be done only when conditions change but it's probably not a big deal
* for now we only get the strip information, not pixels 
* we are treating both fully- and partially-inactive modules the same, i.e. considering the full module as potentially dead

#### PR validation:

http://uaf-10.t2.ucsd.edu/~cerati/deadmodules/
