### PR TITLE
Cand dnn for124 x

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -241,6 +241,8 @@ trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, m
     seeds = 'highPtTripletStepSeeds',
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
+    algo = 22,
+    candWP = -0.3,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)
 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -241,7 +241,7 @@ trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, m
     seeds = 'highPtTripletStepSeeds',
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
-    algo = 22,
+    candMVASel = True,
     candWP = -0.3,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -322,6 +322,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
     algo = 9,
+    flag = 1,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -321,6 +321,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     seeds = 'pixelLessStepSeeds',
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
+    algo = 9,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -322,7 +322,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
     algo = 9,
-    flag = 1,
+    candWP = -0.7,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -321,7 +321,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     seeds = 'pixelLessStepSeeds',
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
-    algo = 9,
+    candMVASel = True,
     candWP = -0.7,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -30,5 +30,9 @@
   <use name="TrackingTools/TrajectoryState"/>
   <use name="TrackingTools/TransientTrackingRecHit"/>
   <use name="rootmath"/>
+  <use name="CondFormats/GBRForest"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="TrackingTools/PatternTools"/>
+  <use name="RecoTracker/FinalTrackSelectors"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -447,10 +447,16 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
   if (algoCandSelection_) {
     const std::vector<float> dnnScores = computeDNNs(
         output, states, bs, vertices, session, chi2, mkFitOutput.propagatedToFirstLayer() && doErrorRescale_);
-    for (int s = dnnScores.size() - 1; s >= 0; s--) {
-      if (dnnScores[s] <= algoCandWorkingPoint_)
-        output.erase(output.begin() + s);
+
+    TrackCandidateCollection reducedOutput;
+    int scoreIndex = 0;
+    for (const auto& score : dnnScores) {
+      if (score > algoCandWorkingPoint_)
+        reducedOutput.push_back(output.at(scoreIndex));
+      scoreIndex++;
     }
+
+    output.swap(reducedOutput);
   }
 
   return output;

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -134,6 +134,7 @@ private:
   const bool doErrorRescale_;
   
   const int algo_;
+  const bool algoCandSelection_;
   const float algoCandWorkingPoint_;
   const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
   const edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
@@ -165,10 +166,11 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
       doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
-      algo_{int(iConfig.getParameter<int>("algo"))},
+      algo_{reco::TrackBase::algoByName(TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
+      algoCandSelection_{bool(iConfig.getParameter<bool>("candMVASel"))},
       algoCandWorkingPoint_{float(iConfig.getParameter<double>("candWP"))},
       bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
-      verticesToken_(algo_ > 0 ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
+      verticesToken_(algoCandSelection_ ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
                                : edm::EDGetTokenT<reco::VertexCollection>()),
       tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
       tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))) {}
@@ -197,7 +199,7 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
 
-  desc.add<int>("algo", 0)->setComment("flag used to trigger MVA selection at cand level and store algo number");
+  desc.add<bool>("candMVASel", false)->setComment("flag used to trigger MVA selection at cand level");
   desc.add<double>("candWP", 0)->setComment("MVA selection at cand level working point");
 
   descriptions.addWithDefaultLabel(desc);
@@ -220,7 +222,7 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
 
   // primary vertices under the algo_ because in initialStepPreSplitting there are no firstStepPrimaryVertices
   const reco::VertexCollection* vertices = nullptr;
-  if (algo_ > 0) {
+  if (algoCandSelection_) {
     edm::Handle<reco::VertexCollection> hVtx;
     iEvent.getByToken(verticesToken_, hVtx);
     vertices = hVtx.product();
@@ -426,7 +428,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     // convert to persistent, from CkfTrackCandidateMakerBase
     auto pstate = trajectoryStateTransform::persistentState(tsosDet.first, tsosDet.second->geographicalId().rawId());
 
-    if (algo_ == 0)  //default
+    if (!algoCandSelection_)  //default
     {
       output.emplace_back(
           recHits,

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -61,6 +61,9 @@
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
 namespace {
   template <typename T>
   bool isBarrel(T subdet) {
@@ -95,7 +98,7 @@ private:
                                              const TkClonerImpl& hitCloner,
                                              const std::vector<const DetLayer*>& detLayers,
                                              const mkfit::TrackVec& mkFitSeeds,
-                                             const reco::BeamSpot& bs,
+                                             const reco::BeamSpot& bs, const reco::VertexCollection* vertices,
                                              const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const;
 
   std::pair<TrajectoryStateOnSurface, const GeomDet*> backwardFit(const FreeTrajectoryState& fts,
@@ -111,8 +114,10 @@ private:
                                                                             const Propagator& propagatorAlong,
                                                                             const Propagator& propagatorOpposite) const;
                                                                             
-  float computeTFDNN(const TrackCandidate& tkC, const reco::BeamSpot& bs, const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const;
+  float computeTFDNN(const TrackCandidate& tkC, const reco::BeamSpot& bs, const reco::VertexCollection* vertices, const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session, int missing, float chi2) const;
 
+  const int flag_;
+  
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> stripClusterIndexToHitToken_;
@@ -120,6 +125,7 @@ private:
   const edm::EDGetTokenT<MkFitOutputWrapper> tracksToken_;
   const edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
   const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> vertices_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
@@ -144,13 +150,15 @@ private:
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
-    : eventOfHitsToken_{consumes<MkFitEventOfHits>(iConfig.getParameter<edm::InputTag>("mkFitEventOfHits"))},
+    : flag_{int(iConfig.getParameter<int>("flag"))}, 
+      eventOfHitsToken_{consumes<MkFitEventOfHits>(iConfig.getParameter<edm::InputTag>("mkFitEventOfHits"))},
       pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitPixelHits"))},
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitStripHits"))},
       mkfitSeedToken_{consumes<MkFitSeedWrapper>(iConfig.getParameter<edm::InputTag>("mkFitSeeds"))},
       tracksToken_{consumes<MkFitOutputWrapper>(iConfig.getParameter<edm::InputTag>("tracks"))},
       seedToken_{consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("seeds"))},
       bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+      vertices_(flag_>0?consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices")):edm::EDGetTokenT<reco::VertexCollection>()),
       propagatorAlongToken_{
           esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
       propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
@@ -197,6 +205,7 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
    
   desc.add<int>("algo", 0)->setComment("algo used to check which iteration");  
+  desc.add<int>("flag", 0)->setComment("flag used to check vtx iter");  
  
   descriptions.addWithDefaultLabel(desc);
 }
@@ -215,7 +224,14 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
   edm::Handle<reco::BeamSpot> bsHandle;
   iEvent.getByToken(bsToken_, bsHandle);
   const reco::BeamSpot &beamspot = *bsHandle.product();
-  
+ 
+  // Select good primary vertices for use in subsequent track selection
+  const reco::VertexCollection* vertices = nullptr;
+  if(algo_>0 && flag_>0){
+  edm::Handle<reco::VertexCollection> hVtx;
+  iEvent.getByToken(vertices_, hVtx);
+  vertices = hVtx.product();     }
+
   const tensorflow::Session* session = iSetup.getData(tfDnnToken_).getSession(); 
 
   // Convert mkfit presentation back to CMSSW
@@ -231,7 +247,7 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
                                    tkBuilder->cloner(),
                                    mkFitGeom.detLayers(),
                                    mkfitSeeds.seeds(),
-                                   beamspot,
+                                   beamspot,vertices,
                                    ttrhBuilder, session));
 
   // TODO: SeedStopInfo is currently unfilled
@@ -249,7 +265,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const TkClonerImpl& hitCloner,
                                                                  const std::vector<const DetLayer*>& detLayers,
                                                                  const mkfit::TrackVec& mkFitSeeds,
-                                                                 const reco::BeamSpot& bs,
+                                                                 const reco::BeamSpot& bs, const reco::VertexCollection* vertices,
                                                                  const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const {
   TrackCandidateCollection output;
   const auto& candidates = mkFitOutput.tracks();
@@ -427,7 +443,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     else
     {
     const TrackCandidate cmsswcand = TrackCandidate( recHits, seeds.at(seedIndex), pstate, seeds.refAt(seedIndex),  0,  static_cast<uint8_t>(StopReason::UNINITIALIZED) );
-    float disc = computeTFDNN(cmsswcand, bs, mf, theTTRHBuilder, session);
+    float disc = computeTFDNN(cmsswcand, bs, vertices, mf, theTTRHBuilder, session, cand.nInsideMinusOneHits(), cand.chi2());
     if(disc>-0.8)
     {
       output.push_back(cmsswcand);
@@ -571,7 +587,8 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
   return std::make_pair(tsosDouble.first, det);
 }
 
-float MkFitOutputConverter::computeTFDNN(const TrackCandidate &tkC, const reco::BeamSpot& bs, const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const{
+float MkFitOutputConverter::computeTFDNN(const TrackCandidate &tkC, const reco::BeamSpot& bs, const reco::VertexCollection* vertices, 
+                                         const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session, int missing, float chi2) const{
   
   TSCBLBuilderNoMaterial tscblBuilder;
 
@@ -585,33 +602,44 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate &tkC, const reco::
     return 0;
   }
   
-  GlobalPoint v0 = tsAtClosestApproachTrackCand.trackStateAtPCA().position();
-  GlobalVector p = tsAtClosestApproachTrackCand.trackStateAtPCA().momentum();
-  GlobalPoint v(v0.x() - bs.x0(), v0.y() - bs.y0(), v0.z() - bs.z0());
+  auto const stateAtPCA = tsAtClosestApproachTrackCand.trackStateAtPCA();
+  auto v0 = stateAtPCA.position();
+  auto p = stateAtPCA.momentum();
+  math::XYZPoint pos(v0.x(), v0.y(), v0.z());
+  math::XYZVector mom(p.x(), p.y(), p.z());
 
-  double dxy = (-v.x() * sin(p.phi()) + v.y() * cos(p.phi()));
-
-  double dz = v.z() - (v.x() * p.x() + v.y() * p.y()) / p.perp() * p.z() / p.perp();
+  //pseduo track for access to easy methods
+  reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
   
-  tensorflow::Tensor input1(tensorflow::DT_FLOAT, {1, 29});
-  tensorflow::Tensor input2(tensorflow::DT_FLOAT, {1, 1});
+  float dzmin = std::numeric_limits<float>::max();
+  float dxy_zmin=0;
 
-  //count recHits
+  for (auto const& vertex : *vertices) {
+     if (std::abs(trk.dz(vertex.position())) < dzmin ) {dzmin=trk.dz(vertex.position());dxy_zmin=trk.dxy(vertex.position());}
+  }
+
+
   // loop over the RecHits
-
   int ndof=0;
   int pix=0;
   int strip=0;
   for (auto const& recHit : tkC.recHits()) {
-     //std::cout << recHit.geographicalId().subdetId() << " thed det id "<< std::endl;
+     ndof+=recHit.dimension();
+     
      auto const subdet = recHit.geographicalId().subdetId();
-     if(subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap ) {pix++;ndof++;ndof++;}
-     else if(subdet == StripSubdetector::TEC || subdet == StripSubdetector::TID ) {strip++;ndof++;}
-     else if(subdet == StripSubdetector::TOB || subdet == StripSubdetector::TIB ) {strip++;ndof++;ndof++;}
+     if(subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap ) 
+       pix++;
+     else 
+       strip++;
+     
   }
+  ndof=ndof-5;
 
-  input1.matrix<float>()(0, 0) = sqrt(state.globalMomentum().perp2());
-  input1.matrix<float>()(0, 1) = p.x();
+  tensorflow::Tensor input1(tensorflow::DT_FLOAT, {1, 29});
+  tensorflow::Tensor input2(tensorflow::DT_FLOAT, {1, 1});
+  
+  input1.matrix<float>()(0, 0) = trk.pt();
+  input1.matrix<float>()(0, 1) = p.x(); //here everything is inner, also pt eta phi??
   input1.matrix<float>()(0, 2) = p.y();
   input1.matrix<float>()(0, 3) = p.z();
   input1.matrix<float>()(0, 4) = p.perp();
@@ -619,21 +647,21 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate &tkC, const reco::
   input1.matrix<float>()(0, 6) = p.y();
   input1.matrix<float>()(0, 7) = p.z();
   input1.matrix<float>()(0, 8) = p.perp();
-  input1.matrix<float>()(0, 9) = 0.001;//trk.ptError();
-  input1.matrix<float>()(0, 10) = dxy;//trk.dxy(bestVertex);
-  input1.matrix<float>()(0, 11) = dz;//trk.dz(bestVertex);
-  input1.matrix<float>()(0, 12) = dxy;
-  input1.matrix<float>()(0, 13) = dz;
-  input1.matrix<float>()(0, 14) = 0;//trk.dxyError();
-  input1.matrix<float>()(0, 15) = 0;//trk.dzError();
+  input1.matrix<float>()(0, 9) = trk.ptError();
+  input1.matrix<float>()(0, 10) = dxy_zmin;
+  input1.matrix<float>()(0, 11) = dzmin;
+  input1.matrix<float>()(0, 12) = trk.dxy(bs.position());
+  input1.matrix<float>()(0, 13) = trk.dz(bs.position());
+  input1.matrix<float>()(0, 14) = trk.dxyError();
+  input1.matrix<float>()(0, 15) = trk.dzError();
   input1.matrix<float>()(0, 16) = 1.3;
-  input1.matrix<float>()(0, 17) = state.globalPosition().eta();
-  input1.matrix<float>()(0, 18) = state.globalPosition().phi();
-  input1.matrix<float>()(0, 19) = 0.0001;//trk.etaError();
-  input1.matrix<float>()(0, 20) = 0.0001;//trk.phiError();
+  input1.matrix<float>()(0, 17) = trk.eta();
+  input1.matrix<float>()(0, 18) = trk.phi();
+  input1.matrix<float>()(0, 19) = trk.etaError();
+  input1.matrix<float>()(0, 20) = trk.phiError();
   input1.matrix<float>()(0, 21) = pix;//trk.hitPattern().numberOfValidPixelHits();
   input1.matrix<float>()(0, 22) = strip;//trk.hitPattern().numberOfValidStripHits();
-  input1.matrix<float>()(0, 23) = ndof-5;//trk.ndof();
+  input1.matrix<float>()(0, 23) = ndof;//trk.ndof();
   input1.matrix<float>()(0, 24) = 0;
   input1.matrix<float>()(0, 25) = 0;
   input1.matrix<float>()(0, 26) = 0;

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -101,15 +101,14 @@ private:
                                                                             const edm::OwnVector<TrackingRecHit>& hits,
                                                                             const Propagator& propagatorAlong,
                                                                             const Propagator& propagatorOpposite) const;
-                                                                            
-                     
+
   std::vector<float> computeDNNs(TrackCandidateCollection tkCC,
-                     const reco::BeamSpot& bs,
-                     const reco::VertexCollection* vertices,
-                     const MagneticField& theMF,
-                     const TransientTrackingRecHitBuilder& theTTRHBuilder,
-                     const tensorflow::Session* session,
-                     const std::vector<float> chi2) const;
+                                 const reco::BeamSpot& bs,
+                                 const reco::VertexCollection* vertices,
+                                 const MagneticField& theMF,
+                                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                 const tensorflow::Session* session,
+                                 const std::vector<float> chi2) const;
 
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -167,12 +166,13 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
       doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
-      algo_{reco::TrackBase::algoByName(TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
+      algo_{reco::TrackBase::algoByName(
+          TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
       algoCandSelection_{bool(iConfig.getParameter<bool>("candMVASel"))},
       algoCandWorkingPoint_{float(iConfig.getParameter<double>("candWP"))},
       bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
       verticesToken_(algoCandSelection_ ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
-                               : edm::EDGetTokenT<reco::VertexCollection>()),
+                                        : edm::EDGetTokenT<reco::VertexCollection>()),
       tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
       tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))) {}
 
@@ -275,7 +275,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
   LogTrace("MkFitOutputConverter") << "Number of candidates " << candidates.size();
 
   std::vector<float> chi2;
-  
+
   int candIndex = -1;
   for (const auto& cand : candidates) {
     ++candIndex;
@@ -439,18 +439,18 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         0,                                               // mkFit does not produce loopers, so set nLoops=0
         static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
     );
-    
-     chi2.push_back(cand.chi2());
-    
+
+    chi2.push_back(cand.chi2());
   }
-    
-  if(algoCandSelection_) {
-    const std::vector<float> DNNscores= computeDNNs (output, bs, vertices, mf, theTTRHBuilder, session, chi2);
-    for (int s=DNNscores.size()-1; s>=0; s--){
-    if(DNNscores[s]<=algoCandWorkingPoint_)  output.erase(output.begin()+s);
+
+  if (algoCandSelection_) {
+    const std::vector<float> DNNscores = computeDNNs(output, bs, vertices, mf, theTTRHBuilder, session, chi2);
+    for (int s = DNNscores.size() - 1; s >= 0; s--) {
+      if (DNNscores[s] <= algoCandWorkingPoint_)
+        output.erase(output.begin() + s);
     }
   }
-  
+
   return output;
 }
 
@@ -587,37 +587,32 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
   return std::make_pair(tsosDouble.first, det);
 }
 
-std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tkCC,
-                                         const reco::BeamSpot& bs,
-                                         const reco::VertexCollection* vertices,
-                                         const MagneticField& theMF,
-                                         const TransientTrackingRecHitBuilder& theTTRHBuilder,
-                                         const tensorflow::Session* session,
-                                         const std::vector<float> chi2) const {
-  
-  
+std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection tkCC,
+                                                     const reco::BeamSpot& bs,
+                                                     const reco::VertexCollection* vertices,
+                                                     const MagneticField& theMF,
+                                                     const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                                     const tensorflow::Session* session,
+                                                     const std::vector<float> chi2) const {
+  int size_in = (int)tkCC.size();
+  int bsize = 16;
+  int nbatches = size_in / bsize;
 
-  int size_in=(int)tkCC.size();
-  int bsize=16;
-  int nbatches=size_in/bsize;
-  
   std::vector<float> output;
   output.resize(size_in);
-  
+
   TSCBLBuilderNoMaterial tscblBuilder;
   auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(&theTTRHBuilder))->geometry();
-  
-  for (auto nb=0; nb<nbatches+1; nb++){
-    
+
+  for (auto nb = 0; nb < nbatches + 1; nb++) {
     // tensorflow part
     tensorflow::Tensor input1(tensorflow::DT_FLOAT, {bsize, 29});
     tensorflow::Tensor input2(tensorflow::DT_FLOAT, {bsize, 1});
-    
-    for (auto nt=0; nt<bsize; nt++)
-    {
-      
-      int itrack=nt+bsize*nb;
-      if (itrack>=size_in) continue;
+
+    for (auto nt = 0; nt < bsize; nt++) {
+      int itrack = nt + bsize * nb;
+      if (itrack >= size_in)
+        continue;
 
       auto const& tkC = tkCC.at(itrack);
       auto const& candSS = tkC.trajectoryStateOnDet();
@@ -664,7 +659,7 @@ std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tk
           strip++;
       }
       ndof = ndof - 5;
-      
+
       input1.matrix<float>()(nt, 0) = trk.pt();  //using inner track only
       input1.matrix<float>()(nt, 1) = p.x();
       input1.matrix<float>()(nt, 2) = p.y();
@@ -681,7 +676,7 @@ std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tk
       input1.matrix<float>()(nt, 13) = trk.dz(bs.position());
       input1.matrix<float>()(nt, 14) = trk.dxyError();
       input1.matrix<float>()(nt, 15) = trk.dzError();
-      input1.matrix<float>()(nt, 16) = chi2[itrack]/ndof;
+      input1.matrix<float>()(nt, 16) = chi2[itrack] / ndof;
       input1.matrix<float>()(nt, 17) = trk.eta();
       input1.matrix<float>()(nt, 18) = trk.phi();
       input1.matrix<float>()(nt, 19) = trk.etaError();
@@ -696,9 +691,8 @@ std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tk
       input1.matrix<float>()(nt, 28) = 0;
 
       input2.matrix<float>()(nt, 0) = algo_;
-
     }
-    
+
     //inputs finalized
     tensorflow::NamedTensorList inputs;
     inputs.resize(2);
@@ -708,17 +702,17 @@ std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tk
     //eval and rescale
     std::vector<tensorflow::Tensor> outputs;
     tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
-    
-    for (auto nt=0; nt<bsize; nt++)
-    {        
-        int itrack=nt+bsize*nb;
-        if (itrack>=size_in) continue;
-        
-        float out0 = 2.0 * outputs[0].matrix<float>()(nt, 0) - 1.0;
-        output[itrack]=out0;
+
+    for (auto nt = 0; nt < bsize; nt++) {
+      int itrack = nt + bsize * nb;
+      if (itrack >= size_in)
+        continue;
+
+      float out0 = 2.0 * outputs[0].matrix<float>()(nt, 0) - 1.0;
+      output[itrack] = out0;
     }
   }
-  
+
   return output;
 }
 

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -132,7 +132,7 @@ private:
   const bool qualitySignPt_;
 
   const bool doErrorRescale_;
-  
+
   const int algo_;
   const bool algoCandSelection_;
   const float algoCandWorkingPoint_;
@@ -446,7 +446,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
   }
 
   if (algoCandSelection_) {
-    const std::vector<float> DNNscores = computeDNNs(output, states, bs, vertices, session, chi2, mkFitOutput.propagatedToFirstLayer() && doErrorRescale_);
+    const std::vector<float> DNNscores = computeDNNs(
+        output, states, bs, vertices, session, chi2, mkFitOutput.propagatedToFirstLayer() && doErrorRescale_);
     for (int s = DNNscores.size() - 1; s >= 0; s--) {
       if (DNNscores[s] <= algoCandWorkingPoint_)
         output.erase(output.begin() + s);
@@ -616,11 +617,12 @@ std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection tk
         continue;
 
       auto const& tkC = tkCC.at(itrack);
-      
+
       TrajectoryStateOnSurface state = states.at(itrack);
-          
-      if(rescaledError) state.rescaleError(1/100.f);
-            
+
+      if (rescaledError)
+        state.rescaleError(1 / 100.f);
+
       TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
           tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
 

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -292,8 +292,6 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
           << "Candidate " << candIndex << " failed state quality checks" << cand.state().parameters;
       continue;
     }
-    
-    chi2.push_back(cand.chi2());
 
     auto state = cand.state();  // copy because have to modify
     state.convertFromCCSToGlbCurvilinear();
@@ -441,6 +439,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         0,                                               // mkFit does not produce loopers, so set nLoops=0
         static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
     );
+    
+     chi2.push_back(cand.chi2());
     
   }
     

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -86,7 +86,6 @@ private:
                                              const mkfit::TrackVec& mkFitSeeds,
                                              const reco::BeamSpot& bs,
                                              const reco::VertexCollection* vertices,
-                                             const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                              const tensorflow::Session* session) const;
 
   std::pair<TrajectoryStateOnSurface, const GeomDet*> backwardFit(const FreeTrajectoryState& fts,
@@ -246,7 +245,6 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
                                    mkfitSeeds.seeds(),
                                    beamspot,
                                    vertices,
-                                   ttrhBuilder,
                                    session));
 
   // TODO: SeedStopInfo is currently unfilled
@@ -266,7 +264,6 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const mkfit::TrackVec& mkFitSeeds,
                                                                  const reco::BeamSpot& bs,
                                                                  const reco::VertexCollection* vertices,
-                                                                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                                                  const tensorflow::Session* session) const {
   TrackCandidateCollection output;
   const auto& candidates = mkFitOutput.tracks();

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -84,7 +84,7 @@ private:
                                              const TkClonerImpl& hitCloner,
                                              const std::vector<const DetLayer*>& detLayers,
                                              const mkfit::TrackVec& mkFitSeeds,
-                                             const reco::BeamSpot& bs,
+                                             const reco::BeamSpot* bs,
                                              const reco::VertexCollection* vertices,
                                              const tensorflow::Session* session) const;
 
@@ -103,7 +103,7 @@ private:
 
   std::vector<float> computeDNNs(TrackCandidateCollection const& tkCC,
                                  const std::vector<TrajectoryStateOnSurface>& states,
-                                 const reco::BeamSpot& bs,
+                                 const reco::BeamSpot* bs,
                                  const reco::VertexCollection* vertices,
                                  const tensorflow::Session* session,
                                  const std::vector<float>& chi2,
@@ -169,7 +169,8 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
           TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
       algoCandSelection_{bool(iConfig.getParameter<bool>("candMVASel"))},
       algoCandWorkingPoint_{float(iConfig.getParameter<double>("candWP"))},
-      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+      bsToken_(algoCandSelection_ ? consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))
+                                  : edm::EDGetTokenT<reco::BeamSpot>()),
       verticesToken_(algoCandSelection_ ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
                                         : edm::EDGetTokenT<reco::VertexCollection>()),
       tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
@@ -216,19 +217,22 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
   }
   const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
 
-  edm::Handle<reco::BeamSpot> bsHandle;
-  iEvent.getByToken(bsToken_, bsHandle);
-  const reco::BeamSpot& beamspot = *bsHandle.product();
-
   // primary vertices under the algo_ because in initialStepPreSplitting there are no firstStepPrimaryVertices
+  // beamspot as well since the producer can be used in hlt
   const reco::VertexCollection* vertices = nullptr;
+  const reco::BeamSpot* beamspot = nullptr;
   if (algoCandSelection_) {
     edm::Handle<reco::VertexCollection> hVtx;
     iEvent.getByToken(verticesToken_, hVtx);
     vertices = hVtx.product();
+    edm::Handle<reco::BeamSpot> hBs;
+    iEvent.getByToken(bsToken_, hBs);
+    beamspot = hBs.product();
   }
 
-  const tensorflow::Session* session = iSetup.getData(tfDnnToken_).getSession();
+  const tensorflow::Session* session = nullptr;
+  if (algoCandSelection_)
+    session = iSetup.getData(tfDnnToken_).getSession();
 
   // Convert mkfit presentation back to CMSSW
   iEvent.emplace(putTrackCandidateToken_,
@@ -262,7 +266,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const TkClonerImpl& hitCloner,
                                                                  const std::vector<const DetLayer*>& detLayers,
                                                                  const mkfit::TrackVec& mkFitSeeds,
-                                                                 const reco::BeamSpot& bs,
+                                                                 const reco::BeamSpot* bs,
                                                                  const reco::VertexCollection* vertices,
                                                                  const tensorflow::Session* session) const {
   TrackCandidateCollection output;
@@ -597,7 +601,7 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
 
 std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection const& tkCC,
                                                      const std::vector<TrajectoryStateOnSurface>& states,
-                                                     const reco::BeamSpot& bs,
+                                                     const reco::BeamSpot* bs,
                                                      const reco::VertexCollection* vertices,
                                                      const tensorflow::Session* session,
                                                      const std::vector<float>& chi2,
@@ -628,7 +632,7 @@ std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection co
         state.rescaleError(1 / 100.f);
 
       TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
-          tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
+          tscblBuilder(*state.freeState(), *bs);  //as in TrackProducerAlgorithm
 
       if (!(tsAtClosestApproachTrackCand.isValid())) {
         edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
@@ -681,8 +685,8 @@ std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection co
       input1.matrix<float>()(nt, 9) = trk.ptError();
       input1.matrix<float>()(nt, 10) = dxy_zmin;
       input1.matrix<float>()(nt, 11) = dzmin;
-      input1.matrix<float>()(nt, 12) = trk.dxy(bs.position());
-      input1.matrix<float>()(nt, 13) = trk.dz(bs.position());
+      input1.matrix<float>()(nt, 12) = trk.dxy(bs->position());
+      input1.matrix<float>()(nt, 13) = trk.dz(bs->position());
       input1.matrix<float>()(nt, 14) = trk.dxyError();
       input1.matrix<float>()(nt, 15) = trk.dzError();
       input1.matrix<float>()(nt, 16) = chi2[itrack] / ndof;

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -101,14 +101,15 @@ private:
                                                                             const edm::OwnVector<TrackingRecHit>& hits,
                                                                             const Propagator& propagatorAlong,
                                                                             const Propagator& propagatorOpposite) const;
-
-  float computeTFDNN(const TrackCandidate& tkC,
+                                                                            
+                     
+  std::vector<float> computeDNNs(TrackCandidateCollection tkCC,
                      const reco::BeamSpot& bs,
                      const reco::VertexCollection* vertices,
                      const MagneticField& theMF,
                      const TransientTrackingRecHitBuilder& theTTRHBuilder,
                      const tensorflow::Session* session,
-                     const float chi2) const;
+                     const std::vector<float> chi2) const;
 
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -273,6 +274,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
 
   LogTrace("MkFitOutputConverter") << "Number of candidates " << candidates.size();
 
+  std::vector<float> chi2;
+  
   int candIndex = -1;
   for (const auto& cand : candidates) {
     ++candIndex;
@@ -289,6 +292,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
           << "Candidate " << candIndex << " failed state quality checks" << cand.state().parameters;
       continue;
     }
+    
+    chi2.push_back(cand.chi2());
 
     auto state = cand.state();  // copy because have to modify
     state.convertFromCCSToGlbCurvilinear();
@@ -428,30 +433,24 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     // convert to persistent, from CkfTrackCandidateMakerBase
     auto pstate = trajectoryStateTransform::persistentState(tsosDet.first, tsosDet.second->geographicalId().rawId());
 
-    if (!algoCandSelection_)  //default
-    {
-      output.emplace_back(
-          recHits,
-          seeds.at(seedIndex),
-          pstate,
-          seeds.refAt(seedIndex),
-          0,                                               // mkFit does not produce loopers, so set nLoops=0
-          static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
-      );
-    } else  //exception
-    {
-      const TrackCandidate cmsswcand = TrackCandidate(recHits,
-                                                      seeds.at(seedIndex),
-                                                      pstate,
-                                                      seeds.refAt(seedIndex),
-                                                      0,
-                                                      static_cast<uint8_t>(StopReason::UNINITIALIZED));
-      float disc = computeTFDNN(cmsswcand, bs, vertices, mf, theTTRHBuilder, session, cand.chi2());
-      if (disc > algoCandWorkingPoint_) {
-        output.push_back(cmsswcand);
-      }
-    }  //exception
+    output.emplace_back(
+        recHits,
+        seeds.at(seedIndex),
+        pstate,
+        seeds.refAt(seedIndex),
+        0,                                               // mkFit does not produce loopers, so set nLoops=0
+        static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
+    );
+    
   }
+    
+  if(algoCandSelection_) {
+    const std::vector<float> DNNscores= computeDNNs (output, bs, vertices, mf, theTTRHBuilder, session, chi2);
+    for (int s=DNNscores.size()-1; s>=0; s--){
+    if(DNNscores[s]<=algoCandWorkingPoint_)  output.erase(output.begin()+s);
+    }
+  }
+  
   return output;
 }
 
@@ -588,108 +587,138 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
   return std::make_pair(tsosDouble.first, det);
 }
 
-float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
+std::vector<float>MkFitOutputConverter::computeDNNs (TrackCandidateCollection tkCC,
                                          const reco::BeamSpot& bs,
                                          const reco::VertexCollection* vertices,
                                          const MagneticField& theMF,
                                          const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                          const tensorflow::Session* session,
-                                         const float chi2) const {
+                                         const std::vector<float> chi2) const {
+  
+  
+
+  int size_in=(int)tkCC.size();
+  int bsize=16;
+  int nbatches=size_in/bsize;
+  
+  std::vector<float> output;
+  output.resize(size_in);
+  
   TSCBLBuilderNoMaterial tscblBuilder;
-
-  //get parameters and errors from the candidate state
   auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(&theTTRHBuilder))->geometry();
-  auto const& candSS = tkC.trajectoryStateOnDet();
-  TrajectoryStateOnSurface state =
-      trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
-  TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
-      tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
+  
+  for (auto nb=0; nb<nbatches+1; nb++){
+    
+    // tensorflow part
+    tensorflow::Tensor input1(tensorflow::DT_FLOAT, {bsize, 29});
+    tensorflow::Tensor input2(tensorflow::DT_FLOAT, {bsize, 1});
+    
+    for (auto nt=0; nt<bsize; nt++)
+    {
+      
+      int itrack=nt+bsize*nb;
+      if (itrack>=size_in) continue;
 
-  if (!(tsAtClosestApproachTrackCand.isValid())) {
-    edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
-    return 0;
-  }
+      auto const& tkC = tkCC.at(itrack);
+      auto const& candSS = tkC.trajectoryStateOnDet();
+      TrajectoryStateOnSurface state =
+          trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
+      TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
+          tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
 
-  auto const& stateAtPCA = tsAtClosestApproachTrackCand.trackStateAtPCA();
-  auto v0 = stateAtPCA.position();
-  auto p = stateAtPCA.momentum();
-  math::XYZPoint pos(v0.x(), v0.y(), v0.z());
-  math::XYZVector mom(p.x(), p.y(), p.z());
+      if (!(tsAtClosestApproachTrackCand.isValid())) {
+        edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
+        continue;
+      }
 
-  //pseudo track for access to easy methods
-  reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
+      auto const& stateAtPCA = tsAtClosestApproachTrackCand.trackStateAtPCA();
+      auto v0 = stateAtPCA.position();
+      auto p = stateAtPCA.momentum();
+      math::XYZPoint pos(v0.x(), v0.y(), v0.z());
+      math::XYZVector mom(p.x(), p.y(), p.z());
 
-  // get best vertex
-  float dzmin = std::numeric_limits<float>::max();
-  float dxy_zmin = 0;
+      //pseudo track for access to easy methods
+      reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
 
-  for (auto const& vertex : *vertices) {
-    if (std::abs(trk.dz(vertex.position())) < dzmin) {
-      dzmin = trk.dz(vertex.position());
-      dxy_zmin = trk.dxy(vertex.position());
+      // get best vertex
+      float dzmin = std::numeric_limits<float>::max();
+      float dxy_zmin = 0;
+
+      for (auto const& vertex : *vertices) {
+        if (std::abs(trk.dz(vertex.position())) < dzmin) {
+          dzmin = trk.dz(vertex.position());
+          dxy_zmin = trk.dxy(vertex.position());
+        }
+      }
+
+      // loop over the RecHits
+      int ndof = 0;
+      int pix = 0;
+      int strip = 0;
+      for (auto const& recHit : tkC.recHits()) {
+        ndof += recHit.dimension();
+        auto const subdet = recHit.geographicalId().subdetId();
+        if (subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap)
+          pix++;
+        else
+          strip++;
+      }
+      ndof = ndof - 5;
+      
+      input1.matrix<float>()(nt, 0) = trk.pt();  //using inner track only
+      input1.matrix<float>()(nt, 1) = p.x();
+      input1.matrix<float>()(nt, 2) = p.y();
+      input1.matrix<float>()(nt, 3) = p.z();
+      input1.matrix<float>()(nt, 4) = p.perp();
+      input1.matrix<float>()(nt, 5) = p.x();
+      input1.matrix<float>()(nt, 6) = p.y();
+      input1.matrix<float>()(nt, 7) = p.z();
+      input1.matrix<float>()(nt, 8) = p.perp();
+      input1.matrix<float>()(nt, 9) = trk.ptError();
+      input1.matrix<float>()(nt, 10) = dxy_zmin;
+      input1.matrix<float>()(nt, 11) = dzmin;
+      input1.matrix<float>()(nt, 12) = trk.dxy(bs.position());
+      input1.matrix<float>()(nt, 13) = trk.dz(bs.position());
+      input1.matrix<float>()(nt, 14) = trk.dxyError();
+      input1.matrix<float>()(nt, 15) = trk.dzError();
+      input1.matrix<float>()(nt, 16) = chi2[itrack]/ndof;
+      input1.matrix<float>()(nt, 17) = trk.eta();
+      input1.matrix<float>()(nt, 18) = trk.phi();
+      input1.matrix<float>()(nt, 19) = trk.etaError();
+      input1.matrix<float>()(nt, 20) = trk.phiError();
+      input1.matrix<float>()(nt, 21) = pix;    //trk.hitPattern().numberOfValidPixelHits();
+      input1.matrix<float>()(nt, 22) = strip;  //trk.hitPattern().numberOfValidStripHits();
+      input1.matrix<float>()(nt, 23) = ndof;   //trk.ndof();
+      input1.matrix<float>()(nt, 24) = 0;
+      input1.matrix<float>()(nt, 25) = 0;
+      input1.matrix<float>()(nt, 26) = 0;
+      input1.matrix<float>()(nt, 27) = 0;
+      input1.matrix<float>()(nt, 28) = 0;
+
+      input2.matrix<float>()(nt, 0) = algo_;
+
+    }
+    
+    //inputs finalized
+    tensorflow::NamedTensorList inputs;
+    inputs.resize(2);
+    inputs[0] = tensorflow::NamedTensor("x", input1);
+    inputs[1] = tensorflow::NamedTensor("y", input2);
+
+    //eval and rescale
+    std::vector<tensorflow::Tensor> outputs;
+    tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
+    
+    for (auto nt=0; nt<bsize; nt++)
+    {        
+        int itrack=nt+bsize*nb;
+        if (itrack>=size_in) continue;
+        
+        float out0 = 2.0 * outputs[0].matrix<float>()(nt, 0) - 1.0;
+        output[itrack]=out0;
     }
   }
-
-  // loop over the RecHits
-  int ndof = 0;
-  int pix = 0;
-  int strip = 0;
-  for (auto const& recHit : tkC.recHits()) {
-    ndof += recHit.dimension();
-    auto const subdet = recHit.geographicalId().subdetId();
-    if (subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap)
-      pix++;
-    else
-      strip++;
-  }
-  ndof = ndof - 5;
-
-  // tensorflow part
-  tensorflow::Tensor input1(tensorflow::DT_FLOAT, {1, 29});
-  tensorflow::Tensor input2(tensorflow::DT_FLOAT, {1, 1});
-
-  input1.matrix<float>()(0, 0) = trk.pt();  //using inner track only
-  input1.matrix<float>()(0, 1) = p.x();
-  input1.matrix<float>()(0, 2) = p.y();
-  input1.matrix<float>()(0, 3) = p.z();
-  input1.matrix<float>()(0, 4) = p.perp();
-  input1.matrix<float>()(0, 5) = p.x();
-  input1.matrix<float>()(0, 6) = p.y();
-  input1.matrix<float>()(0, 7) = p.z();
-  input1.matrix<float>()(0, 8) = p.perp();
-  input1.matrix<float>()(0, 9) = trk.ptError();
-  input1.matrix<float>()(0, 10) = dxy_zmin;
-  input1.matrix<float>()(0, 11) = dzmin;
-  input1.matrix<float>()(0, 12) = trk.dxy(bs.position());
-  input1.matrix<float>()(0, 13) = trk.dz(bs.position());
-  input1.matrix<float>()(0, 14) = trk.dxyError();
-  input1.matrix<float>()(0, 15) = trk.dzError();
-  input1.matrix<float>()(0, 16) = chi2 / ndof;
-  input1.matrix<float>()(0, 17) = trk.eta();
-  input1.matrix<float>()(0, 18) = trk.phi();
-  input1.matrix<float>()(0, 19) = trk.etaError();
-  input1.matrix<float>()(0, 20) = trk.phiError();
-  input1.matrix<float>()(0, 21) = pix;    //trk.hitPattern().numberOfValidPixelHits();
-  input1.matrix<float>()(0, 22) = strip;  //trk.hitPattern().numberOfValidStripHits();
-  input1.matrix<float>()(0, 23) = ndof;   //trk.ndof();
-  input1.matrix<float>()(0, 24) = 0;
-  input1.matrix<float>()(0, 25) = 0;
-  input1.matrix<float>()(0, 26) = 0;
-  input1.matrix<float>()(0, 27) = 0;
-  input1.matrix<float>()(0, 28) = 0;
-
-  input2.matrix<float>()(0, 0) = algo_;
-
-  //inputs finalized
-  tensorflow::NamedTensorList inputs;
-  inputs.resize(2);
-  inputs[0] = tensorflow::NamedTensor("x", input1);
-  inputs[1] = tensorflow::NamedTensor("y", input2);
-
-  //eval and rescale
-  std::vector<tensorflow::Tensor> outputs;
-  tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
-  float output = 2.0 * outputs[0].matrix<float>()(0, 0) - 1.0;
+  
   return output;
 }
 

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -41,28 +41,13 @@
 #include "RecoTracker/MkFitCore/interface/Track.h"
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
-//copied from TrackTfClassifier
-//remove as much as possible
-#include "RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "RecoTracker/FinalTrackSelectors/interface/getBestVertex.h"
-
+//extra for DNN with cands
 #include "TrackingTools/Records/interface/TfGraphRecord.h"
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
 #include "RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h"
-
-#include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
-
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 namespace {
   template <typename T>
@@ -123,10 +108,7 @@ private:
                      const MagneticField& theMF,
                      const TransientTrackingRecHitBuilder& theTTRHBuilder,
                      const tensorflow::Session* session,
-                     int algo,
-                     float chi2) const;
-
-  const int flag_;
+                     const float chi2) const;
 
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -134,8 +116,6 @@ private:
   const edm::EDGetTokenT<MkFitSeedWrapper> mkfitSeedToken_;
   const edm::EDGetTokenT<MkFitOutputWrapper> tracksToken_;
   const edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
-  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
-  const edm::EDGetTokenT<reco::VertexCollection> vertices_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
@@ -153,22 +133,21 @@ private:
 
   const bool doErrorRescale_;
   
+  const int algo_;
+  const float algoCandWorkingPoint_;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
   const std::string tfDnnLabel_;
   const edm::ESGetToken<TfGraphDefWrapper, TfGraphRecord> tfDnnToken_;
-  const int algo_;
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
-    : flag_{int(iConfig.getParameter<int>("flag"))},
-      eventOfHitsToken_{consumes<MkFitEventOfHits>(iConfig.getParameter<edm::InputTag>("mkFitEventOfHits"))},
+    : eventOfHitsToken_{consumes<MkFitEventOfHits>(iConfig.getParameter<edm::InputTag>("mkFitEventOfHits"))},
       pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitPixelHits"))},
       stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitStripHits"))},
       mkfitSeedToken_{consumes<MkFitSeedWrapper>(iConfig.getParameter<edm::InputTag>("mkFitSeeds"))},
       tracksToken_{consumes<MkFitOutputWrapper>(iConfig.getParameter<edm::InputTag>("tracks"))},
       seedToken_{consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("seeds"))},
-      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
-      vertices_(flag_ > 0 ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
-                          : edm::EDGetTokenT<reco::VertexCollection>()),
       propagatorAlongToken_{
           esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
       propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
@@ -186,9 +165,13 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
       doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
+      algo_{int(iConfig.getParameter<int>("algo"))},
+      algoCandWorkingPoint_{float(iConfig.getParameter<double>("candWP"))},
+      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+      verticesToken_(algo_ > 0 ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
+                               : edm::EDGetTokenT<reco::VertexCollection>()),
       tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
-      tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))),
-      algo_{int(iConfig.getParameter<int>("algo"))} {}
+      tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))) {}
 
 void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -214,8 +197,8 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
 
-  desc.add<int>("algo", 0)->setComment("algo used to check which iteration");
-  desc.add<int>("flag", 0)->setComment("flag used to check vtx iter");
+  desc.add<int>("algo", 0)->setComment("flag used to trigger MVA selection at cand level and store algo number");
+  desc.add<double>("candWP", 0)->setComment("MVA selection at cand level working point");
 
   descriptions.addWithDefaultLabel(desc);
 }
@@ -235,11 +218,11 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
   iEvent.getByToken(bsToken_, bsHandle);
   const reco::BeamSpot& beamspot = *bsHandle.product();
 
-  // Select good primary vertices for use in subsequent track selection
+  // primary vertices under the algo_ because in initialStepPreSplitting there are no firstStepPrimaryVertices
   const reco::VertexCollection* vertices = nullptr;
-  if (algo_ > 0 && flag_ > 0) {
+  if (algo_ > 0) {
     edm::Handle<reco::VertexCollection> hVtx;
-    iEvent.getByToken(vertices_, hVtx);
+    iEvent.getByToken(verticesToken_, hVtx);
     vertices = hVtx.product();
   }
 
@@ -461,8 +444,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                       seeds.refAt(seedIndex),
                                                       0,
                                                       static_cast<uint8_t>(StopReason::UNINITIALIZED));
-      float disc = computeTFDNN(cmsswcand, bs, vertices, mf, theTTRHBuilder, session, algo_, cand.chi2());
-      if (disc > -0.5) {
+      float disc = computeTFDNN(cmsswcand, bs, vertices, mf, theTTRHBuilder, session, cand.chi2());
+      if (disc > algoCandWorkingPoint_) {
         output.push_back(cmsswcand);
       }
     }  //exception
@@ -609,8 +592,7 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
                                          const MagneticField& theMF,
                                          const TransientTrackingRecHitBuilder& theTTRHBuilder,
                                          const tensorflow::Session* session,
-                                         int algo,
-                                         float chi2) const {
+                                         const float chi2) const {
   TSCBLBuilderNoMaterial tscblBuilder;
 
   //get parameters and errors from the candidate state
@@ -620,6 +602,7 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
       trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
   TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
       tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
+
   if (!(tsAtClosestApproachTrackCand.isValid())) {
     edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
     return 0;
@@ -631,9 +614,10 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
   math::XYZPoint pos(v0.x(), v0.y(), v0.z());
   math::XYZVector mom(p.x(), p.y(), p.z());
 
-  //pseduo track for access to easy methods
+  //pseudo track for access to easy methods
   reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
 
+  // get best vertex
   float dzmin = std::numeric_limits<float>::max();
   float dxy_zmin = 0;
 
@@ -650,7 +634,6 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
   int strip = 0;
   for (auto const& recHit : tkC.recHits()) {
     ndof += recHit.dimension();
-
     auto const subdet = recHit.geographicalId().subdetId();
     if (subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap)
       pix++;
@@ -659,11 +642,12 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
   }
   ndof = ndof - 5;
 
+  // tensorflow part
   tensorflow::Tensor input1(tensorflow::DT_FLOAT, {1, 29});
   tensorflow::Tensor input2(tensorflow::DT_FLOAT, {1, 1});
 
-  input1.matrix<float>()(0, 0) = trk.pt();
-  input1.matrix<float>()(0, 1) = p.x();  //here everything is inner, also pt eta phi??
+  input1.matrix<float>()(0, 0) = trk.pt();  //using inner track only
+  input1.matrix<float>()(0, 1) = p.x();
   input1.matrix<float>()(0, 2) = p.y();
   input1.matrix<float>()(0, 3) = p.z();
   input1.matrix<float>()(0, 4) = p.perp();
@@ -692,18 +676,17 @@ float MkFitOutputConverter::computeTFDNN(const TrackCandidate& tkC,
   input1.matrix<float>()(0, 27) = 0;
   input1.matrix<float>()(0, 28) = 0;
 
-  //update later from TrackBase
-  input2.matrix<float>()(0, 0) = algo;
+  input2.matrix<float>()(0, 0) = algo_;
 
+  //inputs finalized
   tensorflow::NamedTensorList inputs;
   inputs.resize(2);
   inputs[0] = tensorflow::NamedTensor("x", input1);
   inputs[1] = tensorflow::NamedTensor("y", input2);
-  std::vector<tensorflow::Tensor> outputs;
 
-  //evaluate the input
+  //eval and rescale
+  std::vector<tensorflow::Tensor> outputs;
   tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
-  //scale output to be [-1, 1] due to convention
   float output = 2.0 * outputs[0].matrix<float>()(0, 0) - 1.0;
   return output;
 }

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -41,6 +41,26 @@
 #include "RecoTracker/MkFitCore/interface/Track.h"
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
+//copied from TrackTfClassifier
+//remove as much as possible
+#include "RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "RecoTracker/FinalTrackSelectors/interface/getBestVertex.h"
+
+#include "TrackingTools/Records/interface/TfGraphRecord.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h"
+
+#include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
+
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
 namespace {
   template <typename T>
   bool isBarrel(T subdet) {
@@ -61,7 +81,6 @@ public:
   ~MkFitOutputConverter() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-
 private:
   void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
@@ -75,7 +94,9 @@ private:
                                              const Propagator& propagatorOpposite,
                                              const TkClonerImpl& hitCloner,
                                              const std::vector<const DetLayer*>& detLayers,
-                                             const mkfit::TrackVec& mkFitSeeds) const;
+                                             const mkfit::TrackVec& mkFitSeeds,
+                                             const reco::BeamSpot& bs,
+                                             const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const;
 
   std::pair<TrajectoryStateOnSurface, const GeomDet*> backwardFit(const FreeTrajectoryState& fts,
                                                                   const edm::OwnVector<TrackingRecHit>& hits,
@@ -89,6 +110,8 @@ private:
                                                                             const edm::OwnVector<TrackingRecHit>& hits,
                                                                             const Propagator& propagatorAlong,
                                                                             const Propagator& propagatorOpposite) const;
+                                                                            
+  float computeTFDNN(const TrackCandidate& tkC, const reco::BeamSpot& bs, const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const;
 
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -96,6 +119,7 @@ private:
   const edm::EDGetTokenT<MkFitSeedWrapper> mkfitSeedToken_;
   const edm::EDGetTokenT<MkFitOutputWrapper> tracksToken_;
   const edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
@@ -112,6 +136,11 @@ private:
   const bool qualitySignPt_;
 
   const bool doErrorRescale_;
+  
+  const std::string tfDnnLabel_;
+  const edm::ESGetToken<TfGraphDefWrapper, TfGraphRecord> tfDnnToken_;
+  const int algo_;
+
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
@@ -121,6 +150,7 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       mkfitSeedToken_{consumes<MkFitSeedWrapper>(iConfig.getParameter<edm::InputTag>("mkFitSeeds"))},
       tracksToken_{consumes<MkFitOutputWrapper>(iConfig.getParameter<edm::InputTag>("tracks"))},
       seedToken_{consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("seeds"))},
+      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
       propagatorAlongToken_{
           esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
       propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
@@ -137,7 +167,10 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
-      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")} {}
+      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
+      tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
+      tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))),
+      algo_{int(iConfig.getParameter<int>("algo"))} {}
 
 void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -161,6 +194,10 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<bool>("doErrorRescale", true)->setComment("rescale candidate error before final fit");
 
+  desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
+   
+  desc.add<int>("algo", 0)->setComment("algo used to check which iteration");  
+ 
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -174,6 +211,12 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
     throw cms::Exception("LogicError") << "TTRHBuilder must be of type TkTransientTrackingRecHitBuilder";
   }
   const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
+  
+  edm::Handle<reco::BeamSpot> bsHandle;
+  iEvent.getByToken(bsToken_, bsHandle);
+  const reco::BeamSpot &beamspot = *bsHandle.product();
+  
+  const tensorflow::Session* session = iSetup.getData(tfDnnToken_).getSession(); 
 
   // Convert mkfit presentation back to CMSSW
   iEvent.emplace(putTrackCandidateToken_,
@@ -187,7 +230,9 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
                                    iSetup.getData(propagatorOppositeToken_),
                                    tkBuilder->cloner(),
                                    mkFitGeom.detLayers(),
-                                   mkfitSeeds.seeds()));
+                                   mkfitSeeds.seeds(),
+                                   beamspot,
+                                   ttrhBuilder, session));
 
   // TODO: SeedStopInfo is currently unfilled
   iEvent.emplace(putSeedStopInfoToken_, seeds.size());
@@ -203,7 +248,9 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const Propagator& propagatorOpposite,
                                                                  const TkClonerImpl& hitCloner,
                                                                  const std::vector<const DetLayer*>& detLayers,
-                                                                 const mkfit::TrackVec& mkFitSeeds) const {
+                                                                 const mkfit::TrackVec& mkFitSeeds,
+                                                                 const reco::BeamSpot& bs,
+                                                                 const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const {
   TrackCandidateCollection output;
   const auto& candidates = mkFitOutput.tracks();
   output.reserve(candidates.size());
@@ -365,14 +412,28 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     // convert to persistent, from CkfTrackCandidateMakerBase
     auto pstate = trajectoryStateTransform::persistentState(tsosDet.first, tsosDet.second->geographicalId().rawId());
 
-    output.emplace_back(
-        recHits,
-        seeds.at(seedIndex),
-        pstate,
-        seeds.refAt(seedIndex),
-        0,                                               // mkFit does not produce loopers, so set nLoops=0
-        static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
-    );
+    //if (algo_>0) std::cout << algo_<< " ALGOINTN"<< std::endl;
+    if (algo_!=9)
+    {    
+      output.emplace_back(
+          recHits,
+          seeds.at(seedIndex),
+          pstate,
+          seeds.refAt(seedIndex),
+          0,                                               // mkFit does not produce loopers, so set nLoops=0
+          static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
+      );
+    }
+    else
+    {
+    const TrackCandidate cmsswcand = TrackCandidate( recHits, seeds.at(seedIndex), pstate, seeds.refAt(seedIndex),  0,  static_cast<uint8_t>(StopReason::UNINITIALIZED) );
+    float disc = computeTFDNN(cmsswcand, bs, mf, theTTRHBuilder, session);
+    if(disc>-0.8)
+    {
+      output.push_back(cmsswcand);
+     //std::cout << " c " <<candidates.size() << " OUTPUT size " <<output.size()<< std::endl; 
+    }     
+    }//exception
   }
   return output;
 }
@@ -508,6 +569,94 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
   }
 
   return std::make_pair(tsosDouble.first, det);
+}
+
+float MkFitOutputConverter::computeTFDNN(const TrackCandidate &tkC, const reco::BeamSpot& bs, const MagneticField& theMF, const TransientTrackingRecHitBuilder& theTTRHBuilder, const tensorflow::Session* session) const{
+  
+  TSCBLBuilderNoMaterial tscblBuilder;
+
+  //get parameters and errors from the candidate state
+  auto const& theG = ((TkTransientTrackingRecHitBuilder const*)(&theTTRHBuilder))->geometry();
+  auto const& candSS = tkC.trajectoryStateOnDet();
+  TrajectoryStateOnSurface state = trajectoryStateTransform::transientState(candSS, &(theG->idToDet(candSS.detId())->surface()), &theMF);
+  TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand = tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
+  if (!(tsAtClosestApproachTrackCand.isValid())) {
+    edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
+    return 0;
+  }
+  
+  GlobalPoint v0 = tsAtClosestApproachTrackCand.trackStateAtPCA().position();
+  GlobalVector p = tsAtClosestApproachTrackCand.trackStateAtPCA().momentum();
+  GlobalPoint v(v0.x() - bs.x0(), v0.y() - bs.y0(), v0.z() - bs.z0());
+
+  double dxy = (-v.x() * sin(p.phi()) + v.y() * cos(p.phi()));
+
+  double dz = v.z() - (v.x() * p.x() + v.y() * p.y()) / p.perp() * p.z() / p.perp();
+  
+  tensorflow::Tensor input1(tensorflow::DT_FLOAT, {1, 29});
+  tensorflow::Tensor input2(tensorflow::DT_FLOAT, {1, 1});
+
+  //count recHits
+  // loop over the RecHits
+
+  int ndof=0;
+  int pix=0;
+  int strip=0;
+  for (auto const& recHit : tkC.recHits()) {
+     //std::cout << recHit.geographicalId().subdetId() << " thed det id "<< std::endl;
+     auto const subdet = recHit.geographicalId().subdetId();
+     if(subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap ) {pix++;ndof++;ndof++;}
+     else if(subdet == StripSubdetector::TEC || subdet == StripSubdetector::TID ) {strip++;ndof++;}
+     else if(subdet == StripSubdetector::TOB || subdet == StripSubdetector::TIB ) {strip++;ndof++;ndof++;}
+  }
+
+  input1.matrix<float>()(0, 0) = sqrt(state.globalMomentum().perp2());
+  input1.matrix<float>()(0, 1) = p.x();
+  input1.matrix<float>()(0, 2) = p.y();
+  input1.matrix<float>()(0, 3) = p.z();
+  input1.matrix<float>()(0, 4) = p.perp();
+  input1.matrix<float>()(0, 5) = p.x();
+  input1.matrix<float>()(0, 6) = p.y();
+  input1.matrix<float>()(0, 7) = p.z();
+  input1.matrix<float>()(0, 8) = p.perp();
+  input1.matrix<float>()(0, 9) = 0.001;//trk.ptError();
+  input1.matrix<float>()(0, 10) = dxy;//trk.dxy(bestVertex);
+  input1.matrix<float>()(0, 11) = dz;//trk.dz(bestVertex);
+  input1.matrix<float>()(0, 12) = dxy;
+  input1.matrix<float>()(0, 13) = dz;
+  input1.matrix<float>()(0, 14) = 0;//trk.dxyError();
+  input1.matrix<float>()(0, 15) = 0;//trk.dzError();
+  input1.matrix<float>()(0, 16) = 1.3;
+  input1.matrix<float>()(0, 17) = state.globalPosition().eta();
+  input1.matrix<float>()(0, 18) = state.globalPosition().phi();
+  input1.matrix<float>()(0, 19) = 0.0001;//trk.etaError();
+  input1.matrix<float>()(0, 20) = 0.0001;//trk.phiError();
+  input1.matrix<float>()(0, 21) = pix;//trk.hitPattern().numberOfValidPixelHits();
+  input1.matrix<float>()(0, 22) = strip;//trk.hitPattern().numberOfValidStripHits();
+  input1.matrix<float>()(0, 23) = ndof-5;//trk.ndof();
+  input1.matrix<float>()(0, 24) = 0;
+  input1.matrix<float>()(0, 25) = 0;
+  input1.matrix<float>()(0, 26) = 0;
+  input1.matrix<float>()(0, 27) = 0;
+  input1.matrix<float>()(0, 28) = 0;
+
+  //Original algo as its own input, it will enter the graph so that it gets one-hot encoded, as is the preferred
+  //format for categorical inputs, where the labels do not have any metric amongst them
+  input2.matrix<float>()(0, 0) = 9;
+  
+  tensorflow::NamedTensorList inputs;
+  inputs.resize(2);
+  inputs[0] = tensorflow::NamedTensor("x", input1);
+  inputs[1] = tensorflow::NamedTensor("y", input2);
+  std::vector<tensorflow::Tensor> outputs;
+  
+  //evaluate the input
+  tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
+  //scale output to be [-1, 1] due to convention
+  float output = 2.0 * outputs[0].matrix<float>()(0, 0) - 1.0;
+  //std::cout << output << std::endl;
+  return output;
+
 }
 
 DEFINE_FWK_MODULE(MkFitOutputConverter);

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -444,7 +444,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     {
     const TrackCandidate cmsswcand = TrackCandidate( recHits, seeds.at(seedIndex), pstate, seeds.refAt(seedIndex),  0,  static_cast<uint8_t>(StopReason::UNINITIALIZED) );
     float disc = computeTFDNN(cmsswcand, bs, vertices, mf, theTTRHBuilder, session, cand.nInsideMinusOneHits(), cand.chi2());
-    if(disc>-0.8)
+    if(disc>-0.7)
     {
       output.push_back(cmsswcand);
      //std::cout << " c " <<candidates.size() << " OUTPUT size " <<output.size()<< std::endl; 


### PR DESCRIPTION
#### PR description:

this PR addresses the conflicts in 95+ most of the comments

the cand DNN evaluation was in conflict with the error scaling and rescaling back was needed. (the rescaling here https://github.com/cms-sw/cmssw/blob/master/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc#L354 changes the error slightly and to have the same numbers as without rescaling one would have to do it just one step later, in  tsosDet.first)
the result is compatible anyway.

this PR improves timing, while the physics is compatible.

#### PR validation:

timing in iterations where DNN cand selection is applied
![image](https://user-images.githubusercontent.com/7805577/167452073-481d2767-2943-49c8-a9ae-d97fda43a860.png)
![image](https://user-images.githubusercontent.com/7805577/167453073-f8d14ea1-9f92-48d4-b716-f1dfe820ceb2.png)


timing global 
![image](https://user-images.githubusercontent.com/7805577/167452360-e8434b7a-1b6c-41a4-a013-aaea46a836ce.png)

physics validation
http://uaf-10.t2.ucsd.edu/~legianni/test-2configurations-html/

profiling with igprof

- mem
  before  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/NODNNMEM
  after  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/DNNMEM

- cpu
  before  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/NODNNCPU
  after  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/DNNCPU

