### PR TITLE
disable clang format in files in the standalone/ directories

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/CMS-2017.acc
+++ b/RecoTracker/MkFitCMS/standalone/CMS-2017.acc
@@ -1,3 +1,4 @@
+// clang-format off
 void Create_CMS_2017_AutoGen(TrackerInfo &ti, IterationsInfo &ii)
 {
   // PIXB

--- a/RecoTracker/MkFitCMS/standalone/CMS-2017/CMS-2017.C
+++ b/RecoTracker/MkFitCMS/standalone/CMS-2017/CMS-2017.C
@@ -1,3 +1,4 @@
+// clang-format off
 // To be used in compiled mode
 
 #include "../Geoms/CMS-2017.cc"

--- a/RecoTracker/MkFitCMS/standalone/CMS-2017/make_trk_info.C
+++ b/RecoTracker/MkFitCMS/standalone/CMS-2017/make_trk_info.C
@@ -1,3 +1,4 @@
+// clang-format off
 /*
   Sibling layers are needed for seeding from MC tracks.
   As we do not do seeding we also do not fill them here.

--- a/RecoTracker/MkFitCMS/standalone/CMS-2017/tnc.C
+++ b/RecoTracker/MkFitCMS/standalone/CMS-2017/tnc.C
@@ -1,3 +1,4 @@
+// clang-format off
 #define tnc_cxx
 #include "tnc.h"
 #include <TH2.h>

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/CramerInversion.icc
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/CramerInversion.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // @(#)root/smatrix:$Id$
 // Authors: L. Moneta    2005  
 

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/CramerInversionSym.icc
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/CramerInversionSym.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // @(#)root/smatrix:$Id$
 // Authors: L. Moneta    2005  
 

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/MatrixInversion.icc
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/MatrixInversion.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // @(#)root/smatrix:$Id$
 // Authors: CLHEP authors, L. Moneta    2006  
 

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/SMatrix.icc
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/SMatrix.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // @(#)root/smatrix:$Id$
 // Authors: T. Glebe, L. Moneta    2005  
 

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/SVector.icc
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/from-root/Math/SVector.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // @(#)root/smatrix:$Id$
 // Authors: T. Glebe, L. Moneta    2005  
 

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/nlohmann/json.hpp
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/nlohmann/json.hpp
@@ -1,3 +1,4 @@
+// clang-format off
 /*
     __ _____ _____ _____
  __|  |   __|     |   | |  JSON for Modern C++

--- a/RecoTracker/MkFitCore/standalone/dusty-chest/nlohmann/json_fwd.hpp
+++ b/RecoTracker/MkFitCore/standalone/dusty-chest/nlohmann/json_fwd.hpp
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
 #define INCLUDE_NLOHMANN_JSON_FWD_HPP_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/Common.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/Common.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _Common_
 #define _Common_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotBenchmarks.cpp
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotBenchmarks.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include "PlotBenchmarks.hh"
 
 #include <iostream>

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotBenchmarks.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotBenchmarks.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _PlotBenchmarks_
 #define _PlotBenchmarks_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotMEIFBenchmarks.cpp
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotMEIFBenchmarks.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include "PlotMEIFBenchmarks.hh"
 
 PlotMEIFBenchmarks::PlotMEIFBenchmarks(const TString & arch, const TString & sample, const TString &  build)

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotMEIFBenchmarks.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotMEIFBenchmarks.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _PlotMEIFBenchmarks_
 #define _PlotMEIFBenchmarks_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotValidation.cpp
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotValidation.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include "PlotValidation.hh"
 
 //////////////////////////////

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotValidation.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotValidation.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _PlotValidation_
 #define _PlotValidation_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotsFromDump.cpp
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotsFromDump.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include "PlotsFromDump.hh"
 
 PlotsFromDump::PlotsFromDump(const TString & sample, const TString & build, const TString & suite, const int useARCH) 

--- a/RecoTracker/MkFitCore/standalone/plotting/PlotsFromDump.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/PlotsFromDump.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _PlotsFromDump_
 #define _PlotsFromDump_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/StackValidation.cpp
+++ b/RecoTracker/MkFitCore/standalone/plotting/StackValidation.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include "StackValidation.hh"
 
 StackValidation::StackValidation(const TString & label, const TString & extra, const Bool_t cmsswComp, const TString & suite)

--- a/RecoTracker/MkFitCore/standalone/plotting/StackValidation.hh
+++ b/RecoTracker/MkFitCore/standalone/plotting/StackValidation.hh
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef _StackValidation_
 #define _StackValidation_
 

--- a/RecoTracker/MkFitCore/standalone/plotting/makeBenchmarkPlots.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/makeBenchmarkPlots.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "plotting/PlotBenchmarks.cpp+"
 
 void makeBenchmarkPlots(const TString & arch, const TString & sample, const TString & suite)

--- a/RecoTracker/MkFitCore/standalone/plotting/makeMEIFBenchmarkPlots.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/makeMEIFBenchmarkPlots.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "plotting/PlotMEIFBenchmarks.cpp+"
 
 void makeMEIFBenchmarkPlots(const TString & arch, const TString & sample, const TString & build)

--- a/RecoTracker/MkFitCore/standalone/plotting/makePlotsFromDump.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/makePlotsFromDump.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "plotting/PlotsFromDump.cpp+"
 
 void makePlotsFromDump(const TString & sample, const TString & build, const TString & suite, const int useARCH)

--- a/RecoTracker/MkFitCore/standalone/plotting/makeValidation.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/makeValidation.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "plotting/StackValidation.cpp+"
 
 void makeValidation(const TString & label = "", const TString & extra = "", const Bool_t cmsswComp = false, const TString & suite = "forPR")

--- a/RecoTracker/MkFitCore/standalone/plotting/plotStress.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/plotStress.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "TString.h"
 #include "TColor.h"
 #include "TStyle.h"

--- a/RecoTracker/MkFitCore/standalone/plotting/runValidation.C
+++ b/RecoTracker/MkFitCore/standalone/plotting/runValidation.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "plotting/PlotValidation.cpp+"
 
 void runValidation(const TString & test = "", const Bool_t cmsswComp = false, const int algo = 0, const Bool_t mvInput = true, const Bool_t rmSuffix = true,

--- a/RecoTracker/MkFitCore/standalone/test/CylCowWLids.C
+++ b/RecoTracker/MkFitCore/standalone/test/CylCowWLids.C
@@ -1,3 +1,4 @@
+// clang-format off
 // To be used in compiled mode
 
 #include "../CylCowWLids.cc"

--- a/RecoTracker/MkFitCore/standalone/test/DumpHitSearchStats.icc
+++ b/RecoTracker/MkFitCore/standalone/test/DumpHitSearchStats.icc
@@ -1,3 +1,4 @@
+// clang-format off
 // To be included after SelectHitRange / Indices().
 
 #define MKFP(_V_) mkfp->_V_.ConstAt(mi,0,0)

--- a/RecoTracker/MkFitCore/standalone/test/config-parse/dump_vars.C
+++ b/RecoTracker/MkFitCore/standalone/test/config-parse/dump_vars.C
@@ -1,3 +1,4 @@
+// clang-format off
 #include "TClass.h"
 
 #include <string>


### PR DESCRIPTION
this PR disables clang format in the standalone files.
This is somewhat temporary, until the migration and setup of the standalone builds inside cmssw repository is working.

This should let the cmssw tests PR going.

@makortel 
please check and perhaps merge if the change looks reasonable