### PR TITLE
restore LogWarning note [candidate ignored] in MkFitOutputConverter

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -291,7 +291,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         CurvilinearTrajectoryError(cov));
     if (!fts.curvilinearError().posDef()) {
       edm::LogWarning("MkFitOutputConverter") << "Curvilinear error not pos-def\n"
-                                              << fts.curvilinearError().matrix();
+                                              << fts.curvilinearError().matrix() << "\ncandidate ignored";
       continue;
     }
 


### PR DESCRIPTION
recover a part of the logwarning message lost in trackreco/cmssw#28

