### PR TITLE
When seed hit is a matched hit, process both mono/stereo hits.

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -113,7 +113,7 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
     SVector3 mom(gmom.x(), gmom.y(), gmom.z());
 
     const auto& cov = tsos.curvilinearError().matrix();
-    SMatrixSym66 err; //fill a sub-matrix, mkfit::TrackState will convert internally
+    SMatrixSym66 err;  //fill a sub-matrix, mkfit::TrackState will convert internally
     for (int i = 0; i < 5; ++i) {
       for (int j = i; j < 5; ++j) {
         err.At(i, j) = cov[i][j];
@@ -130,8 +130,8 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
       if (not trackerHitRTTI::isFromDet(recHit)) {
         throw cms::Exception("Assert") << "Encountered a seed with a hit which is not trackerHitRTTI::isFromDet()";
       }
-      auto &baseTrkRecHit = static_cast<const BaseTrackerRecHit&>(recHit);
-      if ( ! baseTrkRecHit.isMatched()) {
+      auto& baseTrkRecHit = static_cast<const BaseTrackerRecHit&>(recHit);
+      if (!baseTrkRecHit.isMatched()) {
         const auto& clusterRef = baseTrkRecHit.firstClusterRef();
         const auto detId = recHit.geographicalId();
         const auto ilay = mkFitGeom.layerNumberConverter().convertLayerNumber(
@@ -140,17 +140,16 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
                                        << " ilay " << ilay;
         ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
       } else {
-        auto &matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
-        OmniClusterRef clRefs[2] = { matched2D.monoClusterRef(), matched2D.stereoClusterRef() };
-        DetId          detIds[2] = { matched2D.monoId(),         matched2D.stereoId() };
+        auto& matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
+        const OmniClusterRef* const clRefs[2] = {&matched2D.monoClusterRef(), &matched2D.stereoClusterRef()};
+        const DetId detIds[2] = {matched2D.monoId(), matched2D.stereoId()};
         for (int ii = 0; ii < 2; ++ii) {
-          const auto& clusterRef = clRefs[ii];
           const auto& detId = detIds[ii];
           const auto ilay = mkFitGeom.layerNumberConverter().convertLayerNumber(
               detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
-          LogTrace("MkFitSeedConverter") << " adding matched hit detid " << detId.rawId() << " index " << clusterRef.index()
-                                         << " ilay " << ilay;
-          ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
+          LogTrace("MkFitSeedConverter") << " adding matched hit detid " << detId.rawId() << " index "
+                                         << clRefs[ii]->index() << " ilay " << ilay;
+          ret.back().addHitIdx(clRefs[ii]->index(), ilay, 0);  // per-hit chi2 is not known
         }
       }
     }

--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -8,6 +8,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 #include "DataFormats/TrackerRecHit2D/interface/trackerHitRTTI.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
@@ -129,13 +130,29 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
       if (not trackerHitRTTI::isFromDet(recHit)) {
         throw cms::Exception("Assert") << "Encountered a seed with a hit which is not trackerHitRTTI::isFromDet()";
       }
-      const auto& clusterRef = static_cast<const BaseTrackerRecHit&>(recHit).firstClusterRef();
-      const auto detId = recHit.geographicalId();
-      const auto ilay = mkFitGeom.layerNumberConverter().convertLayerNumber(
-          detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
-      LogTrace("MkFitSeedConverter") << " addin hit detid " << detId.rawId() << " index " << clusterRef.index()
-                                     << " ilay " << ilay;
-      ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
+      auto &baseTrkRecHit = static_cast<const BaseTrackerRecHit&>(recHit);
+      if ( ! baseTrkRecHit.isMatched()) {
+        const auto& clusterRef = baseTrkRecHit.firstClusterRef();
+        const auto detId = recHit.geographicalId();
+        const auto ilay = mkFitGeom.layerNumberConverter().convertLayerNumber(
+            detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
+        LogTrace("MkFitSeedConverter") << " adding hit detid " << detId.rawId() << " index " << clusterRef.index()
+                                       << " ilay " << ilay;
+        ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
+      } else {
+        auto &matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
+        OmniClusterRef clRefs[2] = { matched2D.monoClusterRef(), matched2D.stereoClusterRef() };
+        DetId          detIds[2] = { matched2D.monoId(),         matched2D.stereoId() };
+        for (int ii = 0; ii < 2; ++ii) {
+          const auto& clusterRef = clRefs[ii];
+          const auto& detId = detIds[ii];
+          const auto ilay = mkFitGeom.layerNumberConverter().convertLayerNumber(
+              detId.subdetId(), ttopo.layer(detId), false, ttopo.isStereo(detId), isPlusSide(detId));
+          LogTrace("MkFitSeedConverter") << " adding matched hit detid " << detId.rawId() << " index " << clusterRef.index()
+                                         << " ilay " << ilay;
+          ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
+        }
+      }
     }
     ++seed_index;
   }


### PR DESCRIPTION
MTV plots are on top #59!

MTV vs. CKF and PR-369: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/tobtec-tr-fix-2.vs.CKF
MTV with PR-369 as ref: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/tobtec-tr-fix-2.vs.PR-369

1. The if can be rewritten so both cases fill the custer/detid arrays ... this removes code duplication.
2. Is dynamic_cast needed for getting SiStripMatchedRecHit2D? The branch is in this repo so it can be edited in place by whomever knows what is the correct cast incantation.