### PR TITLE
Fix include in MkFitOutputConverter

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -27,7 +27,7 @@
 #include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
-#include "TrackingTools/MaterialEffects/src/PropagatorWithMaterial.cc"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 
 #include "RecoTracker/MkFit/interface/MkFitEventOfHits.h"
 #include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"


### PR DESCRIPTION
#### PR description:

Include a header file instead of a source file, pointed out by @slava77. I have no idea how that had crept in, from git history the `#include` has been like that "since the beginning".

#### PR validation:

Code compiles.