### PR TITLE
use dead strip info by default in MkFitEventOfHitsProducer

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -66,7 +66,7 @@ void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
-  desc.add("useStripStripQualityDB", false)->setComment("Use SiStrip quality DB information");
+  desc.add("useStripStripQualityDB", true)->setComment("Use SiStrip quality DB information");
 
   descriptions.addWithDefaultLabel(desc);
 }


### PR DESCRIPTION
based on improvements integrated in trackreco/mkFit#339
and validation plots in http://uaf-10.t2.ucsd.edu/~legianni/plots_2024scenario and http://uaf-10.t2.ucsd.edu/~legianni/plots_2021scenario

