### PR TITLE
Seed partition function with TID detection

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -14,10 +14,10 @@
 namespace {
   using namespace mkfit;
 
-  void partitionSeeds0(const TrackerInfo &trk_info,
-                       const TrackVec &in_seeds,
-                       const EventOfHits &eoh,
-                       IterationSeedPartition &part) {
+  [[maybe_unused]] void partitionSeeds0(const TrackerInfo &trk_info,
+                                        const TrackVec &in_seeds,
+                                        const EventOfHits &eoh,
+                                        IterationSeedPartition &part) {
     // Seeds are placed into eta regions and sorted on region + eta.
 
     const size_t size = in_seeds.size();
@@ -106,10 +106,10 @@ namespace {
     }
   }
 
-  void partitionSeeds1(const TrackerInfo &trk_info,
-                       const TrackVec &in_seeds,
-                       const EventOfHits &eoh,
-                       IterationSeedPartition &part) {
+  [[maybe_unused]] void partitionSeeds1(const TrackerInfo &trk_info,
+                                        const TrackVec &in_seeds,
+                                        const EventOfHits &eoh,
+                                        IterationSeedPartition &part) {
     // Seeds are placed into eta regions and sorted on region + eta.
 
     const LayerInfo &tib1 = trk_info.m_layers[4];
@@ -241,9 +241,6 @@ void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescript
 
 std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
     const TrackerRecoGeometryRecord &iRecord) {
-  // Avoid unused variable warnings.
-  (void)partitionSeeds0;
-  (void)partitionSeeds1;
   auto it_conf = mkfit::ConfigJson_Load_File(configFile_);
   it_conf->m_partition_seeds = partitionSeeds1;
   return it_conf;


### PR DESCRIPTION
In seed partition function also check if the track is hitting TID. In the original one only TEC was checked to determine tansition region versus barrel determination. This puts more tracks into the transition region and should help with:
a) low pT tracks;
b) displaced tracks;
c) poorly defined seeds.
However, proper tuning and scoring needs to be applied.

With current tuning of windows, scoring, and filters/cleaners things get better for initialStep, highPtTriplet, pixelLess and tobTec (a bit less so) and get worse for detachedQuadruplet/Triplet below .5 GeV and better above 5 GeV. It's trivial to use the old partition function for these two iterations before we figure out the correct tuning for them.

MTV vs. CKF: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/seed_part_tid-std
MTV vs. PR-369: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/seed_part_tid.vs.PR-369

There is further provision in the code to extend the transition-region determination margin that should, in principle, help with low-pT tracks and poor quality seeds. However, this seems to do more harm with the current tuning. Perhaps something to revisit in the future, along with pT dependence of these checks.

These are MTV plots for extra margins of 5 cm for TID and 10 cm TEC (commented out in the code):
vs. CKF: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/seed_part_tid_ext-std
vs. PR-369: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/seed_part_tid_ext.vs.PR-369
