### PR TITLE
update in strip dead region ranges after the code review

### DIFF
--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -1,6 +1,9 @@
 <library file="*.cc" name="RecoTrackerMkFitPlugins">
+  <use name="CalibFormats/SiStripObjects"/>
+  <use name="CalibTracker/Records"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
+  <use name="DataFormats/SiStripCommon"/>
   <use name="DataFormats/SiPixelCluster"/>
   <use name="DataFormats/TrackCandidate"/>
   <use name="DataFormats/TrackReco"/>
@@ -10,6 +13,7 @@
   <use name="DataFormats/TrajectorySeed"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
+  <use name="Geometry/CommonTopologies"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="RecoTracker/MeasurementDet"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -7,6 +7,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
 #include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
@@ -102,8 +103,8 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
         int lastApv = -1;
 
         auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
-          auto const firstPoint = surf.toGlobal(topo.localPosition(first * 128));
-          auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * 128));
+          auto const firstPoint = surf.toGlobal(topo.localPosition(first * sistrip::STRIPS_PER_APV));
+          auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * sistrip::STRIPS_PER_APV));
           float phi1 = firstPoint.phi();
           float phi2 = lastPoint.phi();
           if (reco::deltaPhi(phi1, phi2) > 0)
@@ -112,18 +113,18 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
           dv.push_back({phi1, phi2, q1, q2});
         };
 
-        for (int apv = 0; apv < 6; ++apv) {
+        const int nApvs = topo.nstrips() / sistrip::STRIPS_PER_APV;
+        for (int apv = 0; apv < nApvs; ++apv) {
           const bool isBad = bs.BadApvs & (1 << apv);
-          if (isBad)
-            LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
           if (isBad) {
+            LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
             if (lastApv == -1) {
               firstApv = apv;
               lastApv = apv;
             } else if (lastApv + 1 == apv)
               lastApv++;
 
-            if (apv == 5)
+            if (apv + 1 == nApvs)
               addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
           } else if (firstApv != -1) {
             addRangeAPV(firstApv, lastApv, deadvectors[ilay]);


### PR DESCRIPTION
- RecoTracker/MkFit/plugins/BuildFile.xml is updated to cover the direct includes recently added in MkFitEventOfHitsProducer
- RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc is updated following the code review comments in the cmssw PR 34921

For validation I checked that the dump of the `deadvectors` did not change after this update.