### PR TITLE
restrict dead strip regions to invalid APVs if only a part of the module is dead

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -4,7 +4,14 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
 #include "RecoTracker/MkFit/interface/MkFitEventOfHits.h"
@@ -12,10 +19,6 @@
 #include "RecoTracker/MkFit/interface/MkFitHitWrapper.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
 
 // mkFit includes
 #include "mkFit/HitStructures.h"
@@ -85,16 +88,60 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
     const auto& trackerGeom = iSetup.getData(geomToken_);
     const auto& badStrips = siStripQuality.getBadComponentList();
     for (const auto& bs : badStrips) {
-      const auto& surf = trackerGeom.idToDet(DetId(bs.detid))->surface();
       const DetId detid(bs.detid);
+      const auto& surf = trackerGeom.idToDet(detid)->surface();
       bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
       const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
-      //dump content of deadmodules.h in standalone setup
-      // std::cout << "deadvectors["<<ilay<<"].push_back({"<<surf.phiSpan().first<<","<<surf.phiSpan().second<<","
-      // 		<<(isBarrel ? surf.zSpan().first : surf.rSpan().first)<<","<<(isBarrel ? surf.zSpan().second : surf.rSpan().second)<<"});"<<std::endl;
-      deadvectors[ilay].push_back({surf.phiSpan().first,surf.phiSpan().second,
-	    (isBarrel ? surf.zSpan().first : surf.rSpan().first),(isBarrel ? surf.zSpan().second : surf.rSpan().second)});
+      const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
+      const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
+      if (bs.BadModule)
+        deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
+      else { //assume that BadApvs are filled in sync with BadFibers
+        auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
+        int firstApv = -1;
+        int lastApv = -1;
+
+        auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
+          auto const firstPoint = surf.toGlobal(topo.localPosition(first * 128));
+          auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * 128));
+          float phi1 = firstPoint.phi();
+          float phi2 = lastPoint.phi();
+          if (reco::deltaPhi(phi1, phi2) > 0)
+            std::swap(phi1, phi2);
+          LogTrace("SiStripBadComponents")<<"insert bad range "<<first<<" to "<<last<<" "<<phi1<<" "<<phi2;
+          dv.push_back({phi1, phi2, q1, q2});
+        };
+
+        for (int apv = 0; apv < 6; ++apv) {
+          const bool isBad = bs.BadApvs & (1 << apv);
+          if (isBad)
+            LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
+          if (isBad) {
+            if (lastApv == -1) {
+              firstApv = apv;
+              lastApv = apv;
+            } else if (lastApv + 1 == apv)
+              lastApv++;
+
+            if (apv == 5)
+              addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
+          } else if (firstApv != -1) {
+            addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
+            //and reset
+            firstApv = -1;
+            lastApv = -1;
+          }
+        }
+      }//for (const auto& bs : badStrips)
     }
+    //dump content for deadmodules.h in standalone setup
+    //    int ilay = -1;
+    //    for (auto const& dv : deadvectors) {
+    //      ilay++;
+    //      for (auto const& dr : dv )
+    //        std::cout << "deadvectors[" << ilay << "].push_back({"
+    //                  << dr.phi1 << "," << dr.phi2 << "," << dr.q1 << "," << dr.q2 << "});" << std::endl;
+    //    }
     mkfit::StdSeq::LoadDeads(*eventOfHits, deadvectors);
   }
 


### PR DESCRIPTION
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit_dr_dead-restricted-Qbin-p256-apv_mbc09d1e_cc70ceba/plots_initialStep.html
has this PR in black (the ; 
- blue/reference is without dead regions as of trackreco/mkFit#335
- red is mkFit from my local repo which equates to devel with trackreco/mkFit#339 for red without  trackreco/mkFit#336 and includes dead regions
- black is red with this PR

There is an epsilon improvement in fake rates and even a bit of improvement in 
<img width="892" alt="image" src="https://user-images.githubusercontent.com/4676718/129407916-aff521f3-b0b5-4965-a3a1-78ea2576e0b2.png">
The impact on the number of hits for the signal tracks is rather negligible
<img width="887" alt="image" src="https://user-images.githubusercontent.com/4676718/129408312-ff9c26bc-541f-44b0-bd73-a6d47202bebf.png">

10mu comparisons do not have much of a difference
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10mu_mkFit_dr_dead-restricted-Qbin-p256-apv_mbc09d1e_cc70ceba/plots_initialStep.html

here are a few diffs from the printed out deadmodules:
```diff
-deadvectors[10].push_back({-2.07947,-1.92233,72.9367,91.5501});
+deadvectors[10].push_back({-2.07944,-2.0009,72.9367,91.5501});
 ...
-deadvectors[10].push_back({1.06611,1.21527,-0.0751572,18.5383});
+deadvectors[10].push_back({1.06614,1.10337,-0.0751572,18.5383});
-deadvectors[10].push_back({1.06613,1.21529,72.937,91.5505});
+deadvectors[10].push_back({1.06616,1.14071,72.937,91.5505});
-deadvectors[10].push_back({1.66321,1.81498,-54.3722,-35.7588});
+deadvectors[10].push_back({1.66324,1.7391,-54.3722,-35.7588});
```


I still wanted to add an ESWatcher to update the `deadvectors`  only when the IOVs change, but having it in a combination with `edm::global` will require some learning for me.

the vector dump for the standalone tests is in trackreco/mkFit#343
