### PR TITLE
code-checks/code-format for mkFit-reincarnated

### DIFF
--- a/RecoTracker/MkFitCMS/src/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/src/buildtestMPlex.cc
@@ -21,7 +21,7 @@ namespace mkfit {
     IterationMaskIfcCmssw(const TrackerInfo &ti, const std::vector<const std::vector<bool> *> &maskvec)
         : m_trk_info(ti), m_mask_vector(maskvec) {}
 
-    const std::vector<bool> *get_mask_for_layer(int layer) const {
+    const std::vector<bool> *get_mask_for_layer(int layer) const override {
       return m_trk_info.m_layers[layer].is_pix_lyr() ? m_mask_vector[0] : m_mask_vector[1];
     }
   };

--- a/RecoTracker/MkFitCore/src/Ice/IceRevisitedRadix.cc
+++ b/RecoTracker/MkFitCore/src/Ice/IceRevisitedRadix.cc
@@ -186,7 +186,7 @@ To do:
  *	Constructor.
  */
 //----------------------------------------------------------------------
-RadixSort::RadixSort() : mCurrentSize(0), mRanks(0), mRanks2(0), mTotalCalls(0), mNbHits(0) {
+RadixSort::RadixSort() : mCurrentSize(0), mRanks(nullptr), mRanks2(nullptr), mTotalCalls(0), mNbHits(0) {
 #ifndef RADIX_LOCAL_RAM
   // Allocate input-independent ram
   mHistogram = new udword[256 * 4];
@@ -219,7 +219,7 @@ RadixSort::~RadixSort() {
 //----------------------------------------------------------------------
 udword* RadixSort::RelinquishRanks() {
   udword* ranks = mRanks;
-  mRanks = 0;
+  mRanks = nullptr;
   DELETEARRAY(mRanks2);
   mCurrentSize = 0;
   return ranks;

--- a/RecoTracker/MkFitCore/src/IterationConfig.cc
+++ b/RecoTracker/MkFitCore/src/IterationConfig.cc
@@ -363,7 +363,7 @@ namespace mkfit {
 
   namespace {
     // Open file for writing, throw exception on failure.
-    void open_ofstream(std::ofstream &ofs, const std::string &fname, const char *pfx = 0) {
+    void open_ofstream(std::ofstream &ofs, const std::string &fname, const char *pfx = nullptr) {
       ofs.open(fname, std::ofstream::trunc);
       if (!ofs) {
         char m[2048];
@@ -373,7 +373,7 @@ namespace mkfit {
     }
 
     // Open file for reading, throw exception on failure.
-    void open_ifstream(std::ifstream &ifs, const std::string &fname, const char *pfx = 0) {
+    void open_ifstream(std::ifstream &ifs, const std::string &fname, const char *pfx = nullptr) {
       ifs.open(fname);
       if (!ifs) {
         char m[2048];

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.icc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.icc
@@ -3,82 +3,77 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfLH, typename TfQF1, typename TfQF2, typename TfLL>
-static inline void KHMult_imp(const TfLH& a, const TfQF1& b00, const TfQF2&  b01, TfLL& c,
-                              const int nmin, const int nmax)
-{
+static inline void KHMult_imp(
+    const TfLH& a, const TfQF1& b00, const TfQF2& b01, TfLL& c, const int nmin, const int nmax) {
 #pragma omp simd
-   for (int n = nmin; n < nmax; ++n)
-   {
-      c(n, 0,  0) = a(n, 0,  0)*b00(n, 0, 0);
-      c(n, 0,  1) = a(n, 0,  0)*b01(n, 0, 0);
-      c(n, 0,  2) = a(n, 0,  1);
-      c(n, 0,  3) = 0;
-      c(n, 0,  4) = 0;
-      c(n, 0,  5) = 0;
-      c(n, 0,  6) = a(n, 0,  3)*b00(n, 0, 0);
-      c(n, 0,  7) = a(n, 0,  3)*b01(n, 0, 0);
-      c(n, 0,  8) = a(n, 0,  4);
-      c(n, 0,  9) = 0;
-      c(n, 0, 10) = 0;
-      c(n, 0, 11) = 0;
-      c(n, 0, 12) = a(n, 0,  6)*b00(n, 0, 0);
-      c(n, 0, 13) = a(n, 0,  6)*b01(n, 0, 0);
-      c(n, 0, 14) = a(n, 0,  7);
-      c(n, 0, 15) = 0;
-      c(n, 0, 16) = 0;
-      c(n, 0, 17) = 0;
-      c(n, 0, 18) = a(n, 0,  9)*b00(n, 0, 0);
-      c(n, 0, 19) = a(n, 0,  9)*b01(n, 0, 0);
-      c(n, 0, 20) = a(n, 0, 10);
-      c(n, 0, 21) = 0;
-      c(n, 0, 22) = 0;
-      c(n, 0, 23) = 0;
-      c(n, 0, 24) = a(n, 0, 12)*b00(n, 0, 0);
-      c(n, 0, 25) = a(n, 0, 12)*b01(n, 0, 0);
-      c(n, 0, 26) = a(n, 0, 13);
-      c(n, 0, 27) = 0;
-      c(n, 0, 28) = 0;
-      c(n, 0, 29) = 0;
-      c(n, 0, 30) = a(n, 0, 15)*b00(n, 0, 0);
-      c(n, 0, 31) = a(n, 0, 15)*b01(n, 0, 0);
-      c(n, 0, 32) = a(n, 0, 16);
-      c(n, 0, 33) = 0;
-      c(n, 0, 34) = 0;
-      c(n, 0, 35) = 0;
-   }
+  for (int n = nmin; n < nmax; ++n) {
+    c(n, 0, 0) = a(n, 0, 0) * b00(n, 0, 0);
+    c(n, 0, 1) = a(n, 0, 0) * b01(n, 0, 0);
+    c(n, 0, 2) = a(n, 0, 1);
+    c(n, 0, 3) = 0;
+    c(n, 0, 4) = 0;
+    c(n, 0, 5) = 0;
+    c(n, 0, 6) = a(n, 0, 3) * b00(n, 0, 0);
+    c(n, 0, 7) = a(n, 0, 3) * b01(n, 0, 0);
+    c(n, 0, 8) = a(n, 0, 4);
+    c(n, 0, 9) = 0;
+    c(n, 0, 10) = 0;
+    c(n, 0, 11) = 0;
+    c(n, 0, 12) = a(n, 0, 6) * b00(n, 0, 0);
+    c(n, 0, 13) = a(n, 0, 6) * b01(n, 0, 0);
+    c(n, 0, 14) = a(n, 0, 7);
+    c(n, 0, 15) = 0;
+    c(n, 0, 16) = 0;
+    c(n, 0, 17) = 0;
+    c(n, 0, 18) = a(n, 0, 9) * b00(n, 0, 0);
+    c(n, 0, 19) = a(n, 0, 9) * b01(n, 0, 0);
+    c(n, 0, 20) = a(n, 0, 10);
+    c(n, 0, 21) = 0;
+    c(n, 0, 22) = 0;
+    c(n, 0, 23) = 0;
+    c(n, 0, 24) = a(n, 0, 12) * b00(n, 0, 0);
+    c(n, 0, 25) = a(n, 0, 12) * b01(n, 0, 0);
+    c(n, 0, 26) = a(n, 0, 13);
+    c(n, 0, 27) = 0;
+    c(n, 0, 28) = 0;
+    c(n, 0, 29) = 0;
+    c(n, 0, 30) = a(n, 0, 15) * b00(n, 0, 0);
+    c(n, 0, 31) = a(n, 0, 15) * b01(n, 0, 0);
+    c(n, 0, 32) = a(n, 0, 16);
+    c(n, 0, 33) = 0;
+    c(n, 0, 34) = 0;
+    c(n, 0, 35) = 0;
+  }
 }
-  
+
 ///////////////////////////////////////////////////////////////////////////////
 /// ConvertToCCS_imp
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfLV1, typename TfLV2, typename TfLL>
-static inline void ConvertToCCS_imp(const TfLV1& a, TfLV2& b, TfLL& c,
-                                    const int nmin, const int nmax)
-{
+static inline void ConvertToCCS_imp(const TfLV1& a, TfLV2& b, TfLL& c, const int nmin, const int nmax) {
 #pragma omp simd
-  for (int n = nmin; n < nmax; ++n)
-  {
-    const float pt = getHypot(a(n, 0,  3), a(n, 0,  4));
-    const float p2 = pt*pt + a(n, 0,  5)*a(n, 0,  5);
+  for (int n = nmin; n < nmax; ++n) {
+    const float pt = getHypot(a(n, 0, 3), a(n, 0, 4));
+    const float p2 = pt * pt + a(n, 0, 5) * a(n, 0, 5);
     //
-    b(n, 0,  0) = a(n, 0,  0);
-    b(n, 0,  1) = a(n, 0,  1);
-    b(n, 0,  2) = a(n, 0,  2);
-    b(n, 0,  3) = 1.0f/pt;
-    b(n, 0,  4) = getPhi(a(n, 0,  3), a(n, 0,  4)); //fixme: use trig approx
-    b(n, 0,  5) = getTheta(pt, a(n, 0,  5));
+    b(n, 0, 0) = a(n, 0, 0);
+    b(n, 0, 1) = a(n, 0, 1);
+    b(n, 0, 2) = a(n, 0, 2);
+    b(n, 0, 3) = 1.0f / pt;
+    b(n, 0, 4) = getPhi(a(n, 0, 3), a(n, 0, 4));  //fixme: use trig approx
+    b(n, 0, 5) = getTheta(pt, a(n, 0, 5));
     //
-    c(n, 0,  0) = 1.;
-    c(n, 0,  1) = 0.;
-    c(n, 0,  2) = 0.;
-    c(n, 0,  3) = 0.;
-    c(n, 0,  4) = 0.;
-    c(n, 0,  5) = 0.;
-    c(n, 0,  6) = 0.;
-    c(n, 0,  7) = 1.;
-    c(n, 0,  8) = 0.;
-    c(n, 0,  9) = 0.;
+    c(n, 0, 0) = 1.;
+    c(n, 0, 1) = 0.;
+    c(n, 0, 2) = 0.;
+    c(n, 0, 3) = 0.;
+    c(n, 0, 4) = 0.;
+    c(n, 0, 5) = 0.;
+    c(n, 0, 6) = 0.;
+    c(n, 0, 7) = 1.;
+    c(n, 0, 8) = 0.;
+    c(n, 0, 9) = 0.;
     c(n, 0, 10) = 0.;
     c(n, 0, 11) = 0.;
     c(n, 0, 12) = 0.;
@@ -90,21 +85,21 @@ static inline void ConvertToCCS_imp(const TfLV1& a, TfLV2& b, TfLL& c,
     c(n, 0, 18) = 0.;
     c(n, 0, 19) = 0.;
     c(n, 0, 20) = 0.;
-    c(n, 0, 21) = -a(n, 0,  3)/(pt*pt*pt);
-    c(n, 0, 22) = -a(n, 0,  4)/(pt*pt*pt);
+    c(n, 0, 21) = -a(n, 0, 3) / (pt * pt * pt);
+    c(n, 0, 22) = -a(n, 0, 4) / (pt * pt * pt);
     c(n, 0, 23) = 0.;
     c(n, 0, 24) = 0.;
     c(n, 0, 25) = 0.;
     c(n, 0, 26) = 0.;
-    c(n, 0, 27) = -a(n, 0,  4)/(pt*pt);
-    c(n, 0, 28) =  a(n, 0,  3)/(pt*pt);
+    c(n, 0, 27) = -a(n, 0, 4) / (pt * pt);
+    c(n, 0, 28) = a(n, 0, 3) / (pt * pt);
     c(n, 0, 29) = 0.;
     c(n, 0, 30) = 0.;
     c(n, 0, 31) = 0.;
     c(n, 0, 32) = 0.;
-    c(n, 0, 33) =  a(n, 0,  3)*a(n, 0,  5)/(pt*p2);
-    c(n, 0, 34) =  a(n, 0,  4)*a(n, 0,  5)/(pt*p2);
-    c(n, 0, 35) = -pt/p2;
+    c(n, 0, 33) = a(n, 0, 3) * a(n, 0, 5) / (pt * p2);
+    c(n, 0, 34) = a(n, 0, 4) * a(n, 0, 5) / (pt * p2);
+    c(n, 0, 35) = -pt / p2;
   }
 }
 
@@ -113,34 +108,31 @@ static inline void ConvertToCCS_imp(const TfLV1& a, TfLV2& b, TfLL& c,
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfLV1, typename TfLV2, typename TfLL>
-static inline void ConvertToCartesian_imp(const TfLV1& a, TfLV2& b, TfLL& c,
-                                          const int nmin, const int nmax)
-{
+static inline void ConvertToCartesian_imp(const TfLV1& a, TfLV2& b, TfLL& c, const int nmin, const int nmax) {
 #pragma omp simd
-  for (int n = nmin; n < nmax; ++n)
-  {
-    const float cosP = std::cos(a(n, 0,  4)); //fixme: use trig approx
-    const float sinP = std::sin(a(n, 0,  4));
-    const float cosT = std::cos(a(n, 0,  5));
-    const float sinT = std::sin(a(n, 0,  5));
+  for (int n = nmin; n < nmax; ++n) {
+    const float cosP = std::cos(a(n, 0, 4));  //fixme: use trig approx
+    const float sinP = std::sin(a(n, 0, 4));
+    const float cosT = std::cos(a(n, 0, 5));
+    const float sinT = std::sin(a(n, 0, 5));
     //
-    b(n, 0,  0) = a(n, 0,  0);
-    b(n, 0,  1) = a(n, 0,  1);
-    b(n, 0,  2) = a(n, 0,  2);
-    b(n, 0,  3) = cosP/a(n, 0,  3);
-    b(n, 0,  4) = sinP/a(n, 0,  3);
-    b(n, 0,  5) = cosT/(sinT*a(n, 0,  3));
+    b(n, 0, 0) = a(n, 0, 0);
+    b(n, 0, 1) = a(n, 0, 1);
+    b(n, 0, 2) = a(n, 0, 2);
+    b(n, 0, 3) = cosP / a(n, 0, 3);
+    b(n, 0, 4) = sinP / a(n, 0, 3);
+    b(n, 0, 5) = cosT / (sinT * a(n, 0, 3));
     //
-    c(n, 0,  0) = 1.;
-    c(n, 0,  1) = 0.;
-    c(n, 0,  2) = 0.;
-    c(n, 0,  3) = 0.;
-    c(n, 0,  4) = 0.;
-    c(n, 0,  5) = 0.;
-    c(n, 0,  6) = 0.;
-    c(n, 0,  7) = 1.;
-    c(n, 0,  8) = 0.;
-    c(n, 0,  9) = 0.;
+    c(n, 0, 0) = 1.;
+    c(n, 0, 1) = 0.;
+    c(n, 0, 2) = 0.;
+    c(n, 0, 3) = 0.;
+    c(n, 0, 4) = 0.;
+    c(n, 0, 5) = 0.;
+    c(n, 0, 6) = 0.;
+    c(n, 0, 7) = 1.;
+    c(n, 0, 8) = 0.;
+    c(n, 0, 9) = 0.;
     c(n, 0, 10) = 0.;
     c(n, 0, 11) = 0.;
     c(n, 0, 12) = 0.;
@@ -152,43 +144,40 @@ static inline void ConvertToCartesian_imp(const TfLV1& a, TfLV2& b, TfLL& c,
     c(n, 0, 18) = 0.;
     c(n, 0, 19) = 0.;
     c(n, 0, 20) = 0.;
-    c(n, 0, 21) = -cosP/(a(n, 0,  3)*a(n, 0,  3));
-    c(n, 0, 22) = -sinP/a(n, 0,  3);
+    c(n, 0, 21) = -cosP / (a(n, 0, 3) * a(n, 0, 3));
+    c(n, 0, 22) = -sinP / a(n, 0, 3);
     c(n, 0, 23) = 0.;
     c(n, 0, 24) = 0.;
     c(n, 0, 25) = 0.;
     c(n, 0, 26) = 0.;
-    c(n, 0, 27) = -sinP/(a(n, 0,  3)*a(n, 0,  3));
-    c(n, 0, 28) =  cosP/a(n, 0,  3);
+    c(n, 0, 27) = -sinP / (a(n, 0, 3) * a(n, 0, 3));
+    c(n, 0, 28) = cosP / a(n, 0, 3);
     c(n, 0, 29) = 0.;
     c(n, 0, 30) = 0.;
     c(n, 0, 31) = 0.;
     c(n, 0, 32) = 0.;
-    c(n, 0, 33) = -cosT/(sinT*a(n, 0,  3)*a(n, 0,  3));
+    c(n, 0, 33) = -cosT / (sinT * a(n, 0, 3) * a(n, 0, 3));
     c(n, 0, 34) = 0.;
-    c(n, 0, 35) = -1.0f/(sinT*sinT*a(n, 0,  3));
+    c(n, 0, 35) = -1.0f / (sinT * sinT * a(n, 0, 3));
   }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// MultResidualsAdd_imp 
+/// MultResidualsAdd_imp
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfLH, typename TfLV1, typename Tf2V, typename TfLV2>
-static inline void MultResidualsAdd_imp(const TfLH& a, const TfLV1& b,
-                                       const Tf2V& c, TfLV2& d,
-                                       const int nmin, const int nmax)
-{
+static inline void MultResidualsAdd_imp(
+    const TfLH& a, const TfLV1& b, const Tf2V& c, TfLV2& d, const int nmin, const int nmax) {
 #pragma omp simd
-   for (int n = nmin; n < nmax; ++n)
-   {
-      d(n, 0, 0) = b(n, 0, 0) + a(n, 0,  0) * c(n, 0, 0) + a(n, 0,  1) * c(n, 0, 1);
-      d(n, 0, 1) = b(n, 0, 1) + a(n, 0,  3) * c(n, 0, 0) + a(n, 0,  4) * c(n, 0, 1);
-      d(n, 0, 2) = b(n, 0, 2) + a(n, 0,  6) * c(n, 0, 0) + a(n, 0,  7) * c(n, 0, 1);
-      d(n, 0, 3) = b(n, 0, 3) + a(n, 0,  9) * c(n, 0, 0) + a(n, 0, 10) * c(n, 0, 1);
-      d(n, 0, 4) = b(n, 0, 4) + a(n, 0, 12) * c(n, 0, 0) + a(n, 0, 13) * c(n, 0, 1);
-      d(n, 0, 5) = b(n, 0, 5) + a(n, 0, 15) * c(n, 0, 0) + a(n, 0, 16) * c(n, 0, 1);
-   }
+  for (int n = nmin; n < nmax; ++n) {
+    d(n, 0, 0) = b(n, 0, 0) + a(n, 0, 0) * c(n, 0, 0) + a(n, 0, 1) * c(n, 0, 1);
+    d(n, 0, 1) = b(n, 0, 1) + a(n, 0, 3) * c(n, 0, 0) + a(n, 0, 4) * c(n, 0, 1);
+    d(n, 0, 2) = b(n, 0, 2) + a(n, 0, 6) * c(n, 0, 0) + a(n, 0, 7) * c(n, 0, 1);
+    d(n, 0, 3) = b(n, 0, 3) + a(n, 0, 9) * c(n, 0, 0) + a(n, 0, 10) * c(n, 0, 1);
+    d(n, 0, 4) = b(n, 0, 4) + a(n, 0, 12) * c(n, 0, 0) + a(n, 0, 13) * c(n, 0, 1);
+    d(n, 0, 5) = b(n, 0, 5) + a(n, 0, 15) * c(n, 0, 0) + a(n, 0, 16) * c(n, 0, 1);
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -196,10 +185,8 @@ static inline void MultResidualsAdd_imp(const TfLH& a, const TfLV1& b,
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfLS, typename TfHS1, typename TfHS2>
-static inline void AddIntoUpperLeft3x3_imp(const TfLS& A, const TfHS1& B, TfHS2& C,
-                                           const int aN, const int bN, const int cN,
-                                           const int nmin, const int nmax)
-{
+static inline void AddIntoUpperLeft3x3_imp(
+    const TfLS& A, const TfHS1& B, TfHS2& C, const int aN, const int bN, const int cN, const int nmin, const int nmax) {
   // Problem here: (n, i, j) uses indirection -> slow on the GPU
 }
 
@@ -208,13 +195,11 @@ static inline void AddIntoUpperLeft3x3_imp(const TfLS& A, const TfHS1& B, TfHS2&
 ///////////////////////////////////////////////////////////////////////////////
 
 template <typename TfQF1, typename TfQF2, typename TfHV, typename Tf2V>
-static inline void RotateResidulsOnTangentPlane_impl(const TfQF1& r00,
-    const TfQF2& r01, const TfHV& a, Tf2V& b, const int nmin, const int nmax)
-{
+static inline void RotateResidulsOnTangentPlane_impl(
+    const TfQF1& r00, const TfQF2& r01, const TfHV& a, Tf2V& b, const int nmin, const int nmax) {
 #pragma omp simd
-   for (int n = nmin; n < nmax; ++n)
-   {
-      b(n, 0, 0) =  r00(n, 0, 0)*a(n, 0, 0) + r01(n, 0, 0)*a(n, 0, 1);
-      b(n, 0, 1) =  a(n, 0, 2);
-   }
+  for (int n = nmin; n < nmax; ++n) {
+    b(n, 0, 0) = r00(n, 0, 0) * a(n, 0, 0) + r01(n, 0, 0) * a(n, 0, 1);
+    b(n, 0, 1) = a(n, 0, 2);
+  }
 }

--- a/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
@@ -368,14 +368,14 @@ namespace Matriplex {
 
   template <typename T, idx_t D, idx_t N>
   struct CramerInverter {
-    static void Invert(MPlex<T, D, D, N>& A, double* determ = 0) {
+    static void Invert(MPlex<T, D, D, N>& A, double* determ = nullptr) {
       throw std::runtime_error("general cramer inversion not supported");
     }
   };
 
   template <typename T, idx_t N>
   struct CramerInverter<T, 2, N> {
-    static void Invert(MPlex<T, 2, 2, N>& A, double* determ = 0) {
+    static void Invert(MPlex<T, 2, 2, N>& A, double* determ = nullptr) {
       typedef T TT;
 
       T* a = A.fArray;
@@ -401,7 +401,7 @@ namespace Matriplex {
 
   template <typename T, idx_t N>
   struct CramerInverter<T, 3, N> {
-    static void Invert(MPlex<T, 3, 3, N>& A, double* determ = 0) {
+    static void Invert(MPlex<T, 3, 3, N>& A, double* determ = nullptr) {
       typedef T TT;
 
       T* a = A.fArray;
@@ -440,7 +440,7 @@ namespace Matriplex {
   };
 
   template <typename T, idx_t D, idx_t N>
-  void InvertCramer(MPlex<T, D, D, N>& A, double* determ = 0) {
+  void InvertCramer(MPlex<T, D, D, N>& A, double* determ = nullptr) {
     // We don't do general Inverts.
 
     CramerInverter<T, D, N>::Invert(A, determ);

--- a/RecoTracker/MkFitCore/src/Matrix.h
+++ b/RecoTracker/MkFitCore/src/Matrix.h
@@ -27,7 +27,7 @@ namespace mkfit {
   inline double dtime() {
     double tseconds = 0.0;
     struct timeval mytime;
-    gettimeofday(&mytime, (struct timezone*)0);
+    gettimeofday(&mytime, (struct timezone*)nullptr);
     tseconds = (double)(mytime.tv_sec + mytime.tv_usec * 1.0e-6);
     return (tseconds);
   }

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -56,7 +56,7 @@ namespace mkfit {
 namespace {
   using namespace mkfit;
   auto retcand = [](CandCloner *cloner) { g_exe_ctx.m_cloners.ReturnToPool(cloner); };
-  auto retfitr = [](MkFitter *mkfttr) { g_exe_ctx.m_fitters.ReturnToPool(mkfttr); };
+  [[maybe_unused]] auto retfitr = [](MkFitter *mkfttr) { g_exe_ctx.m_fitters.ReturnToPool(mkfttr); };
   auto retfndr = [](MkFinder *mkfndr) { g_exe_ctx.m_finders.ReturnToPool(mkfndr); };
 
   // Range of indices processed within one iteration of a TBB parallel_for.
@@ -1745,7 +1745,7 @@ void MkBuilder::PrepareSeeds()
 
           // now fill out the output candidates
           for (int is = 0; is < n_seeds; ++is) {
-            if (tmp_cands[is].size() > 0) {
+            if (!tmp_cands[is].empty()) {
               eoccs[start_seed + is].clear();
 
               // Put good candidates into eoccs, process -2 candidates.

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -2,245 +2,290 @@
 /// helixAtRFromIterativeCCS_impl
 ///////////////////////////////////////////////////////////////////////////////
 
-template<typename Tf, typename Ti, typename TfLL1, typename Tf11, typename TfLLL>
-static inline void helixAtRFromIterativeCCS_impl(const    Tf& __restrict__ inPar,
-                                                 const    Ti& __restrict__ inChg,
-                                                 const  Tf11& __restrict__ msRad,
-                                                       TfLL1& __restrict__ outPar,
-                                                       TfLLL& __restrict__ errorProp,
-                                                          Ti& __restrict__ outFailFlag, // expected to be initialized to 0
-                                                 const int nmin, const int nmax,
+template <typename Tf, typename Ti, typename TfLL1, typename Tf11, typename TfLLL>
+static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
+                                                 const Ti& __restrict__ inChg,
+                                                 const Tf11& __restrict__ msRad,
+                                                 TfLL1& __restrict__ outPar,
+                                                 TfLLL& __restrict__ errorProp,
+                                                 Ti& __restrict__ outFailFlag,  // expected to be initialized to 0
+                                                 const int nmin,
+                                                 const int nmax,
                                                  const int N_proc,
-                                                 const PropagationFlags pf)
-{
+                                                 const PropagationFlags pf) {
   // bool debug = true;
 
 #pragma omp simd
-  for (int n = nmin; n < nmax; ++n)
-    {
-      //initialize erroProp to identity matrix
-      errorProp(n,0,0) = 1.f;
-      errorProp(n,1,1) = 1.f;
-      errorProp(n,2,2) = 1.f;
-      errorProp(n,3,3) = 1.f;
-      errorProp(n,4,4) = 1.f;
-      errorProp(n,5,5) = 1.f;
+  for (int n = nmin; n < nmax; ++n) {
+    //initialize erroProp to identity matrix
+    errorProp(n, 0, 0) = 1.f;
+    errorProp(n, 1, 1) = 1.f;
+    errorProp(n, 2, 2) = 1.f;
+    errorProp(n, 3, 3) = 1.f;
+    errorProp(n, 4, 4) = 1.f;
+    errorProp(n, 5, 5) = 1.f;
 
-      float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
-      const float k = inChg(n, 0, 0) * 100.f / (-Config::sol*(pf.use_param_b_field ? Config::BfieldFromZR(inPar(n,2,0),r0) : Config::Bfield));
-      const float r = msRad(n, 0, 0);
+    float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
+    const float k = inChg(n, 0, 0) * 100.f /
+                    (-Config::sol * (pf.use_param_b_field ? Config::BfieldFromZR(inPar(n, 2, 0), r0) : Config::Bfield));
+    const float r = msRad(n, 0, 0);
 
-      // if (std::abs(r-r0)<0.0001f) {
-      // 	dprint("distance less than 1mum, skip");
-      // 	continue;
-      // }
+    // if (std::abs(r-r0)<0.0001f) {
+    // 	dprint("distance less than 1mum, skip");
+    // 	continue;
+    // }
 
-      const float xin   = inPar(n, 0, 0);
-      const float yin   = inPar(n, 1, 0);
-      const float ipt   = inPar(n, 3, 0);
-      const float phiin = inPar(n, 4, 0);
-      const float theta = inPar(n, 5, 0);
+    const float xin = inPar(n, 0, 0);
+    const float yin = inPar(n, 1, 0);
+    const float ipt = inPar(n, 3, 0);
+    const float phiin = inPar(n, 4, 0);
+    const float theta = inPar(n, 5, 0);
 
-      dprint(std::endl);
-      dprint_np(n, "input parameters"
-            << " inPar(n, 0, 0)=" << std::setprecision(9) << inPar(n, 0, 0)
-            << " inPar(n, 1, 0)=" << std::setprecision(9) << inPar(n, 1, 0)
-            << " inPar(n, 2, 0)=" << std::setprecision(9) << inPar(n, 2, 0)
-            << " inPar(n, 3, 0)=" << std::setprecision(9) << inPar(n, 3, 0)
-            << " inPar(n, 4, 0)=" << std::setprecision(9) << inPar(n, 4, 0)
-            << " inPar(n, 5, 0)=" << std::setprecision(9) << inPar(n, 5, 0)
-            );
+    dprint(std::endl);
+    dprint_np(n,
+              "input parameters"
+                  << " inPar(n, 0, 0)=" << std::setprecision(9) << inPar(n, 0, 0) << " inPar(n, 1, 0)="
+                  << std::setprecision(9) << inPar(n, 1, 0) << " inPar(n, 2, 0)=" << std::setprecision(9)
+                  << inPar(n, 2, 0) << " inPar(n, 3, 0)=" << std::setprecision(9) << inPar(n, 3, 0)
+                  << " inPar(n, 4, 0)=" << std::setprecision(9) << inPar(n, 4, 0)
+                  << " inPar(n, 5, 0)=" << std::setprecision(9) << inPar(n, 5, 0));
 
-      const float kinv  = 1.f / k;
-      const float pt    = 1.f / ipt;
+    const float kinv = 1.f / k;
+    const float pt = 1.f / ipt;
 
-      float D = 0., cosa = 0., sina = 0., cosah = 0., sinah = 0., id = 0.;
-      //no trig approx here, phi can be large
-      float cosPorT = std::cos(phiin), sinPorT = std::sin(phiin);
-      float pxin = cosPorT*pt;
-      float pyin = sinPorT*pt;
+    float D = 0., cosa = 0., sina = 0., cosah = 0., sinah = 0., id = 0.;
+    //no trig approx here, phi can be large
+    float cosPorT = std::cos(phiin), sinPorT = std::sin(phiin);
+    float pxin = cosPorT * pt;
+    float pyin = sinPorT * pt;
 
-      dprint_np(n, "k=" << std::setprecision(9) << k << " pxin=" << std::setprecision(9) << pxin << " pyin="
-             << std::setprecision(9) << pyin << " cosPorT=" << std::setprecision(9) << cosPorT
-             << " sinPorT=" << std::setprecision(9) << sinPorT << " pt=" << std::setprecision(9) << pt);
+    dprint_np(n,
+              "k=" << std::setprecision(9) << k << " pxin=" << std::setprecision(9) << pxin
+                   << " pyin=" << std::setprecision(9) << pyin << " cosPorT=" << std::setprecision(9) << cosPorT
+                   << " sinPorT=" << std::setprecision(9) << sinPorT << " pt=" << std::setprecision(9) << pt);
 
-      //derivatives initialized to value for first iteration, i.e. distance = r-r0in
-      float dDdx = r0 > 0.f ? -xin/r0 : 0.f;
-      float dDdy = r0 > 0.f ? -yin/r0 : 0.f;
-      float dDdipt = 0.;
-      float dDdphi = 0.;
+    //derivatives initialized to value for first iteration, i.e. distance = r-r0in
+    float dDdx = r0 > 0.f ? -xin / r0 : 0.f;
+    float dDdy = r0 > 0.f ? -yin / r0 : 0.f;
+    float dDdipt = 0.;
+    float dDdphi = 0.;
 
-      for (int i = 0; i < Config::Niter; ++i)
+    for (int i = 0; i < Config::Niter; ++i) {
+      //compute distance and path for the current iteration
+      r0 = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
+
+      // Use one over dot produce of transverse momentum and radial
+      // direction to scale the step. Propagation is prevented from reaching
+      // too close to the apex (dotp > 0.2).
+      // - Can / should we come up with a better approximation?
+      // - Can / should take +/- curvature into account?
+
+      const float oodotp = r0 * pt / (pxin * outPar(n, 0, 0) + pyin * outPar(n, 1, 0));
+
+      if (oodotp > 5.0f || oodotp < 0)  // 0.2 is 78.5 deg
       {
-        //compute distance and path for the current iteration
-        r0  = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
-
-        // Use one over dot produce of transverse momentum and radial
-        // direction to scale the step. Propagation is prevented from reaching
-        // too close to the apex (dotp > 0.2).
-        // - Can / should we come up with a better approximation?
-        // - Can / should take +/- curvature into account?
-
-        const float oodotp = r0 * pt / (pxin * outPar(n,0,0) + pyin * outPar(n,1,0));
-
-        if (oodotp > 5.0f || oodotp < 0) // 0.2 is 78.5 deg
-        {
-          id = 0.0f;
-          outFailFlag(n, 0, 0) = 1;
-        }
-        else
-        {
-          // Can we come up with a better approximation?
-          // Should take +/- curvature into account.
-          id = (r - r0) * oodotp;
-        }
-        D  += id;
-
-        if (Config::useTrigApprox) {
-          sincos4(id*ipt*kinv*0.5f, sinah, cosah);
-        } else {
-          cosah=std::cos(id*ipt*kinv*0.5f);
-          sinah=std::sin(id*ipt*kinv*0.5f);
-        }
-        cosa=1.f-2.f*sinah*sinah;
-        sina=2.f*sinah*cosah;
-
-        dprint_np(n, "Attempt propagation from r=" << r0 << " to r=" << r << std::endl
-                  << "   x=" << xin << " y=" << yin  << " z=" << inPar(n, 2, 0)
-                  << " px=" << pxin << " py=" << pyin << " pz=" << pt*std::tan(theta) << " q=" << inChg(n, 0, 0) << std::endl
-                  << "   r=" << std::setprecision(9) << r << " r0=" << std::setprecision(9) << r0
-                  << " id=" << std::setprecision(9) << id << " dr=" << std::setprecision(9) << r - r0 << " cosa=" << cosa << " sina=" << sina);
-
-        //update derivatives on total distance
-        if (i+1 != Config::Niter)
-        {
-          const float x = outPar(n, 0, 0);
-          const float y = outPar(n, 1, 0);
-          const float oor0 = (r0 > 0.f && std::abs(r-r0) < 0.0001f) ? 1.f / r0 : 0.f;
-
-          const float dadipt = id*kinv;
-
-          const float dadx = -x*ipt*kinv*oor0;
-          const float dady = -y*ipt*kinv*oor0;
-
-          const float pxca = pxin*cosa;
-          const float pxsa = pxin*sina;
-          const float pyca = pyin*cosa;
-          const float pysa = pyin*sina;
-
-          float tmp;
-
-          tmp   = k*dadx;
-          dDdx -= ( x*(1.f + tmp*(pxca - pysa)) + y*tmp*(pyca + pxsa) )*oor0;
-
-          tmp   = k*dady;
-          dDdy -= ( x*tmp*(pxca - pysa) + y*(1.f + tmp*(pyca + pxsa)) )*oor0;
-
-          //now r0 depends on ipt and phi as well
-          tmp     = dadipt*ipt;
-          dDdipt -= k*( x*(pxca*tmp - pysa*tmp - pyca - pxsa + pyin) +
-                        y*(pyca*tmp + pxsa*tmp - pysa + pxca - pxin) )*pt*oor0;
-          dDdphi += k*( x*(pysa - pxin + pxca) - y*(pxsa - pyin + pyca) )*oor0;
-        }
-
-        //update parameters
-        outPar(n, 0, 0) = outPar(n, 0, 0) + 2.f*k*sinah*(pxin*cosah - pyin*sinah);
-        outPar(n, 1, 0) = outPar(n, 1, 0) + 2.f*k*sinah*(pyin*cosah + pxin*sinah);
-        const float pxinold = pxin;//copy before overwriting
-        pxin = pxin*cosa - pyin*sina;
-        pyin = pyin*cosa + pxinold*sina;
-
-        dprint_np(n, "outPar(n, 0, 0)=" << outPar(n, 0, 0) << " outPar(n, 1, 0)=" << outPar(n, 1, 0)
-               << " pxin=" << pxin << " pyin=" << pyin);
+        id = 0.0f;
+        outFailFlag(n, 0, 0) = 1;
+      } else {
+        // Can we come up with a better approximation?
+        // Should take +/- curvature into account.
+        id = (r - r0) * oodotp;
       }
-
-      const float alpha  = D*ipt*kinv;
-      const float dadx   = dDdx*ipt*kinv;
-      const float dady   = dDdy*ipt*kinv;
-      const float dadipt = (ipt*dDdipt + D)*kinv;
-      const float dadphi = dDdphi*ipt*kinv;
+      D += id;
 
       if (Config::useTrigApprox) {
-        sincos4(alpha, sina, cosa);
+        sincos4(id * ipt * kinv * 0.5f, sinah, cosah);
       } else {
-        cosa=std::cos(alpha);
-        sina=std::sin(alpha);
+        cosah = std::cos(id * ipt * kinv * 0.5f);
+        sinah = std::sin(id * ipt * kinv * 0.5f);
+      }
+      cosa = 1.f - 2.f * sinah * sinah;
+      sina = 2.f * sinah * cosah;
+
+      dprint_np(n,
+                "Attempt propagation from r="
+                    << r0 << " to r=" << r << std::endl
+                    << "   x=" << xin << " y=" << yin << " z=" << inPar(n, 2, 0) << " px=" << pxin << " py=" << pyin
+                    << " pz=" << pt * std::tan(theta) << " q=" << inChg(n, 0, 0) << std::endl
+                    << "   r=" << std::setprecision(9) << r << " r0=" << std::setprecision(9) << r0
+                    << " id=" << std::setprecision(9) << id << " dr=" << std::setprecision(9) << r - r0
+                    << " cosa=" << cosa << " sina=" << sina);
+
+      //update derivatives on total distance
+      if (i + 1 != Config::Niter) {
+        const float x = outPar(n, 0, 0);
+        const float y = outPar(n, 1, 0);
+        const float oor0 = (r0 > 0.f && std::abs(r - r0) < 0.0001f) ? 1.f / r0 : 0.f;
+
+        const float dadipt = id * kinv;
+
+        const float dadx = -x * ipt * kinv * oor0;
+        const float dady = -y * ipt * kinv * oor0;
+
+        const float pxca = pxin * cosa;
+        const float pxsa = pxin * sina;
+        const float pyca = pyin * cosa;
+        const float pysa = pyin * sina;
+
+        float tmp;
+
+        tmp = k * dadx;
+        dDdx -= (x * (1.f + tmp * (pxca - pysa)) + y * tmp * (pyca + pxsa)) * oor0;
+
+        tmp = k * dady;
+        dDdy -= (x * tmp * (pxca - pysa) + y * (1.f + tmp * (pyca + pxsa))) * oor0;
+
+        //now r0 depends on ipt and phi as well
+        tmp = dadipt * ipt;
+        dDdipt -=
+            k *
+            (x * (pxca * tmp - pysa * tmp - pyca - pxsa + pyin) + y * (pyca * tmp + pxsa * tmp - pysa + pxca - pxin)) *
+            pt * oor0;
+        dDdphi += k * (x * (pysa - pxin + pxca) - y * (pxsa - pyin + pyca)) * oor0;
       }
 
-      errorProp(n,0,0) = 1.f+k*dadx*(cosPorT*cosa-sinPorT*sina)*pt;
-      errorProp(n,0,1) =     k*dady*(cosPorT*cosa-sinPorT*sina)*pt;
-      errorProp(n,0,2) = 0.f;
-      errorProp(n,0,3) = k*(cosPorT*(ipt*dadipt*cosa-sina)+sinPorT*((1.f-cosa)-ipt*dadipt*sina))*pt*pt;
-      errorProp(n,0,4) = k*(cosPorT*dadphi*cosa - sinPorT*dadphi*sina - sinPorT*sina + cosPorT*cosa - cosPorT)*pt;
-      errorProp(n,0,5) = 0.f;
+      //update parameters
+      outPar(n, 0, 0) = outPar(n, 0, 0) + 2.f * k * sinah * (pxin * cosah - pyin * sinah);
+      outPar(n, 1, 0) = outPar(n, 1, 0) + 2.f * k * sinah * (pyin * cosah + pxin * sinah);
+      const float pxinold = pxin;  //copy before overwriting
+      pxin = pxin * cosa - pyin * sina;
+      pyin = pyin * cosa + pxinold * sina;
 
-      errorProp(n,1,0) =     k*dadx*(sinPorT*cosa+cosPorT*sina)*pt;
-      errorProp(n,1,1) = 1.f+k*dady*(sinPorT*cosa+cosPorT*sina)*pt;
-      errorProp(n,1,2) = 0.f;
-      errorProp(n,1,3) = k*(sinPorT*(ipt*dadipt*cosa-sina)+cosPorT*(ipt*dadipt*sina-(1.f-cosa)))*pt*pt;
-      errorProp(n,1,4) = k*(sinPorT*dadphi*cosa + cosPorT*dadphi*sina + sinPorT*cosa + cosPorT*sina - sinPorT)*pt;
-      errorProp(n,1,5) = 0.f;
-
-      //no trig approx here, theta can be large
-      cosPorT=std::cos(theta);
-      sinPorT=std::sin(theta);
-      //redefine sinPorT as 1./sinPorT to reduce the number of temporaries
-      sinPorT = 1.f/sinPorT;
-
-      outPar(n, 2, 0) = inPar(n, 2, 0) + k*alpha*cosPorT*pt*sinPorT;
-
-      errorProp(n,2,0) = k*cosPorT*dadx*pt*sinPorT;
-      errorProp(n,2,1) = k*cosPorT*dady*pt*sinPorT;
-      errorProp(n,2,2) = 1.f;
-      errorProp(n,2,3) = k*cosPorT*(ipt*dadipt-alpha)*pt*pt*sinPorT;
-      errorProp(n,2,4) = k*dadphi*cosPorT*pt*sinPorT;
-      errorProp(n,2,5) =-k*alpha*pt*sinPorT*sinPorT;
-
-      outPar(n, 3, 0) = ipt;
-
-      errorProp(n,3,0) = 0.f;
-      errorProp(n,3,1) = 0.f;
-      errorProp(n,3,2) = 0.f;
-      errorProp(n,3,3) = 1.f;
-      errorProp(n,3,4) = 0.f;
-      errorProp(n,3,5) = 0.f;
-
-      outPar(n, 4, 0) = inPar(n, 4, 0)+alpha;
-
-      errorProp(n,4,0) = dadx;
-      errorProp(n,4,1) = dady;
-      errorProp(n,4,2) = 0.f;
-      errorProp(n,4,3) = dadipt;
-      errorProp(n,4,4) = 1.f+dadphi;
-      errorProp(n,4,5) = 0.f;
-
-      outPar(n, 5, 0) = theta;
-
-      errorProp(n,5,0) = 0.f;
-      errorProp(n,5,1) = 0.f;
-      errorProp(n,5,2) = 0.f;
-      errorProp(n,5,3) = 0.f;
-      errorProp(n,5,4) = 0.f;
-      errorProp(n,5,5) = 1.f;
-
-      dprint_np(n, "propagation end, dump parameters" << std::endl
-                << "   pos = " << outPar(n, 0, 0) << " " << outPar(n, 1, 0) << " " << outPar(n, 2, 0)
-                << "\t\t r=" << std::sqrt( outPar(n, 0, 0)*outPar(n, 0, 0) + outPar(n, 1, 0)*outPar(n, 1, 0) ) << std::endl
-                << "   mom = " << std::cos(outPar(n, 4, 0))/outPar(n, 3, 0) << " " << std::sin(outPar(n, 4, 0))/outPar(n, 3, 0) << " " << 1./(outPar(n, 3, 0)*tan(outPar(n, 5, 0)))
-                << "\t\tpT=" << 1./std::abs(outPar(n, 3, 0)) << std::endl);
-      
-#ifdef DEBUG
-      if (n < N_proc) {
-	dmutex_guard;
-	std::cout << n << ": jacobian" << std::endl;
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,0,0),errorProp(n,0,1),errorProp(n,0,2),errorProp(n,0,3),errorProp(n,0,4),errorProp(n,0,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,1,0),errorProp(n,1,1),errorProp(n,1,2),errorProp(n,1,3),errorProp(n,1,4),errorProp(n,1,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,2,0),errorProp(n,2,1),errorProp(n,2,2),errorProp(n,2,3),errorProp(n,2,4),errorProp(n,2,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,3,0),errorProp(n,3,1),errorProp(n,3,2),errorProp(n,3,3),errorProp(n,3,4),errorProp(n,3,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,4,0),errorProp(n,4,1),errorProp(n,4,2),errorProp(n,4,3),errorProp(n,4,4),errorProp(n,4,5));
-	printf("%5f %5f %5f %5f %5f %5f\n", errorProp(n,5,0),errorProp(n,5,1),errorProp(n,5,2),errorProp(n,5,3),errorProp(n,5,4),errorProp(n,5,5));
-        printf("\n");
-      }
-#endif
+      dprint_np(n,
+                "outPar(n, 0, 0)=" << outPar(n, 0, 0) << " outPar(n, 1, 0)=" << outPar(n, 1, 0) << " pxin=" << pxin
+                                   << " pyin=" << pyin);
     }
+
+    const float alpha = D * ipt * kinv;
+    const float dadx = dDdx * ipt * kinv;
+    const float dady = dDdy * ipt * kinv;
+    const float dadipt = (ipt * dDdipt + D) * kinv;
+    const float dadphi = dDdphi * ipt * kinv;
+
+    if (Config::useTrigApprox) {
+      sincos4(alpha, sina, cosa);
+    } else {
+      cosa = std::cos(alpha);
+      sina = std::sin(alpha);
+    }
+
+    errorProp(n, 0, 0) = 1.f + k * dadx * (cosPorT * cosa - sinPorT * sina) * pt;
+    errorProp(n, 0, 1) = k * dady * (cosPorT * cosa - sinPorT * sina) * pt;
+    errorProp(n, 0, 2) = 0.f;
+    errorProp(n, 0, 3) =
+        k * (cosPorT * (ipt * dadipt * cosa - sina) + sinPorT * ((1.f - cosa) - ipt * dadipt * sina)) * pt * pt;
+    errorProp(n, 0, 4) =
+        k * (cosPorT * dadphi * cosa - sinPorT * dadphi * sina - sinPorT * sina + cosPorT * cosa - cosPorT) * pt;
+    errorProp(n, 0, 5) = 0.f;
+
+    errorProp(n, 1, 0) = k * dadx * (sinPorT * cosa + cosPorT * sina) * pt;
+    errorProp(n, 1, 1) = 1.f + k * dady * (sinPorT * cosa + cosPorT * sina) * pt;
+    errorProp(n, 1, 2) = 0.f;
+    errorProp(n, 1, 3) =
+        k * (sinPorT * (ipt * dadipt * cosa - sina) + cosPorT * (ipt * dadipt * sina - (1.f - cosa))) * pt * pt;
+    errorProp(n, 1, 4) =
+        k * (sinPorT * dadphi * cosa + cosPorT * dadphi * sina + sinPorT * cosa + cosPorT * sina - sinPorT) * pt;
+    errorProp(n, 1, 5) = 0.f;
+
+    //no trig approx here, theta can be large
+    cosPorT = std::cos(theta);
+    sinPorT = std::sin(theta);
+    //redefine sinPorT as 1./sinPorT to reduce the number of temporaries
+    sinPorT = 1.f / sinPorT;
+
+    outPar(n, 2, 0) = inPar(n, 2, 0) + k * alpha * cosPorT * pt * sinPorT;
+
+    errorProp(n, 2, 0) = k * cosPorT * dadx * pt * sinPorT;
+    errorProp(n, 2, 1) = k * cosPorT * dady * pt * sinPorT;
+    errorProp(n, 2, 2) = 1.f;
+    errorProp(n, 2, 3) = k * cosPorT * (ipt * dadipt - alpha) * pt * pt * sinPorT;
+    errorProp(n, 2, 4) = k * dadphi * cosPorT * pt * sinPorT;
+    errorProp(n, 2, 5) = -k * alpha * pt * sinPorT * sinPorT;
+
+    outPar(n, 3, 0) = ipt;
+
+    errorProp(n, 3, 0) = 0.f;
+    errorProp(n, 3, 1) = 0.f;
+    errorProp(n, 3, 2) = 0.f;
+    errorProp(n, 3, 3) = 1.f;
+    errorProp(n, 3, 4) = 0.f;
+    errorProp(n, 3, 5) = 0.f;
+
+    outPar(n, 4, 0) = inPar(n, 4, 0) + alpha;
+
+    errorProp(n, 4, 0) = dadx;
+    errorProp(n, 4, 1) = dady;
+    errorProp(n, 4, 2) = 0.f;
+    errorProp(n, 4, 3) = dadipt;
+    errorProp(n, 4, 4) = 1.f + dadphi;
+    errorProp(n, 4, 5) = 0.f;
+
+    outPar(n, 5, 0) = theta;
+
+    errorProp(n, 5, 0) = 0.f;
+    errorProp(n, 5, 1) = 0.f;
+    errorProp(n, 5, 2) = 0.f;
+    errorProp(n, 5, 3) = 0.f;
+    errorProp(n, 5, 4) = 0.f;
+    errorProp(n, 5, 5) = 1.f;
+
+    dprint_np(n,
+              "propagation end, dump parameters"
+                  << std::endl
+                  << "   pos = " << outPar(n, 0, 0) << " " << outPar(n, 1, 0) << " " << outPar(n, 2, 0) << "\t\t r="
+                  << std::sqrt(outPar(n, 0, 0) * outPar(n, 0, 0) + outPar(n, 1, 0) * outPar(n, 1, 0)) << std::endl
+                  << "   mom = " << std::cos(outPar(n, 4, 0)) / outPar(n, 3, 0) << " "
+                  << std::sin(outPar(n, 4, 0)) / outPar(n, 3, 0) << " " << 1. / (outPar(n, 3, 0) * tan(outPar(n, 5, 0)))
+                  << "\t\tpT=" << 1. / std::abs(outPar(n, 3, 0)) << std::endl);
+
+#ifdef DEBUG
+    if (n < N_proc) {
+      dmutex_guard;
+      std::cout << n << ": jacobian" << std::endl;
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 0, 0),
+             errorProp(n, 0, 1),
+             errorProp(n, 0, 2),
+             errorProp(n, 0, 3),
+             errorProp(n, 0, 4),
+             errorProp(n, 0, 5));
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 1, 0),
+             errorProp(n, 1, 1),
+             errorProp(n, 1, 2),
+             errorProp(n, 1, 3),
+             errorProp(n, 1, 4),
+             errorProp(n, 1, 5));
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 2, 0),
+             errorProp(n, 2, 1),
+             errorProp(n, 2, 2),
+             errorProp(n, 2, 3),
+             errorProp(n, 2, 4),
+             errorProp(n, 2, 5));
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 3, 0),
+             errorProp(n, 3, 1),
+             errorProp(n, 3, 2),
+             errorProp(n, 3, 3),
+             errorProp(n, 3, 4),
+             errorProp(n, 3, 5));
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 4, 0),
+             errorProp(n, 4, 1),
+             errorProp(n, 4, 2),
+             errorProp(n, 4, 3),
+             errorProp(n, 4, 4),
+             errorProp(n, 4, 5));
+      printf("%5f %5f %5f %5f %5f %5f\n",
+             errorProp(n, 5, 0),
+             errorProp(n, 5, 1),
+             errorProp(n, 5, 2),
+             errorProp(n, 5, 3),
+             errorProp(n, 5, 4),
+             errorProp(n, 5, 5));
+      printf("\n");
+    }
+#endif
+  }
 }

--- a/RecoTracker/MkFitCore/src/Track.cc
+++ b/RecoTracker/MkFitCore/src/Track.cc
@@ -675,7 +675,7 @@ namespace mkfit {
 
     // get min chi2
     float minchi2 = -1e6;
-    if (cands.size() > 0) {
+    if (!cands.empty()) {
       std::sort(cands.begin(), cands.end(), sortIDsByChi2);  // in case we just want to stop at the first dPhi match
       minchi2 = cands.front().second;
     }
@@ -800,7 +800,7 @@ namespace mkfit {
     int cmsswTrackID = -1;
 
     // protect against no matches!
-    if (labelMatchVec.size() > 0) {
+    if (!labelMatchVec.empty()) {
       // sort by best matched: most hits matched , then ratio of matches (i.e. which cmssw track is shorter)
       std::sort(labelMatchVec.begin(), labelMatchVec.end(), [&](const int label1, const int label2) {
         if (labelMatchMap[label1] == labelMatchMap[label2]) {

--- a/RecoTracker/MkFitCore/src/TrackerInfo.cc
+++ b/RecoTracker/MkFitCore/src/TrackerInfo.cc
@@ -107,7 +107,7 @@ namespace mkfit {
 #include <cstdlib>
 
   namespace {
-    const char *search_path[] = {"", "../Geoms/", "Geoms/", "../", 0};
+    const char *search_path[] = {"", "../Geoms/", "Geoms/", "../", nullptr};
   }
 
   void TrackerInfo::ExecTrackerInfoCreatorPlugin(const std::string &base,


### PR DESCRIPTION
- fix the "error" in code-checks RecoTracker/MkFitCore/src/MkBuilder.cc by using `maybe_unused` (the lambda is actually used in the FITTER macro, but the checker seems to get confused)
- automated code-check/code-format for everything else ignoring the /standalone subdirectories

Questions:
- do we want to disable formatting for some files?
- how to disable formatting in the standalone/ subdirectories? (IIUC, these are not intended to be inspected/built with scram)
