### PR TITLE
Enable backward search in pixelLessStep and tobTecStep

### DIFF
--- a/RecoTracker/MkFit/data/mkfit-phase1-detachedQuadStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-detachedQuadStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.05000000074505806
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-detachedTripletStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-detachedTripletStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.05000000074505806
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-highPtTripletStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-highPtTripletStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.07999999821186066
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-initialStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-initialStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.004000000189989805,
   "drth_forward": 0.00800000037997961
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-lowPtQuadStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-lowPtQuadStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.029999999329447746,
   "drth_forward": 0.05000000074505806
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-lowPtTripletStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-lowPtTripletStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.017999999225139618
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-mixedTripletStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-mixedTripletStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.05000000074505806
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-pixelLessStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-pixelLessStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.004000000189989805,
   "drth_forward": 0.00800000037997961
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 4,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 2,
+  "maxConsecHoles": 2,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.5,
+  "drth_central": 0.0020000000949949026,
+  "drth_obarrel": 0.004000000189989805,
+  "drth_forward": 0.00800000037997961
+ },
  "m_requires_seed_hit_sorting": true,
  "m_require_quality_filter": true,
  "m_require_dupclean_tight": false,
+ "m_backward_search": true,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-pixelPairStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-pixelPairStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.05000000074505806,
   "drth_forward": 0.05000000074505806
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 3,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 4,
+  "maxConsecHoles": 1,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.1899999976158142,
+  "drth_central": 0.0010000000474974513,
+  "drth_obarrel": 0.0010000000474974513,
+  "drth_forward": 0.0010000000474974513
+ },
  "m_requires_seed_hit_sorting": false,
  "m_require_quality_filter": false,
  "m_require_dupclean_tight": true,
+ "m_backward_search": false,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/data/mkfit-phase1-tobTecStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-tobTecStep.json
@@ -22,9 +22,32 @@
   "drth_obarrel": 0.004000000189989805,
   "drth_forward": 0.00800000037997961
  },
+ "m_backward_params": {
+  "nlayers_per_seed": 4,
+  "maxCandsPerSeed": 5,
+  "maxHolesPerCand": 2,
+  "maxConsecHoles": 2,
+  "chi2Cut_min": 10.0,
+  "chi2CutOverlap": 3.5,
+  "pTCutOverlap": 1.0,
+  "c_ptthr_hpt": 2.0,
+  "c_drmax_bh": 0.009999999776482582,
+  "c_dzmax_bh": 0.004999999888241291,
+  "c_drmax_eh": 0.009999999776482582,
+  "c_dzmax_eh": 0.009999999776482582,
+  "c_drmax_bl": 0.009999999776482582,
+  "c_dzmax_bl": 0.004999999888241291,
+  "c_drmax_el": 0.014999999664723873,
+  "c_dzmax_el": 0.014999999664723873,
+  "fracSharedHits": 0.5,
+  "drth_central": 0.0020000000949949026,
+  "drth_obarrel": 0.004000000189989805,
+  "drth_forward": 0.00800000037997961
+ },
  "m_requires_seed_hit_sorting": true,
  "m_require_quality_filter": true,
  "m_require_dupclean_tight": false,
+ "m_backward_search": true,
  "m_layer_configs": [
   {
    "m_select_min_dphi": 0.009999999776482582,

--- a/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
+++ b/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
@@ -32,7 +32,7 @@ namespace {
       sp.append_plan(47, false);
       sp.fill_plan(48, 53);  // TID,  6 disks (3 mono + 3 stereo)
       sp.fill_plan(54, 71);  // TEC, 18 disks (3 mono + 3 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Transition_Neg];
@@ -47,7 +47,7 @@ namespace {
       sp.fill_plan(48, 53);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(10, 17);  // TOB,  8 layers (6 mono + 2 stereo)
       sp.fill_plan(54, 71);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Barrel];
@@ -57,7 +57,7 @@ namespace {
       sp.append_plan(3, false);
       sp.fill_plan(4, 9);    // TIB, 6 layers (4 mono + 2 stereo)
       sp.fill_plan(10, 17);  // TOB, 8 layers (6 mono + 2 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Transition_Pos];
@@ -72,7 +72,7 @@ namespace {
       sp.fill_plan(21, 26);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(10, 17);  // TOB,  8 layers (6 mono + 2 stereo)
       sp.fill_plan(27, 44);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
     {
       SteeringParams &sp = ic.m_steering_params[TrackerInfo::Reg_Endcap_Pos];
@@ -84,9 +84,34 @@ namespace {
       sp.append_plan(20, false);
       sp.fill_plan(21, 26);  // TID,  6 disks  (3 mono + 3 stereo)
       sp.fill_plan(27, 44);  // TEC, 18 disks  (9 mono + 9 stereo)
-      sp.finalize_plan();
+      sp.set_iterator_limits(2, 0);
     }
   }
+
+ void OverrideSteeringParams_Iter7(IterationConfig& ic)
+  {
+    ic.m_backward_search = true;
+    // Remove pixel layers from FwdSearch, add them to BkwSearch
+    auto &spv = ic.m_steering_params;
+    spv[TrackerInfo::Reg_Endcap_Neg]    .set_iterator_limits(8, 6, 19);
+    spv[TrackerInfo::Reg_Transition_Neg].set_iterator_limits(9, 7, 34);
+    spv[TrackerInfo::Reg_Barrel]        .set_iterator_limits(6, 4, 8);
+    spv[TrackerInfo::Reg_Transition_Pos].set_iterator_limits(9, 7, 34);
+    spv[TrackerInfo::Reg_Endcap_Pos]    .set_iterator_limits(8, 6, 19);
+  }
+
+  void OverrideSteeringParams_Iter8(IterationConfig& ic)
+  {
+    ic.m_backward_search = true;
+    // Remove pixel/tib/tid layers from FwdSearch, add them to BkwSearch/
+    auto &spv = ic.m_steering_params;
+    spv[TrackerInfo::Reg_Endcap_Neg]    .set_iterator_limits(12, 12, 24);
+    spv[TrackerInfo::Reg_Transition_Neg].set_iterator_limits(27, 19, 39);
+    spv[TrackerInfo::Reg_Barrel]        .set_iterator_limits(12, 10, 14);
+    spv[TrackerInfo::Reg_Transition_Pos].set_iterator_limits(27, 19, 39);
+    spv[TrackerInfo::Reg_Endcap_Pos]    .set_iterator_limits(12, 12, 24);
+  }
+
 
   void partitionSeeds0(const TrackerInfo &trk_info,
                        const TrackVec &in_seeds,
@@ -221,9 +246,11 @@ namespace mkfit {
     ii[6].set_iteration_index_and_track_algorithm(6, (int)TrackBase::TrackAlgorithm::mixedTripletStep);
 
     ii[7].Clone(ii[0]);
+    OverrideSteeringParams_Iter7(ii[7]);
     ii[7].set_iteration_index_and_track_algorithm(7, (int)TrackBase::TrackAlgorithm::pixelLessStep);
 
     ii[8].Clone(ii[0]);
+    OverrideSteeringParams_Iter8(ii[8]);
     ii[8].set_iteration_index_and_track_algorithm(8, (int)TrackBase::TrackAlgorithm::tobTecStep);
 
     ii[9].Clone(ii[0]);

--- a/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
+++ b/RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc
@@ -91,6 +91,9 @@ namespace {
  void OverrideSteeringParams_Iter7(IterationConfig& ic)
   {
     ic.m_backward_search = true;
+    ic.m_backward_params = ic.m_params;
+    ic.m_backward_params.maxHolesPerCand = 2;
+    ic.m_backward_params.maxConsecHoles  = 2;
     // Remove pixel layers from FwdSearch, add them to BkwSearch
     auto &spv = ic.m_steering_params;
     spv[TrackerInfo::Reg_Endcap_Neg]    .set_iterator_limits(8, 6, 19);
@@ -103,6 +106,9 @@ namespace {
   void OverrideSteeringParams_Iter8(IterationConfig& ic)
   {
     ic.m_backward_search = true;
+    ic.m_backward_params = ic.m_params;
+    ic.m_backward_params.maxHolesPerCand = 2;
+    ic.m_backward_params.maxConsecHoles  = 2;
     // Remove pixel/tib/tid layers from FwdSearch, add them to BkwSearch/
     auto &spv = ic.m_steering_params;
     spv[TrackerInfo::Reg_Endcap_Neg]    .set_iterator_limits(12, 12, 24);


### PR DESCRIPTION
#### PR description:

modified json files and RecoTracker/MkFit/plugins/createPhase1TrackerGeometry.cc to accommodate backward search in PR 345 https://github.com/trackreco/mkFit/pull/345


