### PR TITLE
Correct transition-region pickup-layer for tobtec iteration.

### DIFF
--- a/RecoTracker/MkFit/data/mkfit-phase1-tobTecStep.json
+++ b/RecoTracker/MkFit/data/mkfit-phase1-tobTecStep.json
@@ -299,7 +299,7 @@
     }
    ],
    "m_region": 1,
-   "m_fwd_search_pickup": 27,
+   "m_fwd_search_pickup": 22,
    "m_bkw_fit_last": 19,
    "m_bkw_search_pickup": 39
   },
@@ -504,7 +504,7 @@
     }
    ],
    "m_region": 3,
-   "m_fwd_search_pickup": 27,
+   "m_fwd_search_pickup": 22,
    "m_bkw_fit_last": 19,
    "m_bkw_search_pickup": 39
   },


### PR DESCRIPTION
MTV vs. CKF and PR-369: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/tobtec-tr-fix.vs.CKF
MTV with PR-369 as ref: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/tobtec-tr-fix.vs.PR-369
