### PR TITLE
switch mkFit state conversion to use the curvilinear covariance on CMSSW side

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -294,12 +294,12 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
 
     // state
     auto state = cand.state();  // copy because have to modify
-    state.convertFromCCSToCartesian();
+    state.convertFromCCSToGlbCurvilinear();
     const auto& param = state.parameters;
     const auto& err = state.errors;
-    AlgebraicSymMatrix66 cov;
-    for (int i = 0; i < 6; ++i) {
-      for (int j = i; j < 6; ++j) {
+    AlgebraicSymMatrix55 cov;
+    for (int i = 0; i < 5; ++i) {
+      for (int j = i; j < 5; ++j) {
         cov[i][j] = err.At(i, j);
       }
     }
@@ -307,11 +307,10 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     auto fts = FreeTrajectoryState(
         GlobalTrajectoryParameters(
             GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
-        CartesianTrajectoryError(cov));
+        CurvilinearTrajectoryError(cov));
     if (!fts.curvilinearError().posDef()) {
       edm::LogWarning("MkFitOutputConverter") << "Curvilinear error not pos-def\n"
-                                              << fts.curvilinearError().matrix() << "\noriginal 6x6 covariance matrix\n"
-                                              << cov << "\ncandidate ignored";
+                                              << fts.curvilinearError().matrix();
       continue;
     }
 

--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -111,17 +111,16 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
     SVector3 pos(gpos.x(), gpos.y(), gpos.z());
     SVector3 mom(gmom.x(), gmom.y(), gmom.z());
 
-    const auto cartError = tsos.cartesianError();  // returns a temporary, so can't chain with the following line
-    const auto& cov = cartError.matrix();
-    SMatrixSym66 err;
-    for (int i = 0; i < 6; ++i) {
-      for (int j = i; j < 6; ++j) {
+    const auto& cov = tsos.curvilinearError().matrix();
+    SMatrixSym66 err; //fill a sub-matrix, mkfit::TrackState will convert internally
+    for (int i = 0; i < 5; ++i) {
+      for (int j = i; j < 5; ++j) {
         err.At(i, j) = cov[i][j];
       }
     }
 
     mkfit::TrackState state(tsos.charge(), pos, mom, err);
-    state.convertFromCartesianToCCS();
+    state.convertFromGlbCurvilinearToCCS();
     ret.emplace_back(state, 0, seed_index, 0, nullptr);
     LogTrace("MkFitSeedConverter") << "Inserted seed with index " << seed_index;
 


### PR DESCRIPTION
requires changes in trackreco/mkFit#324

details of testing are in 
https://github.com/trackreco/mkFit/pull/324#issue-676323448

