### PR TITLE
take magnetic field scale from GT in mkFit

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -251,7 +251,6 @@ std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
 
   const float bz0 = iRecord.get(mfToken_).inTesla(GlobalPoint(0, 0, 0)).z();
   const float bScale = std::abs(bz0) / Config::mag_c1;
-  edm::LogWarning("MYDEBUG") << "Loaded field scale " << bScale;
   it_conf->m_bScale = bScale;
   return it_conf;
 }

--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -213,21 +213,21 @@ public:
   std::unique_ptr<mkfit::IterationConfig> produce(const MkFitComponentsRecord &iRecord);
 
 private:
-  MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig, edm::ESConsumesCollectorT<MkFitComponentsRecord>&&);
-  const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> geomToken_;
-  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
+  edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> geomToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
   const std::string configFile_;
   const float minPtCut_;
   const unsigned int maxClusterSize_;
 };
 
-MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig) : MkFitIterationConfigESProducer(iConfig, setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"))) {}
-MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig, edm::ESConsumesCollectorT<MkFitComponentsRecord>&& cc)
-    : geomToken_{cc.consumes()},
-      mfToken_{cc.consumes(iConfig.getParameter<edm::ESInputTag>("magField"))},
-      configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()},
+MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig)
+    : configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()},
       minPtCut_{(float)iConfig.getParameter<double>("minPt")},
-      maxClusterSize_{iConfig.getParameter<unsigned int>("maxClusterSize")} {}
+      maxClusterSize_{iConfig.getParameter<unsigned int>("maxClusterSize")} {
+        auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
+        geomToken_ = cc.consumes();
+        mfToken_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("magField"));
+      }
 
 void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;

--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -224,23 +224,23 @@ MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::Parame
     : configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()},
       minPtCut_{(float)iConfig.getParameter<double>("minPt")},
       maxClusterSize_{iConfig.getParameter<unsigned int>("maxClusterSize")} {
-        auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
-        geomToken_ = cc.consumes();
-        mfToken_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("magField"));
-      }
+  auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
+  geomToken_ = cc.consumes();
+  mfToken_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("magField"));
+}
 
 void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName")->setComment("Product label");
-  desc.add<edm::ESInputTag>("magField", edm::ESInputTag{"", "ParabolicMf"})->setComment("used only to get the value at (0,0,0)");
+  desc.add<edm::ESInputTag>("magField", edm::ESInputTag{"", "ParabolicMf"})
+      ->setComment("used only to get the value at (0,0,0)");
   desc.add<edm::FileInPath>("config")->setComment("Path to the JSON file for the mkFit configuration parameters");
   desc.add<double>("minPt", 0.0)->setComment("min pT cut applied during track building");
   desc.add<unsigned int>("maxClusterSize", 8)->setComment("Max cluster size of SiStrip hits");
   descriptions.addWithDefaultLabel(desc);
 }
 
-std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
-    const MkFitComponentsRecord &iRecord) {
+std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(const MkFitComponentsRecord &iRecord) {
   mkfit::ConfigJson cj;
   auto it_conf = cj.load_File(configFile_);
   it_conf->m_params.minPtCut = minPtCut_;
@@ -249,9 +249,9 @@ std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
   it_conf->m_params.maxClusterSize = maxClusterSize_;
   it_conf->m_backward_params.maxClusterSize = maxClusterSize_;
 
-  const float bz0 = iRecord.get(mfToken_).inTesla(GlobalPoint(0,0,0)).z();
-  const float bScale = std::abs(bz0)/Config::mag_c1;
-  edm::LogWarning("MYDEBUG")<<"Loaded field scale "<<bScale;
+  const float bz0 = iRecord.get(mfToken_).inTesla(GlobalPoint(0, 0, 0)).z();
+  const float bScale = std::abs(bz0) / Config::mag_c1;
+  edm::LogWarning("MYDEBUG") << "Loaded field scale " << bScale;
   it_conf->m_bScale = bScale;
   return it_conf;
 }

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -15,6 +15,8 @@
 #include "RecoTracker/MkFit/interface/MkFitSeedWrapper.h"
 #include "RecoTracker/MkFit/interface/MkFitOutputWrapper.h"
 #include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+
+#include "RecoTracker/Record/interface/MkFitComponentsRecord.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
 // mkFit includes
@@ -52,7 +54,7 @@ private:
   edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>> pixelMaskToken_;
   edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> stripMaskToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
-  const edm::ESGetToken<mkfit::IterationConfig, TrackerRecoGeometryRecord> mkFitIterConfigToken_;
+  const edm::ESGetToken<mkfit::IterationConfig, MkFitComponentsRecord> mkFitIterConfigToken_;
   const edm::EDPutTokenT<MkFitOutputWrapper> putToken_;
   const float minGoodStripCharge_;
   const bool seedCleaning_;

--- a/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
+++ b/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
@@ -54,7 +54,10 @@ namespace mkfit {
 
     // layer-dependent quality filter
     template <class TRACK>
-    bool qfilter_n_layers(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &trk_inf, const IterationConfig &itc) {
+    bool qfilter_n_layers(const TRACK &t,
+                          const BeamSpot &bspot,
+                          const TrackerInfo &trk_inf,
+                          const IterationConfig &itc) {
       int enhits = t.nHitsByTypeEncoded(trk_inf);
       int npixhits = t.nPixelDecoded(enhits);
       int enlyrs = t.nLayersByTypeEncoded(trk_inf);
@@ -76,7 +79,10 @@ namespace mkfit {
 
     /// quality filter tuned for pixelLess iteration during forward search
     template <class TRACK>
-    bool qfilter_pixelLessFwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info, const IterationConfig &itc) {
+    bool qfilter_pixelLessFwd(const TRACK &t,
+                              const BeamSpot &bspot,
+                              const TrackerInfo &tk_info,
+                              const IterationConfig &itc) {
       float d0BS = t.d0BeamSpot(bspot.x, bspot.y, itc.m_bScale);
       float d0_max = 0.05;  // 0.5 mm
 
@@ -102,7 +108,10 @@ namespace mkfit {
 
     /// quality filter tuned for pixelLess iteration during backward search
     template <class TRACK>
-    bool qfilter_pixelLessBkwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info, const IterationConfig &itc) {
+    bool qfilter_pixelLessBkwd(const TRACK &t,
+                               const BeamSpot &bspot,
+                               const TrackerInfo &tk_info,
+                               const IterationConfig &itc) {
       float d0BS = t.d0BeamSpot(bspot.x, bspot.y, itc.m_bScale);
       float d0_max = 0.1;  // 1 mm
 

--- a/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
+++ b/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
@@ -5,6 +5,7 @@
 #include "RecoTracker/MkFitCore/interface/Hit.h"
 #include "RecoTracker/MkFitCore/interface/Track.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
+#include "RecoTracker/MkFitCore/interface/IterationConfig.h"
 
 namespace mkfit {
 
@@ -53,7 +54,7 @@ namespace mkfit {
 
     // layer-dependent quality filter
     template <class TRACK>
-    bool qfilter_n_layers(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &trk_inf) {
+    bool qfilter_n_layers(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &trk_inf, const IterationConfig &itc) {
       int enhits = t.nHitsByTypeEncoded(trk_inf);
       int npixhits = t.nPixelDecoded(enhits);
       int enlyrs = t.nLayersByTypeEncoded(trk_inf);
@@ -63,7 +64,7 @@ namespace mkfit {
       int lplyr = t.getLastFoundPixelHitLyr();
       float invpt = t.invpT();
       float invptmin = 1.43;  // min 1/pT (=1/0.7) for full filter on (npixhits<=3 .or. npixlyrs<=3)
-      float d0BS = t.d0BeamSpot(bspot.x, bspot.y);
+      float d0BS = t.d0BeamSpot(bspot.x, bspot.y, itc.m_bScale);
       float d0_max = 0.1;  // 1 mm
 
       bool endsInsidePix = (llyr == 2 || llyr == 18 || llyr == 45);
@@ -75,8 +76,8 @@ namespace mkfit {
 
     /// quality filter tuned for pixelLess iteration during forward search
     template <class TRACK>
-    bool qfilter_pixelLessFwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info) {
-      float d0BS = t.d0BeamSpot(bspot.x, bspot.y);
+    bool qfilter_pixelLessFwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info, const IterationConfig &itc) {
+      float d0BS = t.d0BeamSpot(bspot.x, bspot.y, itc.m_bScale);
       float d0_max = 0.05;  // 0.5 mm
 
       int encoded;
@@ -101,8 +102,8 @@ namespace mkfit {
 
     /// quality filter tuned for pixelLess iteration during backward search
     template <class TRACK>
-    bool qfilter_pixelLessBkwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info) {
-      float d0BS = t.d0BeamSpot(bspot.x, bspot.y);
+    bool qfilter_pixelLessBkwd(const TRACK &t, const BeamSpot &bspot, const TrackerInfo &tk_info, const IterationConfig &itc) {
+      float d0BS = t.d0BeamSpot(bspot.x, bspot.y, itc.m_bScale);
       float d0_max = 0.1;  // 1 mm
 
       int encoded;

--- a/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
+++ b/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
@@ -105,6 +105,8 @@ namespace mkfit {
       const float dzmax2_inv_el = 1.f / (dzmax_el * dzmax_el);
       const float drmax2_inv_el = 1.f / (drmax_el * drmax_el);
 
+      const float bScale = itrcfg.m_bScale;
+
       // Merge hits from overlapping seeds?
       // For now always true, we require extra hits after seed.
       const bool merge_hits = true;  // itrcfg.merge_seed_hits_during_cleaning();
@@ -156,7 +158,7 @@ namespace mkfit {
         x[ts] = tk.x();
         y[ts] = tk.y();
         z[ts] = tk.z();
-        d0[ts] = tk.d0BeamSpot(bspot.x, bspot.y);
+        d0[ts] = tk.d0BeamSpot(bspot.x, bspot.y, bScale);
 
         phi_eta_binnor.register_entry_safe(oldPhi[ts], eta[ts]);
         // If one is sure values are *within* axis ranges: b.register_entry(oldPhi[ts], eta[ts]);

--- a/RecoTracker/MkFitCMS/src/runFunctions.cc
+++ b/RecoTracker/MkFitCMS/src/runFunctions.cc
@@ -38,7 +38,7 @@ namespace mkfit {
                         bool do_remove_duplicates) {
     IterationMaskIfcCmssw it_mask_ifc(trackerInfo, hit_masks);
 
-    MkJob job({trackerInfo, itconf, eoh, &it_mask_ifc});
+    MkJob job{trackerInfo, itconf, eoh, &it_mask_ifc};
 
     builder.begin_event(&job, nullptr, __func__);
 
@@ -67,7 +67,7 @@ namespace mkfit {
         builder.filter_comb_cands([&](const TrackCand &t) { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
       } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
         builder.filter_comb_cands(
-            [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), trackerInfo); });
+            [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), trackerInfo, itconf); });
       } else {
         builder.filter_comb_cands(
             [&](const TrackCand &t) { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
@@ -91,10 +91,10 @@ namespace mkfit {
                                                Algo(itconf.m_track_algorithm) == Algo::pixelLessStep)) {
         if (Algo(itconf.m_track_algorithm) == Algo::detachedTripletStep) {
           builder.filter_comb_cands(
-              [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), trackerInfo); });
+              [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), trackerInfo, itconf); });
         } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
           builder.filter_comb_cands(
-              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), trackerInfo); });
+              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), trackerInfo, itconf); });
         }
       }
     }

--- a/RecoTracker/MkFitCMS/src/runFunctions.cc
+++ b/RecoTracker/MkFitCMS/src/runFunctions.cc
@@ -66,8 +66,9 @@ namespace mkfit {
       if (Algo(itconf.m_track_algorithm) == Algo::pixelPairStep) {
         builder.filter_comb_cands([&](const TrackCand &t) { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
       } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
-        builder.filter_comb_cands(
-            [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), trackerInfo, itconf); });
+        builder.filter_comb_cands([&](const TrackCand &t) {
+          return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), trackerInfo, itconf);
+        });
       } else {
         builder.filter_comb_cands(
             [&](const TrackCand &t) { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
@@ -93,8 +94,9 @@ namespace mkfit {
           builder.filter_comb_cands(
               [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), trackerInfo, itconf); });
         } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
-          builder.filter_comb_cands(
-              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), trackerInfo, itconf); });
+          builder.filter_comb_cands([&](const TrackCand &t) {
+            return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), trackerInfo, itconf);
+          });
         }
       }
     }

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -470,7 +470,7 @@ namespace mkfit {
           builder.filter_comb_cands([&](const TrackCand &t) { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
         } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
           builder.filter_comb_cands(
-              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), Config::TrkInfo); });
+              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), Config::TrkInfo, itconf); });
         } else {
           builder.filter_comb_cands(
               [&](const TrackCand &t) { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
@@ -516,10 +516,10 @@ namespace mkfit {
                                                  Algo(itconf.m_track_algorithm) == Algo::pixelLessStep)) {
           if (Algo(itconf.m_track_algorithm) == Algo::detachedTripletStep) {
             builder.filter_comb_cands(
-                [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), Config::TrkInfo); });
+                [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), Config::TrkInfo, itconf); });
           } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
             builder.filter_comb_cands([&](const TrackCand &t) {
-              return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), Config::TrkInfo);
+              return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), Config::TrkInfo, itconf);
             });
           }
         }

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -469,8 +469,9 @@ namespace mkfit {
         if (Algo(itconf.m_track_algorithm) == Algo::pixelPairStep) {
           builder.filter_comb_cands([&](const TrackCand &t) { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
         } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
-          builder.filter_comb_cands(
-              [&](const TrackCand &t) { return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), Config::TrkInfo, itconf); });
+          builder.filter_comb_cands([&](const TrackCand &t) {
+            return StdSeq::qfilter_pixelLessFwd(t, eoh.refBeamSpot(), Config::TrkInfo, itconf);
+          });
         } else {
           builder.filter_comb_cands(
               [&](const TrackCand &t) { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
@@ -515,8 +516,9 @@ namespace mkfit {
         if (itconf.m_requires_quality_filter && (Algo(itconf.m_track_algorithm) == Algo::detachedTripletStep ||
                                                  Algo(itconf.m_track_algorithm) == Algo::pixelLessStep)) {
           if (Algo(itconf.m_track_algorithm) == Algo::detachedTripletStep) {
-            builder.filter_comb_cands(
-                [&](const TrackCand &t) { return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), Config::TrkInfo, itconf); });
+            builder.filter_comb_cands([&](const TrackCand &t) {
+              return StdSeq::qfilter_n_layers(t, eoh.refBeamSpot(), Config::TrkInfo, itconf);
+            });
           } else if (Algo(itconf.m_track_algorithm) == Algo::pixelLessStep) {
             builder.filter_comb_cands([&](const TrackCand &t) {
               return StdSeq::qfilter_pixelLessBkwd(t, eoh.refBeamSpot(), Config::TrkInfo, itconf);

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -140,11 +140,8 @@ namespace mkfit {
 
   class IterationConfig {
   public:
-    using partition_seeds_foo = void(const TrackerInfo &,
-                                     const TrackVec &,
-                                     const EventOfHits &,
-                                     IterationSeedPartition &,
-                                     const float bScale);
+    using partition_seeds_foo =
+        void(const TrackerInfo &, const TrackVec &, const EventOfHits &, IterationSeedPartition &, const float bScale);
 
     int m_iteration_index = -1;
     int m_track_algorithm = -1;
@@ -158,7 +155,7 @@ namespace mkfit {
 
     int m_backward_fit_min_hits = -1;  // Min number of hits to keep when m_backward_drop_seed_hits is true
 
-    float m_bScale = 1.f; // B-field scaling parameter
+    float m_bScale = 1.f;  // B-field scaling parameter
     // Iteration parameters (could be a ptr)
     IterationParams m_params;
     IterationParams m_backward_params;

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -143,7 +143,8 @@ namespace mkfit {
     using partition_seeds_foo = void(const TrackerInfo &,
                                      const TrackVec &,
                                      const EventOfHits &,
-                                     IterationSeedPartition &);
+                                     IterationSeedPartition &,
+                                     const float bScale);
 
     int m_iteration_index = -1;
     int m_track_algorithm = -1;
@@ -157,6 +158,7 @@ namespace mkfit {
 
     int m_backward_fit_min_hits = -1;  // Min number of hits to keep when m_backward_drop_seed_hits is true
 
+    float m_bScale = 1.f; // B-field scaling parameter
     // Iteration parameters (could be a ptr)
     IterationParams m_params;
     IterationParams m_backward_params;

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -32,6 +32,7 @@ namespace mkfit {
     const EventOfHits &m_event_of_hits;
 
     const IterationMaskIfcBase *m_iter_mask_ifc = nullptr;
+    const float bScale = 1.f; // B-field scaling parameter
 
     int num_regions() const { return m_iter_config.m_n_regions; }
     const auto regions_begin() const { return m_iter_config.m_region_order.begin(); }

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -32,7 +32,6 @@ namespace mkfit {
     const EventOfHits &m_event_of_hits;
 
     const IterationMaskIfcBase *m_iter_mask_ifc = nullptr;
-    const float bScale = 1.f; // B-field scaling parameter
 
     int num_regions() const { return m_iter_config.m_n_regions; }
     const auto regions_begin() const { return m_iter_config.m_region_order.begin(); }

--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -194,7 +194,7 @@ namespace mkfit {
 
     bool hasNanNSillyValues() const;
 
-    float d0BeamSpot(const float x_bs, const float y_bs, bool linearize = false) const;
+    float d0BeamSpot(const float x_bs, const float y_bs, const float bScale /*= 1.f*/, bool linearize = false) const;
 
     // ------------------------------------------------------------------------
 
@@ -388,10 +388,10 @@ namespace mkfit {
     // used for swimming cmssw rec tracks to mkFit position
     float swimPhiToR(const float x, const float y) const;
 
-    bool canReachRadius(float R) const;
-    float maxReachRadius() const;
-    float zAtR(float R, float* r_reached = nullptr) const;
-    float rAtZ(float Z) const;
+    bool canReachRadius(float R, float bScale) const;
+    float maxReachRadius(float bScale) const;
+    float zAtR(float R, float bScale, float* r_reached = nullptr) const;
+    float rAtZ(float Z, float bScale) const;
 
     //this function is very inefficient, use only for debug and validation!
     HitVec hitsVector(const std::vector<HitVec>& globalHitVec) const {

--- a/RecoTracker/MkFitCore/interface/binnor.h
+++ b/RecoTracker/MkFitCore/interface/binnor.h
@@ -312,7 +312,7 @@ namespace mkfit {
 
 #ifdef DEBUG
         B_pair n_pair = m_bin_to_n_bin(m_cons[j]);
-        printf("i=%4u j=%4u  %u %u %u %u\n", i, j, n_pair.bin1, n_pair.bin2, c_bin.first, c_bin.count);
+        printf("i=%4u j=%4u  %u %u %u %u\n", i, j, n_pair.bin1(), n_pair.bin2(), c_bin.first, c_bin.count);
 #endif
       }
 

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -9,11 +9,11 @@ namespace mkfit {
 
 #define COMPUTE_CHI2_ARGS                                                                                    \
   const MPlexLS &, const MPlexLV &, const MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLV &, \
-      const int, const PropagationFlags, const bool
+    const int, const PropagationFlags, const float, const bool
 
 #define UPDATE_PARAM_ARGS                                                                                         \
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, const int, \
-      const PropagationFlags, const bool
+    const PropagationFlags, const float, const bool
 
   class FindingFoos {
   public:

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -9,11 +9,11 @@ namespace mkfit {
 
 #define COMPUTE_CHI2_ARGS                                                                                    \
   const MPlexLS &, const MPlexLV &, const MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLV &, \
-    const int, const PropagationFlags, const float, const bool
+      const int, const PropagationFlags, const float, const bool
 
 #define UPDATE_PARAM_ARGS                                                                                         \
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, const int, \
-    const PropagationFlags, const float, const bool
+      const PropagationFlags, const float, const bool
 
   class FindingFoos {
   public:

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -436,7 +436,7 @@ namespace mkfit {
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
                                 const int N_proc,
-                                const PropagationFlags propFlags,
+                                const PropagationFlags propFlags, const float bScale,
                                 const bool propToHit) {
     if (propToHit) {
       MPlexLS propErr;
@@ -447,7 +447,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags, bScale);
 
       kalmanOperation(KFO_Update_Params, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
@@ -481,7 +481,7 @@ namespace mkfit {
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
                                      const int N_proc,
-                                     const PropagationFlags propFlags,
+                                     const PropagationFlags propFlags, const float bScale,
                                      const bool propToHit) {
     propPar = psPar;
     if (propToHit) {
@@ -492,7 +492,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, N_proc, propFlags, bScale);
 
       kalmanOperation(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {
@@ -687,7 +687,7 @@ namespace mkfit {
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
                                       const int N_proc,
-                                      const PropagationFlags propFlags,
+                                      const PropagationFlags propFlags, const float bScale,
                                       const bool propToHit) {
     if (propToHit) {
       MPlexLS propErr;
@@ -698,7 +698,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, N_proc, propFlags, bScale);
 
       kalmanOperationEndcap(KFO_Update_Params, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
@@ -732,7 +732,7 @@ namespace mkfit {
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
                                            const int N_proc,
-                                           const PropagationFlags propFlags,
+                                           const PropagationFlags propFlags, const float bScale,
                                            const bool propToHit) {
     propPar = psPar;
     if (propToHit) {
@@ -743,7 +743,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, N_proc, propFlags, bScale);
 
       kalmanOperationEndcap(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -436,7 +436,8 @@ namespace mkfit {
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
                                 const int N_proc,
-                                const PropagationFlags propFlags, const float bScale,
+                                const PropagationFlags propFlags,
+                                const float bScale,
                                 const bool propToHit) {
     if (propToHit) {
       MPlexLS propErr;
@@ -481,7 +482,8 @@ namespace mkfit {
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
                                      const int N_proc,
-                                     const PropagationFlags propFlags, const float bScale,
+                                     const PropagationFlags propFlags,
+                                     const float bScale,
                                      const bool propToHit) {
     propPar = psPar;
     if (propToHit) {
@@ -687,7 +689,8 @@ namespace mkfit {
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
                                       const int N_proc,
-                                      const PropagationFlags propFlags, const float bScale,
+                                      const PropagationFlags propFlags,
+                                      const float bScale,
                                       const bool propToHit) {
     if (propToHit) {
       MPlexLS propErr;
@@ -732,7 +735,8 @@ namespace mkfit {
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
                                            const int N_proc,
-                                           const PropagationFlags propFlags, const float bScale,
+                                           const PropagationFlags propFlags,
+                                           const float bScale,
                                            const bool propToHit) {
     propPar = psPar;
     if (propToHit) {

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -28,7 +28,7 @@ namespace mkfit {
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
                                 const int N_proc,
-                                const PropagationFlags propFlags,
+                                const PropagationFlags propFlags, const float bScale,
                                 const bool propToHit);
 
   void kalmanComputeChi2(const MPlexLS& psErr,
@@ -47,7 +47,7 @@ namespace mkfit {
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
                                      const int N_proc,
-                                     const PropagationFlags propFlags,
+                                     const PropagationFlags propFlags, const float bScale,
                                      const bool propToHit);
 
   void kalmanOperation(const int kfOp,
@@ -78,7 +78,7 @@ namespace mkfit {
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
                                       const int N_proc,
-                                      const PropagationFlags propFlags,
+                                      const PropagationFlags propFlags, const float bScale,
                                       const bool propToHit);
 
   void kalmanComputeChi2Endcap(const MPlexLS& psErr,
@@ -97,7 +97,7 @@ namespace mkfit {
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
                                            const int N_proc,
-                                           const PropagationFlags propFlags,
+                                           const PropagationFlags propFlags, const float bScale,
                                            const bool propToHit);
 
   void kalmanOperationEndcap(const int kfOp,

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -28,7 +28,8 @@ namespace mkfit {
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
                                 const int N_proc,
-                                const PropagationFlags propFlags, const float bScale,
+                                const PropagationFlags propFlags,
+                                const float bScale,
                                 const bool propToHit);
 
   void kalmanComputeChi2(const MPlexLS& psErr,
@@ -47,7 +48,8 @@ namespace mkfit {
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
                                      const int N_proc,
-                                     const PropagationFlags propFlags, const float bScale,
+                                     const PropagationFlags propFlags,
+                                     const float bScale,
                                      const bool propToHit);
 
   void kalmanOperation(const int kfOp,
@@ -78,7 +80,8 @@ namespace mkfit {
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
                                       const int N_proc,
-                                      const PropagationFlags propFlags, const float bScale,
+                                      const PropagationFlags propFlags,
+                                      const float bScale,
                                       const bool propToHit);
 
   void kalmanComputeChi2Endcap(const MPlexLS& psErr,
@@ -97,7 +100,8 @@ namespace mkfit {
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
                                            const int N_proc,
-                                           const PropagationFlags propFlags, const float bScale,
+                                           const PropagationFlags propFlags,
+                                           const float bScale,
                                            const bool propToHit);
 
   void kalmanOperationEndcap(const int kfOp,

--- a/RecoTracker/MkFitCore/src/MkBase.h
+++ b/RecoTracker/MkFitCore/src/MkBase.h
@@ -46,7 +46,8 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(par.constAt(n, 0, 0), par.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale, noMatEffPtr);
+      propagateHelixToRMPlex(
+          m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale, noMatEffPtr);
     }
 
     //----------------------------------------------------------------------------
@@ -94,7 +95,7 @@ namespace mkfit {
     MPlexLS m_Err[2];
     MPlexLV m_Par[2];
     MPlexQI m_Chg;
-    float m_bScale = 0.f; // implies the value is consistently (re)set where needed
+    float m_bScale = 0.f;  // implies the value is consistently (re)set where needed
   };
 
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkBase.h
+++ b/RecoTracker/MkFitCore/src/MkBase.h
@@ -33,7 +33,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = r;
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale);
     }
 
     void propagateTracksToHitR(const MPlexHV& par,
@@ -46,7 +46,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(par.constAt(n, 0, 0), par.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale, noMatEffPtr);
     }
 
     //----------------------------------------------------------------------------
@@ -58,7 +58,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = z;
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale);
     }
 
     void propagateTracksToHitZ(const MPlexHV& par,
@@ -71,7 +71,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = par.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale, noMatEffPtr);
     }
 
     void propagateTracksToPCAZ(const int N_proc, const PropagationFlags pf) {
@@ -85,7 +85,7 @@ namespace mkfit {
                           (1 + slope * slope);  // PCA to origin
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, m_bScale);
     }
 
     //----------------------------------------------------------------------------
@@ -94,6 +94,7 @@ namespace mkfit {
     MPlexLS m_Err[2];
     MPlexLV m_Par[2];
     MPlexQI m_Chg;
+    float m_bScale = 0.f; // implies the value is consistently (re)set where needed
   };
 
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -244,11 +244,13 @@ namespace mkfit {
       part.m_phi_eta_foo = [&](float phi, float eta) { phi_eta_binnor.register_entry_safe(phi, eta); };
 
       phi_eta_binnor.begin_registration(size);
-      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
+      m_job->m_iter_config.m_partition_seeds(
+          m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
       phi_eta_binnor.finalize_registration();
       ranks.swap(phi_eta_binnor.m_ranks);
     } else {
-      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
+      m_job->m_iter_config.m_partition_seeds(
+          m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
     }
 
     for (int i = 0; i < size; ++i) {
@@ -1317,7 +1319,7 @@ namespace mkfit {
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     const SteeringParams &st_par = m_job->steering_params(region);
     const PropagationConfig &prop_config = PropagationConfig::get_default();
-    mkfndr->setup_bkfit(prop_config);
+    mkfndr->setup_bkfit(prop_config, m_job->m_iter_config.m_bScale);
 
     int step = NN;
     for (int icand = start_cand; icand < end_cand; icand += step) {

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -526,7 +526,8 @@ namespace mkfit {
             mkfndr->setup(prop_config,
                           m_job->m_iter_config.m_params,
                           m_job->m_iter_config.m_layer_configs[curr_layer],
-                          m_job->get_mask_for_layer(curr_layer));
+                          m_job->get_mask_for_layer(curr_layer),
+                          m_job->m_iter_config.m_bScale);
 
             const LayerOfHits &layer_of_hits = m_job->m_event_of_hits[curr_layer];
             const LayerInfo &layer_info = trk_info.layer(curr_layer);
@@ -809,7 +810,8 @@ namespace mkfit {
           mkfndr->setup(prop_config,
                         iter_params,
                         m_job->m_iter_config.m_layer_configs[curr_layer],
-                        m_job->get_mask_for_layer(curr_layer));
+                        m_job->get_mask_for_layer(curr_layer),
+                        m_job->m_iter_config.m_bScale);
 
           dprintf("\n* Processing layer %d\n", curr_layer);
 
@@ -1016,7 +1018,8 @@ namespace mkfit {
       mkfndr->setup(prop_config,
                     iter_params,
                     m_job->m_iter_config.m_layer_configs[curr_layer],
-                    m_job->get_mask_for_layer(curr_layer));
+                    m_job->get_mask_for_layer(curr_layer),
+                    m_job->m_iter_config.m_bScale);
 
       const bool pickup_only = layer_plan_it.is_pickup_only();
 

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -244,11 +244,11 @@ namespace mkfit {
       part.m_phi_eta_foo = [&](float phi, float eta) { phi_eta_binnor.register_entry_safe(phi, eta); };
 
       phi_eta_binnor.begin_registration(size);
-      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part);
+      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
       phi_eta_binnor.finalize_registration();
       ranks.swap(phi_eta_binnor.m_ranks);
     } else {
-      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part);
+      m_job->m_iter_config.m_partition_seeds(m_job->m_trk_info, in_seeds, m_job->m_event_of_hits, part, m_job->m_iter_config.m_bScale);
     }
 
     for (int i = 0; i < size; ++i) {

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -36,11 +36,13 @@ namespace mkfit {
   void MkFinder::setup(const PropagationConfig &pc,
                        const IterationParams &ip,
                        const IterationLayerConfig &ilc,
-                       const std::vector<bool> *ihm) {
+                       const std::vector<bool> *ihm,
+                       const float bScale) {
     m_prop_config = &pc;
     m_iteration_params = &ip;
     m_iteration_layer_config = &ilc;
     m_iteration_hit_mask = ihm;
+    m_bScale = bScale;
   }
 
   void MkFinder::setup_bkfit(const PropagationConfig &pc) { m_prop_config = &pc; }
@@ -50,6 +52,7 @@ namespace mkfit {
     m_iteration_params = nullptr;
     m_iteration_layer_config = nullptr;
     m_iteration_hit_mask = nullptr;
+    m_bScale = 0.f;
   }
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -492,6 +492,7 @@ namespace mkfit {
                                                tmpPropPar,
                                                N_proc,
                                                m_prop_config->finding_intra_layer_pflags,
+                                               m_bScale,
                                                m_prop_config->finding_requires_propagation_to_hit_pos);
 
                 float hx = thishit.x();

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -45,7 +45,10 @@ namespace mkfit {
     m_bScale = bScale;
   }
 
-  void MkFinder::setup_bkfit(const PropagationConfig &pc) { m_prop_config = &pc; }
+  void MkFinder::setup_bkfit(const PropagationConfig &pc, const float bScale) {
+    m_prop_config = &pc;
+    m_bScale = bScale;
+  }
 
   void MkFinder::release() {
     m_prop_config = nullptr;

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -701,6 +701,7 @@ namespace mkfit {
                                      tmpPropPar,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
+                                     m_bScale,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
       //update best hit in case chi2<minChi2
@@ -786,6 +787,7 @@ namespace mkfit {
                                    m_Par[iC],
                                    N_proc,
                                    m_prop_config->finding_intra_layer_pflags,
+                                   m_bScale,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
 
     dprint("m_Par[iP](0,0,0)=" << m_Par[iP](0, 0, 0) << " m_Par[iC](0,0,0)=" << m_Par[iC](0, 0, 0));
@@ -915,6 +917,7 @@ namespace mkfit {
                                      propPar,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
+                                     m_bScale,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
       // Now update the track parameters with this hit (note that some
@@ -969,6 +972,7 @@ namespace mkfit {
                                        m_Par[iC],
                                        N_proc,
                                        m_prop_config->finding_intra_layer_pflags,
+                                       m_bScale,
                                        m_prop_config->finding_requires_propagation_to_hit_pos);
 
         dprint("update parameters" << std::endl
@@ -1154,6 +1158,7 @@ namespace mkfit {
                                      propPar,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
+                                     m_bScale,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
 #pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
@@ -1309,6 +1314,7 @@ namespace mkfit {
                                    m_Par[iC],
                                    N_proc,
                                    m_prop_config->finding_inter_layer_pflags,
+                                   m_bScale,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
   }
 

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -44,7 +44,8 @@ namespace mkfit {
     void setup(const PropagationConfig &pc,
                const IterationParams &ip,
                const IterationLayerConfig &ilc,
-               const std::vector<bool> *ihm);
+               const std::vector<bool> *ihm,
+               const float bScale);
     void setup_bkfit(const PropagationConfig &pc);
     void release();
 

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -46,7 +46,7 @@ namespace mkfit {
                const IterationLayerConfig &ilc,
                const std::vector<bool> *ihm,
                const float bScale);
-    void setup_bkfit(const PropagationConfig &pc);
+    void setup_bkfit(const PropagationConfig &pc, const float bScale);
     void release();
 
     //----------------------------------------------------------------------------

--- a/RecoTracker/MkFitCore/src/MkFitter.h
+++ b/RecoTracker/MkFitCore/src/MkFitter.h
@@ -29,6 +29,8 @@ namespace mkfit {
 
     void setNhits(int newnhits) { m_Nhits = std::min(newnhits, Config::nMaxTrkHits - 1); }
 
+    void setBscale(float bScale) { m_bScale = bScale;}
+
     int countValidHits(int itrack, int end_hit) const;
     int countInvalidHits(int itrack, int end_hit) const;
     int countValidHits(int itrack) const { return countValidHits(itrack, m_Nhits); }

--- a/RecoTracker/MkFitCore/src/MkFitter.h
+++ b/RecoTracker/MkFitCore/src/MkFitter.h
@@ -29,7 +29,7 @@ namespace mkfit {
 
     void setNhits(int newnhits) { m_Nhits = std::min(newnhits, Config::nMaxTrkHits - 1); }
 
-    void setBscale(float bScale) { m_bScale = bScale;}
+    void setBscale(float bScale) { m_bScale = bScale; }
 
     int countValidHits(int itrack, int end_hit) const;
     int countInvalidHits(int itrack, int end_hit) const;

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -293,7 +293,8 @@ namespace mkfit {
                                        MPlexLV& outPar,
                                        MPlexLL& errorProp,
                                        const int N_proc,
-                                       const PropagationFlags pflags, const float bScale) {
+                                       const PropagationFlags pflags,
+                                       const float bScale) {
     errorProp.setVal(0.f);
     MPlexLL errorPropTmp(0.f);   //initialize to zero
     MPlexLL errorPropSwap(0.f);  //initialize to zero
@@ -316,9 +317,8 @@ namespace mkfit {
         continue;
       }
       const float k = inChg.constAt(n, 0, 0) * 100.f /
-        (-Const::sol * bScale * (pflags.use_param_b_field
-                        ? Config::bFieldFromZR(inPar.constAt(n, 2, 0), r0)
-                        : Config::Bfield));
+                      (-Const::sol * bScale *
+                       (pflags.use_param_b_field ? Config::bFieldFromZR(inPar.constAt(n, 2, 0), r0) : Config::Bfield));
 
       const float ipt = inPar.constAt(n, 3, 0);
       const float phiin = inPar.constAt(n, 4, 0);
@@ -481,7 +481,8 @@ namespace mkfit {
                                 MPlexLL& errorProp,
                                 MPlexQI& outFailFlag,
                                 const int N_proc,
-                                const PropagationFlags pflags, const float bScale) {
+                                const PropagationFlags pflags,
+                                const float bScale) {
     errorProp.setVal(0.f);
     outFailFlag.setVal(0.f);
 
@@ -495,8 +496,10 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags, const float bScale,
+                              const PropagationFlags pflags,
+                              const float bScale,
                               const MPlexQI* noMatEffPtr) {
+    assert(bScale != 0);
     // bool debug = true;
 
     // This is used further down when calculating similarity with errorProp (and before in DEBUG).
@@ -603,8 +606,10 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags, const float bScale,
+                              const PropagationFlags pflags,
+                              const float bScale,
                               const MPlexQI* noMatEffPtr) {
+    assert(bScale != 0);
     // debug = true;
 
     outErr = inErr;
@@ -704,7 +709,8 @@ namespace mkfit {
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
                 const int N_proc,
-                const PropagationFlags pflags, const float bScale) {
+                const PropagationFlags pflags,
+                const float bScale) {
     errorProp.setVal(0.f);
 
 #pragma omp simd

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.h
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.h
@@ -37,7 +37,7 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags,
+                              const PropagationFlags pflags, const float bScale,
                               const MPlexQI* noMatEffPtr = nullptr);
 
   void helixAtRFromIterativeCCSFullJac(const MPlexLV& inPar,
@@ -45,6 +45,7 @@ namespace mkfit {
                                        const MPlexQF& msRad,
                                        MPlexLV& outPar,
                                        MPlexLL& errorProp,
+                                       const PropagationFlags pflags, const float bScale,
                                        const int N_proc);
 
   void helixAtRFromIterativeCCS(const MPlexLV& inPar,
@@ -54,7 +55,7 @@ namespace mkfit {
                                 MPlexLL& errorProp,
                                 MPlexQI& outFailFlag,
                                 const int N_proc,
-                                const PropagationFlags pflags);
+                                const PropagationFlags pflags, const float bScale);
 
   void propagateHelixToZMPlex(const MPlexLS& inErr,
                               const MPlexLV& inPar,
@@ -63,7 +64,7 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags,
+                              const PropagationFlags pflags, const float bScale,
                               const MPlexQI* noMatEffPtr = nullptr);
 
   void helixAtZ(const MPlexLV& inPar,
@@ -72,7 +73,7 @@ namespace mkfit {
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
                 const int N_proc,
-                const PropagationFlags pflags);
+                const PropagationFlags pflags, const float bScale);
 
   void applyMaterialEffects(const MPlexQF& hitsRl,
                             const MPlexQF& hitsXi,

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.h
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.h
@@ -37,7 +37,8 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags, const float bScale,
+                              const PropagationFlags pflags,
+                              const float bScale,
                               const MPlexQI* noMatEffPtr = nullptr);
 
   void helixAtRFromIterativeCCSFullJac(const MPlexLV& inPar,
@@ -45,7 +46,8 @@ namespace mkfit {
                                        const MPlexQF& msRad,
                                        MPlexLV& outPar,
                                        MPlexLL& errorProp,
-                                       const PropagationFlags pflags, const float bScale,
+                                       const PropagationFlags pflags,
+                                       const float bScale,
                                        const int N_proc);
 
   void helixAtRFromIterativeCCS(const MPlexLV& inPar,
@@ -55,7 +57,8 @@ namespace mkfit {
                                 MPlexLL& errorProp,
                                 MPlexQI& outFailFlag,
                                 const int N_proc,
-                                const PropagationFlags pflags, const float bScale);
+                                const PropagationFlags pflags,
+                                const float bScale);
 
   void propagateHelixToZMPlex(const MPlexLS& inErr,
                               const MPlexLV& inPar,
@@ -64,7 +67,8 @@ namespace mkfit {
                               MPlexLS& outErr,
                               MPlexLV& outPar,
                               const int N_proc,
-                              const PropagationFlags pflags, const float bScale,
+                              const PropagationFlags pflags,
+                              const float bScale,
                               const MPlexQI* noMatEffPtr = nullptr);
 
   void helixAtZ(const MPlexLV& inPar,
@@ -73,7 +77,8 @@ namespace mkfit {
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
                 const int N_proc,
-                const PropagationFlags pflags, const float bScale);
+                const PropagationFlags pflags,
+                const float bScale);
 
   void applyMaterialEffects(const MPlexQF& hitsRl,
                             const MPlexQF& hitsXi,

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -12,7 +12,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                                                  const int nmin,
                                                  const int nmax,
                                                  const int N_proc,
-                                                 const PropagationFlags pf) {
+                                                 const PropagationFlags pf, const float bScale) {
   // bool debug = true;
 
 #pragma omp simd
@@ -35,12 +35,12 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
   if (pf.use_param_b_field) {
 #pragma omp simd
     for (int n = nmin; n < nmax; ++n) {
-      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * Config::bFieldFromZR(inPar(n, 2, 0), r0[n - nmin]));
+      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * bScale * Config::bFieldFromZR(inPar(n, 2, 0), r0[n - nmin]));
     }
   } else {
 #pragma omp simd
     for (int n = nmin; n < nmax; ++n) {
-      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * Config::Bfield);
+      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * bScale * Config::Bfield);
     }
   }
   float r[nmax - nmin];

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -12,7 +12,8 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                                                  const int nmin,
                                                  const int nmax,
                                                  const int N_proc,
-                                                 const PropagationFlags pf, const float bScale) {
+                                                 const PropagationFlags pf,
+                                                 const float bScale) {
   // bool debug = true;
 
 #pragma omp simd

--- a/RecoTracker/MkFitCore/src/Track.cc
+++ b/RecoTracker/MkFitCore/src/Track.cc
@@ -187,11 +187,11 @@ namespace mkfit {
   }
 
   // If linearize=true, use linear estimate of d0: suitable at pT>~10 GeV (--> 10 micron error)
-  float TrackBase::d0BeamSpot(const float x_bs, const float y_bs, bool linearize) const {
+  float TrackBase::d0BeamSpot(const float x_bs, const float y_bs, const float bScale, bool linearize) const {
     if (linearize) {
       return std::abs(std::cos(momPhi()) * (y() - y_bs) - std::sin(momPhi()) * (x() - x_bs));
     } else {
-      const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * Config::Bfield);
+      const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * bScale * Config::Bfield);
       const float abs_ooc_half = std::abs(k * pT());
       // center of helix in x,y plane
       const float x_center = x() - k * py();
@@ -279,14 +279,14 @@ namespace mkfit {
     return squashPhiGeneral(momPhi() - dPhi);
   }
 
-  bool Track::canReachRadius(float R) const {
-    const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * Config::Bfield);
+  bool Track::canReachRadius(float R, float bScale) const {
+    const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * bScale * Config::Bfield);
     const float ooc = 2.0f * k * pT();
     return std::abs(ooc) > R - std::hypot(x(), y());
   }
 
-  float Track::maxReachRadius() const {
-    const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * Config::Bfield);
+  float Track::maxReachRadius(float bScale) const {
+    const float k = ((charge() < 0) ? 100.0f : -100.0f) / (Const::sol * bScale * Config::Bfield);
     const float abs_ooc_half = std::abs(k * pT());
     // center of helix in x,y plane
     const float x_center = x() - k * py();
@@ -294,14 +294,14 @@ namespace mkfit {
     return std::hypot(x_center, y_center) + abs_ooc_half;
   }
 
-  float Track::zAtR(float R, float* r_reached) const {
+  float Track::zAtR(float R, float bScale, float* r_reached) const {
     float xc = x();
     float yc = y();
     float pxc = px();
     float pyc = py();
 
     const float ipt = invpT();
-    const float kinv = ((charge() < 0) ? 0.01f : -0.01f) * Const::sol * Config::Bfield;
+    const float kinv = ((charge() < 0) ? 0.01f : -0.01f) * Const::sol * bScale * Config::Bfield;
     const float k = 1.0f / kinv;
 
     const float c = 0.5f * kinv * ipt;
@@ -371,14 +371,14 @@ namespace mkfit {
     // ----------------------------------------------------------------
   }
 
-  float Track::rAtZ(float Z) const {
+  float Track::rAtZ(float Z, float bScale) const {
     float xc = x();
     float yc = y();
     float pxc = px();
     float pyc = py();
 
     const float ipt = invpT();
-    const float kinv = ((charge() < 0) ? 0.01f : -0.01f) * Const::sol * Config::Bfield;
+    const float kinv = ((charge() < 0) ? 0.01f : -0.01f) * Const::sol * bScale * Config::Bfield;
     const float k = 1.0f / kinv;
 
     const float dz = Z - z();

--- a/RecoTracker/MkFitCore/standalone/ConformalUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/standalone/ConformalUtilsMPlex.cc
@@ -114,7 +114,8 @@ namespace mkfit {
                          MPlexLV& outPar,
                          const MPlexHV& msPar0,
                          const MPlexHV& msPar1,
-                         const MPlexHV& msPar2) {
+                         const MPlexHV& msPar2,
+                         const float bScale) {
     bool debug(false);
 
     using idx_t = Matriplex::idx_t;
@@ -215,7 +216,7 @@ namespace mkfit {
     }
 
     // constant used throughtout
-    const float k = (Const::sol * Config::Bfield) / 100.0f;
+    const float k = (Const::sol * bScale * Config::Bfield) / 100.0f;
 
     MPlexQF vrx, vry, pT, px, py, pz;
 #pragma omp simd

--- a/RecoTracker/Record/interface/MkFitComponentsRecord.h
+++ b/RecoTracker/Record/interface/MkFitComponentsRecord.h
@@ -8,9 +8,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
-
-class MkFitComponentsRecord
-    : public edm::eventsetup::DependentRecordImplementation<MkFitComponentsRecord,
-                                                            edm::mpl::Vector<TrackerRecoGeometryRecord,
-                                                                             IdealMagneticFieldRecord> > {};
+class MkFitComponentsRecord : public edm::eventsetup::DependentRecordImplementation<
+                                  MkFitComponentsRecord,
+                                  edm::mpl::Vector<TrackerRecoGeometryRecord, IdealMagneticFieldRecord> > {};
 #endif

--- a/RecoTracker/Record/interface/MkFitComponentsRecord.h
+++ b/RecoTracker/Record/interface/MkFitComponentsRecord.h
@@ -1,0 +1,16 @@
+#ifndef RecoTracker_Record_MkFitComponentsRecord_h
+#define RecoTracker_Record_MkFitComponentsRecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Utilities/interface/mplVector.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+
+class MkFitComponentsRecord
+    : public edm::eventsetup::DependentRecordImplementation<MkFitComponentsRecord,
+                                                            edm::mpl::Vector<TrackerRecoGeometryRecord,
+                                                                             IdealMagneticFieldRecord> > {};
+#endif

--- a/RecoTracker/Record/src/MkFitComponentsRecord.cc
+++ b/RecoTracker/Record/src/MkFitComponentsRecord.cc
@@ -1,0 +1,4 @@
+#include "RecoTracker/Record/interface/MkFitComponentsRecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(MkFitComponentsRecord);


### PR DESCRIPTION
`bScale` is derived from our nominal mkFit `Config::mag_c = 13.8114`.
 The `bScale` is saved in the `IterationConfig` and then also in `MkFinder` and `MkFitter` (via `MkBase::m_bScale`) and is then further percolated to
- propagation
- radius or Z extent computations
- (non-linearized) dxy computation wrt beam spot

The code compiles in cmssw and in standalone. For the standalone setup, an update is available in trackreco/mkFit-external#7

I tested this only in the cmssw setup on ttbar PU 50 with the default field (there was some numerical difference in one track in the pixelLess iteration on 100 events; I take it as a possible compiler reoptimization case rather than some inconsistency). 
There doesn't seem to be a reference MC setup with a different non-zero magnetic field.

@makortel @osschar please check (others are welcome to comment as well)
