### PR TITLE
set beamSpot in mkFit eventOfHits

### DIFF
--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
   <use name="CalibTracker/Records"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/SiPixelObjects"/>
+  <use name="DataFormats/BeamSpot"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/SiStripCluster"/>
   <use name="DataFormats/SiStripCommon"/>

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -10,6 +10,7 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h"
 #include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
@@ -42,6 +43,7 @@ private:
             mkfit::EventOfHits& eventOfHits,
             const MkFitGeometry& mkFitGeom) const;
 
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   const edm::EDGetTokenT<MkFitHitWrapper> pixelHitsToken_;
   const edm::EDGetTokenT<MkFitHitWrapper> stripHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -56,7 +58,8 @@ private:
 };
 
 MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iConfig)
-    : pixelHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
+    : beamSpotToken_{consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))},
+      pixelHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
       stripHitsToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
       pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelHits"))},
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripHits"))},
@@ -77,6 +80,7 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
 void MkFitEventOfHitsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
+  desc.add("beamSpot", edm::InputTag{"offlineBeamSpot"});
   desc.add("pixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("stripHits", edm::InputTag{"mkFitSiStripHits"});
   desc.add("usePixelQualityDB", true)->setComment("Use SiPixelQuality DB information");
@@ -180,6 +184,16 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
   fill(iEvent.get(stripClusterIndexToHitToken_).hits(), *eventOfHits, mkFitGeom);
 
   mkfit::StdSeq::Cmssw_LoadHits_End(*eventOfHits);
+
+  auto const bs = iEvent.get(beamSpotToken_);
+  eventOfHits->SetBeamSpot({.x = float(bs.x0()),
+                            .y = float(bs.y0()),
+                            .z = float(bs.z0()),
+                            .sigmaZ = float(bs.sigmaZ()),
+                            .beamWidthX = float(bs.BeamWidthX()),
+                            .beamWidthY = float(bs.BeamWidthY()),
+                            .dxdz = float(bs.dxdz()),
+                            .dydz = float(bs.dydz())});
 
   iEvent.emplace(putToken_, std::move(eventOfHits));
 }


### PR DESCRIPTION
tested with `reco_cfg.py sample=10muvlowpt mkfit="DetachedTripletStep" maxEvents=10 nthreads=1`
and a debug cout in `quality_filter_layers`
```C++
void quality_filter_layers(TrackVec & tracks, const BeamSpot &bspot)
{
  std::cout<<"quality_filter_layers "<<bspot.x<<" "<<bspot.y<<std::endl;
```

```
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 07-Oct-2021 13:36:18.067 PDT
quality_filter_layers 0.0107569 0.0417208
```

