### PR TITLE
dead pixel modules

### DIFF
--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -1,6 +1,8 @@
 <library file="*.cc" name="RecoTrackerMkFitPlugins">
   <use name="CalibFormats/SiStripObjects"/>
   <use name="CalibTracker/Records"/>
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondFormats/SiPixelObjects"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
   <use name="DataFormats/SiStripCommon"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -23,7 +23,6 @@
 #include "RecoTracker/MkFit/interface/MkFitHitWrapper.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
-
 // mkFit includes
 #include "mkFit/HitStructures.h"
 #include "mkFit/MkStdSeqs.h"
@@ -65,15 +64,15 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
       putToken_{produces<MkFitEventOfHits>()},
       usePixelQualityDB_{iConfig.getParameter<bool>("usePixelQualityDB")},
       useStripStripQualityDB_{iConfig.getParameter<bool>("useStripStripQualityDB")} {
-        if (useStripStripQualityDB_ || usePixelQualityDB_)
-          geomToken_ = esConsumes();
-	if (usePixelQualityDB_) {
-	  pixelQualityToken_ = esConsumes();
-	}
-	if (useStripStripQualityDB_) {
-	  stripQualityToken_ = esConsumes();
-	}
-      }
+  if (useStripStripQualityDB_ || usePixelQualityDB_)
+    geomToken_ = esConsumes();
+  if (usePixelQualityDB_) {
+    pixelQualityToken_ = esConsumes();
+  }
+  if (useStripStripQualityDB_) {
+    stripQualityToken_ = esConsumes();
+  }
+}
 
 void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -113,7 +112,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
       }
     }
 
-    if(useStripStripQualityDB_) {
+    if (useStripStripQualityDB_) {
       const auto& siStripQuality = iSetup.getData(stripQualityToken_);
       const auto& badStrips = siStripQuality.getBadComponentList();
       for (const auto& bs : badStrips) {
@@ -125,7 +124,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
         const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
         if (bs.BadModule)
           deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
-        else { //assume that BadApvs are filled in sync with BadFibers
+        else {  //assume that BadApvs are filled in sync with BadFibers
           auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
           int firstApv = -1;
           int lastApv = -1;
@@ -137,7 +136,8 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
             float phi2 = lastPoint.phi();
             if (reco::deltaPhi(phi1, phi2) > 0)
               std::swap(phi1, phi2);
-            LogTrace("SiStripBadComponents")<<"insert bad range "<<first<<" to "<<last<<" "<<phi1<<" "<<phi2;
+            LogTrace("SiStripBadComponents")
+                << "insert bad range " << first << " to " << last << " " << phi1 << " " << phi2;
             dv.push_back({phi1, phi2, q1, q2});
           };
 
@@ -145,7 +145,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
           for (int apv = 0; apv < nApvs; ++apv) {
             const bool isBad = bs.BadApvs & (1 << apv);
             if (isBad) {
-              LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
+              LogTrace("SiStripBadComponents") << "bad apv " << apv << " on " << bs.detid;
               if (lastApv == -1) {
                 firstApv = apv;
                 lastApv = apv;
@@ -161,7 +161,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
               lastApv = -1;
             }
           }
-        }//for (const auto& bs : badStrips)
+        }  //for (const auto& bs : badStrips)
       }
     }
 
@@ -169,12 +169,12 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
     //    int ilay = -1;
     //    for (auto const& dv : deadvectors) {
     //      ilay++;
-    //      for (auto const& dr : dv )
-    //        std::cout << "deadvectors[" << ilay << "].push_back({"
-    //                  << dr.phi1 << "," << dr.phi2 << "," << dr.q1 << "," << dr.q2 << "});" << std::endl;
+    //      for (auto const& dr : dv)
+    //        std::cout << "deadvectors[" << ilay << "].push_back({" << dr.phi1 << "," << dr.phi2 << "," << dr.q1 << ","
+    //                  << dr.q2 << "});" << std::endl;
     //    }
     mkfit::StdSeq::LoadDeads(*eventOfHits, deadvectors);
-  }//if (usePixelQualityDB_ || useStripStripQualityDB_)
+  }  //if (usePixelQualityDB_ || useStripStripQualityDB_)
 
   fill(iEvent.get(pixelClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);
   fill(iEvent.get(stripClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -4,6 +4,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
@@ -45,9 +48,11 @@ private:
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> stripClusterIndexToHitToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
-  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualityToken_;
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixelQualityToken_;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::EDPutTokenT<MkFitEventOfHits> putToken_;
+  const bool usePixelQualityDB_;
   const bool useStripStripQualityDB_;
 };
 
@@ -58,10 +63,15 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       mkFitGeomToken_{esConsumes()},
       putToken_{produces<MkFitEventOfHits>()},
+      usePixelQualityDB_{iConfig.getParameter<bool>("usePixelQualityDB")},
       useStripStripQualityDB_{iConfig.getParameter<bool>("useStripStripQualityDB")} {
+        if (useStripStripQualityDB_ || usePixelQualityDB_)
+          geomToken_ = esConsumes();
+	if (usePixelQualityDB_) {
+	  pixelQualityToken_ = esConsumes();
+	}
 	if (useStripStripQualityDB_) {
-	  qualityToken_ = esConsumes();
-	  geomToken_ = esConsumes();
+	  stripQualityToken_ = esConsumes();
 	}
       }
 
@@ -70,6 +80,7 @@ void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
+  desc.add("usePixelQualityDB", true)->setComment("Use SiPixelQuality DB information");
   desc.add("useStripStripQualityDB", true)->setComment("Use SiStrip quality DB information");
 
   descriptions.addWithDefaultLabel(desc);
@@ -83,58 +94,77 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
   auto eventOfHits = std::make_unique<mkfit::EventOfHits>(mkFitGeom.trackerInfo());
   mkfit::StdSeq::Cmssw_LoadHits_Begin(*eventOfHits, {&pixelHits.hits(), &stripHits.hits()});
 
-  if(useStripStripQualityDB_) {
+  if (usePixelQualityDB_ || useStripStripQualityDB_) {
     std::vector<mkfit::DeadVec> deadvectors(mkFitGeom.layerNumberConverter().nLayers());
-    const auto& siStripQuality = iSetup.getData(qualityToken_);
     const auto& trackerGeom = iSetup.getData(geomToken_);
-    const auto& badStrips = siStripQuality.getBadComponentList();
-    for (const auto& bs : badStrips) {
-      const DetId detid(bs.detid);
-      const auto& surf = trackerGeom.idToDet(detid)->surface();
-      bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
-      const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
-      const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
-      const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
-      if (bs.BadModule)
-        deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
-      else { //assume that BadApvs are filled in sync with BadFibers
-        auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
-        int firstApv = -1;
-        int lastApv = -1;
 
-        auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
-          auto const firstPoint = surf.toGlobal(topo.localPosition(first * sistrip::STRIPS_PER_APV));
-          auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * sistrip::STRIPS_PER_APV));
-          float phi1 = firstPoint.phi();
-          float phi2 = lastPoint.phi();
-          if (reco::deltaPhi(phi1, phi2) > 0)
-            std::swap(phi1, phi2);
-          LogTrace("SiStripBadComponents")<<"insert bad range "<<first<<" to "<<last<<" "<<phi1<<" "<<phi2;
-          dv.push_back({phi1, phi2, q1, q2});
-        };
-
-        const int nApvs = topo.nstrips() / sistrip::STRIPS_PER_APV;
-        for (int apv = 0; apv < nApvs; ++apv) {
-          const bool isBad = bs.BadApvs & (1 << apv);
-          if (isBad) {
-            LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
-            if (lastApv == -1) {
-              firstApv = apv;
-              lastApv = apv;
-            } else if (lastApv + 1 == apv)
-              lastApv++;
-
-            if (apv + 1 == nApvs)
-              addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
-          } else if (firstApv != -1) {
-            addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
-            //and reset
-            firstApv = -1;
-            lastApv = -1;
-          }
-        }
-      }//for (const auto& bs : badStrips)
+    if (usePixelQualityDB_) {
+      const auto& pixelQuality = iSetup.getData(pixelQualityToken_);
+      const auto& badPixels = pixelQuality.getBadComponentList();
+      for (const auto& bp : badPixels) {
+        const DetId detid(bp.DetID);
+        const auto& surf = trackerGeom.idToDet(detid)->surface();
+        bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
+        const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
+        const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
+        const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
+        if (bp.errorType == 0)
+          deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
+      }
     }
+
+    if(useStripStripQualityDB_) {
+      const auto& siStripQuality = iSetup.getData(stripQualityToken_);
+      const auto& badStrips = siStripQuality.getBadComponentList();
+      for (const auto& bs : badStrips) {
+        const DetId detid(bs.detid);
+        const auto& surf = trackerGeom.idToDet(detid)->surface();
+        bool isBarrel = (mkFitGeom.topology()->side(detid) == static_cast<unsigned>(TrackerDetSide::Barrel));
+        const auto ilay = mkFitGeom.mkFitLayerNumber(detid);
+        const auto q1 = isBarrel ? surf.zSpan().first : surf.rSpan().first;
+        const auto q2 = isBarrel ? surf.zSpan().second : surf.rSpan().second;
+        if (bs.BadModule)
+          deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
+        else { //assume that BadApvs are filled in sync with BadFibers
+          auto const& topo = dynamic_cast<const StripTopology&>(trackerGeom.idToDet(detid)->topology());
+          int firstApv = -1;
+          int lastApv = -1;
+
+          auto addRangeAPV = [&topo, &surf, &q1, &q2](int first, int last, mkfit::DeadVec& dv) {
+            auto const firstPoint = surf.toGlobal(topo.localPosition(first * sistrip::STRIPS_PER_APV));
+            auto const lastPoint = surf.toGlobal(topo.localPosition((last + 1) * sistrip::STRIPS_PER_APV));
+            float phi1 = firstPoint.phi();
+            float phi2 = lastPoint.phi();
+            if (reco::deltaPhi(phi1, phi2) > 0)
+              std::swap(phi1, phi2);
+            LogTrace("SiStripBadComponents")<<"insert bad range "<<first<<" to "<<last<<" "<<phi1<<" "<<phi2;
+            dv.push_back({phi1, phi2, q1, q2});
+          };
+
+          const int nApvs = topo.nstrips() / sistrip::STRIPS_PER_APV;
+          for (int apv = 0; apv < nApvs; ++apv) {
+            const bool isBad = bs.BadApvs & (1 << apv);
+            if (isBad) {
+              LogTrace("SiStripBadComponents")<<"bad apv "<<apv<<" on "<<bs.detid;
+              if (lastApv == -1) {
+                firstApv = apv;
+                lastApv = apv;
+              } else if (lastApv + 1 == apv)
+                lastApv++;
+
+              if (apv + 1 == nApvs)
+                addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
+            } else if (firstApv != -1) {
+              addRangeAPV(firstApv, lastApv, deadvectors[ilay]);
+              //and reset
+              firstApv = -1;
+              lastApv = -1;
+            }
+          }
+        }//for (const auto& bs : badStrips)
+      }
+    }
+
     //dump content for deadmodules.h in standalone setup
     //    int ilay = -1;
     //    for (auto const& dv : deadvectors) {
@@ -144,7 +174,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
     //                  << dr.phi1 << "," << dr.phi2 << "," << dr.q1 << "," << dr.q2 << "});" << std::endl;
     //    }
     mkfit::StdSeq::LoadDeads(*eventOfHits, deadvectors);
-  }
+  }//if (usePixelQualityDB_ || useStripStripQualityDB_)
 
   fill(iEvent.get(pixelClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);
   fill(iEvent.get(stripClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);


### PR DESCRIPTION
dead pixel modules are used to fill deadvectors.
The feature is enabled by default.

- In the 2021 setup in 11_3_X (SiPixelQuality_phase1_Run3Beginning) there are 56 modules with bad ROCs, of these 18 are fully bad, which is still 73% of the bad ROCs. 
    - compare this with around 1840 modules with hits ==> around 1% of modules is covered by this PR
- in the 2024 setup (SiPixelQuality_phase1_Run3Endof4years) there are 92 modules with bad ROCs and the difference is in the fully bad modules (54). So, for this setup this PR will cover 89% of the bad ROCs.

Validation is available in http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit-pr351-dead-pix-modules_m7944010_c9b3bccd  (made with `mkfit=all` option in our 11_2_X setup) and compares with the dev as of trackreco/mkFit#351
It's a bit hard to pick up a clear large difference in the validation plots in the 2021 setup

The following plots are from the pixelLess iteration:
in  built tracks around 1% more tracks have 0 missing hits
<img width="404" alt="image" src="https://user-images.githubusercontent.com/4676718/132074014-23bb4f8f-6ea5-42cb-b58b-83f1ce05da46.png">
there is some small increase in the number of pixel hits
<img width="824" alt="image" src="https://user-images.githubusercontent.com/4676718/132074168-42d1fa7c-6fc1-46de-a52b-a61227bd2f63.png">
The impact on the highPurity is even better (3% more tracks with 0 missing)
<img width="571" alt="image" src="https://user-images.githubusercontent.com/4676718/132074331-60556088-0102-4ce8-b438-fc905efd503e.png">
The HP eff and fakes look OK
<img width="876" alt="image" src="https://user-images.githubusercontent.com/4676718/132074465-23a8ad73-dcf5-412e-900f-ae1efb64ee26.png">


@mmasciov or @leonardogiannini please run on 2024 setup

