### PR TITLE
Candcloner bugfixes and follow up mitigation

### DIFF
--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -321,7 +321,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     seeds = 'pixelLessStepSeeds',
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
-    candMVASel = True,
+    candMVASel = False,
     candWP = -0.7,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)

--- a/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
+++ b/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
@@ -121,7 +121,7 @@ namespace mkfit {
       return !(
           ((nLyrs <= 3 || nHits <= 3)) ||
           ((nLyrs <= 4 || nHits <= 4) && (invpt < invptmin || (thetasym > thetasymmin_l && std::abs(d0BS) > d0_max))) ||
-          ((nLyrs <= 5 || nHits <= 6) && (invpt > invptmin && thetasym > thetasymmin_h && std::abs(d0BS) > d0_max)));
+          ((nLyrs <= 5 || nHits <= 5) && (invpt > invptmin && thetasym > thetasymmin_h && std::abs(d0BS) > d0_max)));
     }
 
     template <class TRACK>

--- a/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
+++ b/RecoTracker/MkFitCMS/interface/MkStdSeqs.h
@@ -121,7 +121,7 @@ namespace mkfit {
       return !(
           ((nLyrs <= 3 || nHits <= 3)) ||
           ((nLyrs <= 4 || nHits <= 4) && (invpt < invptmin || (thetasym > thetasymmin_l && std::abs(d0BS) > d0_max))) ||
-          ((nLyrs <= 6 || nHits <= 6) && (invpt > invptmin && thetasym > thetasymmin_h && std::abs(d0BS) > d0_max)));
+          ((nLyrs <= 5 || nHits <= 6) && (invpt > invptmin && thetasym > thetasymmin_h && std::abs(d0BS) > d0_max)));
     }
 
     template <class TRACK>

--- a/RecoTracker/MkFitCMS/src/runFunctions.cc
+++ b/RecoTracker/MkFitCMS/src/runFunctions.cc
@@ -42,11 +42,11 @@ namespace mkfit {
 
     builder.begin_event(&job, nullptr, __func__);
 
-    if (do_seed_clean) {
-      // Seed cleaning not done on pixelLess / tobTec iters
-      if (itconf.m_requires_dupclean_tight)
-        StdSeq::clean_cms_seedtracks_iter(&seeds, itconf, eoh.refBeamSpot());
-    }
+    // Seed cleaning not done on pixelLess / tobTec iters
+    do_seed_clean = do_seed_clean && itconf.m_requires_dupclean_tight;
+
+    if (do_seed_clean)
+      StdSeq::clean_cms_seedtracks_iter(&seeds, itconf, eoh.refBeamSpot());
 
     // Check nans in seeds -- this should not be needed when Slava fixes
     // the track parameter coordinate transformation.

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -440,7 +440,9 @@ namespace mkfit {
         }
       }
 
-      if (itconf.m_requires_dupclean_tight)
+      bool do_seed_clean = itconf.m_requires_dupclean_tight;
+
+      if (do_seed_clean)
         StdSeq::clean_cms_seedtracks_iter(&seeds, itconf, eoh.refBeamSpot());
 
       builder.seed_post_cleaning(seeds);
@@ -449,7 +451,7 @@ namespace mkfit {
       if (seeds.size() <= 0)
         continue;
 
-      builder.find_tracks_load_seeds(seeds, itconf.m_requires_dupclean_tight);
+      builder.find_tracks_load_seeds(seeds, do_seed_clean);
 
       double time = dtime();
 

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -494,9 +494,10 @@ namespace mkfit {
       const HoTNode& hot_node = m_comb_candidate->hot_node(ch);
       int thisL = hot_node.m_hot.layer;
       if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == Hit::kHitCCCFilterIdx)) {
+        bool cStereo = trk_inf[thisL].is_stereo();
         if (trk_inf[thisL].is_pixel())
           ++pix;
-        else if (trk_inf[thisL].is_stereo()) {
+        else if (cStereo) {
           ++stereo;
           if (thisL == prevL)
             doubleStereo = thisL;
@@ -509,7 +510,7 @@ namespace mkfit {
             ++matched;  //doubleMatch, the first is counted early on
         }
         prevL = thisL;
-        prevStereo = stereo;
+        prevStereo = cStereo;
       }
       ch = hot_node.m_prev_idx;
     }
@@ -527,9 +528,10 @@ namespace mkfit {
       int thisL = hot_node.m_hot.layer;
       if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == Hit::kHitCCCFilterIdx) &&
           thisL != prevL) {
+        bool cStereo = trk_inf[thisL].is_stereo();
         if (trk_inf[thisL].is_pixel())
           ++pix;
-        else if (trk_inf[thisL].is_stereo())
+        else if (cStereo)
           ++stereo;
         else {
           //mono if not pixel, nor stereo - can be matched to stereo
@@ -538,7 +540,7 @@ namespace mkfit {
             ++matched;
         }
         prevL = thisL;
-        prevStereo = stereo;
+        prevStereo = cStereo;
       }
       ch = hot_node.m_prev_idx;
     }

--- a/RecoTracker/MkFitCore/src/CandCloner.h
+++ b/RecoTracker/MkFitCore/src/CandCloner.h
@@ -24,7 +24,7 @@ namespace mkfit {
     void release();
 
     void begin_eta_bin(EventOfCombCandidates *e_o_ccs,
-                       std::vector<std::pair<int, int>> *update_list,
+                       std::vector<UpdateIndices> *update_list,
                        std::vector<std::vector<TrackCand>> *extra_cands,
                        int start_seed,
                        int n_seeds);
@@ -56,7 +56,7 @@ namespace mkfit {
 
     const IterationParams *mp_iteration_params = nullptr;
     EventOfCombCandidates *mp_event_of_comb_candidates;
-    std::vector<std::pair<int, int>> *mp_kalman_update_list;
+    std::vector<UpdateIndices> *mp_kalman_update_list;
     std::vector<std::vector<TrackCand>> *mp_extra_cands;
 
 #if defined(CC_TIME_ETA) or defined(CC_TIME_LAYER)

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -304,6 +304,47 @@ namespace {
     }
   }
 
+  inline void CovXYconstrain(const MPlexQF& R00, const MPlexQF& R01, const MPlexLS& Ci, MPlexLS& Co) {
+    // C is transformed to align along y after rotation and rotated back
+
+    typedef float T;
+    const idx_t N = NN;
+
+    const T* r00 = R00.fArray;
+    ASSUME_ALIGNED(r00, 64);
+    const T* r01 = R01.fArray;
+    ASSUME_ALIGNED(r01, 64);
+    const T* ci = Ci.fArray;
+    ASSUME_ALIGNED(ci, 64);
+    T* co = Co.fArray;
+    ASSUME_ALIGNED(co, 64);
+
+#pragma omp simd
+    for (int n = 0; n < N; ++n) {
+      // a bit loopy to avoid temporaries
+      co[0 * N + n] = r00[n] * r00[n] * ci[0 * N + n] + 2 * r00[n] * r01[n] * ci[1 * N + n] + r01[n] * r01[n] * ci[2 * N + n];
+      co[1 * N + n] = r00[n] * r01[n] * co[0 * N + n];
+      co[2 * N + n] = r01[n] * r01[n] * co[0 * N + n];
+      co[0 * N + n] = r00[n] * r00[n] * co[0 * N + n];
+
+      co[3 * N + n] = r00[n] * ci[3 * N + n] + r01[n] * ci[4 * N + n];
+      co[4 * N + n] = r01[n] * co[3 * N + n];
+      co[3 * N + n] = r00[n] * co[3 * N + n];
+
+      co[6 * N + n] = r00[n] * ci[6 * N + n] + r01[n] * ci[7 * N + n];
+      co[7 * N + n] = r01[n] * co[6 * N + n];
+      co[6 * N + n] = r00[n] * co[6 * N + n];
+
+      co[10 * N + n] = r00[n] * ci[10 * N + n] + r01[n] * ci[11 * N + n];
+      co[11 * N + n] = r01[n] * co[10 * N + n];
+      co[10 * N + n] = r00[n] * co[10 * N + n];
+
+      co[15 * N + n] = r00[n] * ci[15 * N + n] + r01[n] * ci[16 * N + n];
+      co[16 * N + n] = r01[n] * co[15 * N + n];
+      co[15 * N + n] = r00[n] * co[15 * N + n];
+    }
+  }
+
   void KalmanGain(const MPlexLS& A, const MPlex2S& B, MPlexL2& C) {
     // C = A * B, C is 6x2, A is 6x6 sym , B is 2x2
 
@@ -425,7 +466,7 @@ namespace mkfit {
                     MPlexLS& outErr,
                     MPlexLV& outPar,
                     const int N_proc) {
-    kalmanOperation(KFO_Update_Params, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
+    kalmanOperation(KFO_Update_Params | KFO_Local_Cov, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
   }
 
   void kalmanPropagateAndUpdate(const MPlexLS& psErr,
@@ -449,9 +490,9 @@ namespace mkfit {
 
       propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
 
-      kalmanOperation(KFO_Update_Params, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
+      kalmanOperation(KFO_Update_Params | KFO_Local_Cov, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
-      kalmanOperation(KFO_Update_Params, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
+      kalmanOperation(KFO_Update_Params | KFO_Local_Cov, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     }
     for (int n = 0; n < NN; ++n) {
       if (outPar.At(n, 3, 0) < 0) {
@@ -608,9 +649,13 @@ namespace mkfit {
     }
 
     if (kfOp & KFO_Update_Params) {
+      MPlexLS psErrLoc = psErr;
+      if (kfOp & KFO_Local_Cov)
+        CovXYconstrain(rotT00, rotT01, psErr, psErrLoc);
+
       MPlexLH K;                                      // kalman gain, fixme should be L2
       KalmanHTG(rotT00, rotT01, resErr_loc, tempHH);  // intermediate term to get kalman gain (H^T*G)
-      KalmanGain(psErr, tempHH, K);
+      KalmanGain(psErrLoc, tempHH, K);
 
       MultResidualsAdd(K, psPar, res_loc, outPar);
       MPlexLL tempLL;
@@ -618,12 +663,21 @@ namespace mkfit {
       squashPhiMPlex(outPar, N_proc);  // ensure phi is between |pi|
 
       KHMult(K, rotT00, rotT01, tempLL);
-      KHC(tempLL, psErr, outErr);
-      outErr.subtract(psErr, outErr);
+      KHC(tempLL, psErrLoc, outErr);
+      outErr.subtract(psErrLoc, outErr);
 
 #ifdef DEBUG
       {
         dmutex_guard;
+        if (kfOp & KFO_Local_Cov) {
+          printf("psErrLoc:\n");
+          for (int i = 0; i < 6; ++i) {
+            for (int j = 0; j < 6; ++j)
+              printf("% 8e ", psErrLoc.At(0, i, j));
+            printf("\n");
+          }
+          printf("\n");
+        }
         printf("res_glo:\n");
         for (int i = 0; i < 3; ++i) {
           printf("%8f ", res_glo.At(0, i, 0));

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -322,7 +322,8 @@ namespace {
 #pragma omp simd
     for (int n = 0; n < N; ++n) {
       // a bit loopy to avoid temporaries
-      co[0 * N + n] = r00[n] * r00[n] * ci[0 * N + n] + 2 * r00[n] * r01[n] * ci[1 * N + n] + r01[n] * r01[n] * ci[2 * N + n];
+      co[0 * N + n] =
+          r00[n] * r00[n] * ci[0 * N + n] + 2 * r00[n] * r01[n] * ci[1 * N + n] + r01[n] * r01[n] * ci[2 * N + n];
       co[1 * N + n] = r00[n] * r01[n] * co[0 * N + n];
       co[2 * N + n] = r01[n] * r01[n] * co[0 * N + n];
       co[0 * N + n] = r00[n] * r00[n] * co[0 * N + n];
@@ -490,9 +491,11 @@ namespace mkfit {
 
       propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
 
-      kalmanOperation(KFO_Update_Params | KFO_Local_Cov, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
+      kalmanOperation(
+          KFO_Update_Params | KFO_Local_Cov, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
-      kalmanOperation(KFO_Update_Params | KFO_Local_Cov, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
+      kalmanOperation(
+          KFO_Update_Params | KFO_Local_Cov, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     }
     for (int n = 0; n < NN; ++n) {
       if (outPar.At(n, 3, 0) < 0) {

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -8,7 +8,7 @@ namespace mkfit {
 
   //------------------------------------------------------------------------------
 
-  enum KalmanFilterOperation { KFO_Calculate_Chi2 = 1, KFO_Update_Params = 2 };
+  enum KalmanFilterOperation { KFO_Calculate_Chi2 = 1, KFO_Update_Params = 2, KFO_Local_Cov = 4 };
 
   //------------------------------------------------------------------------------
 

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -972,7 +972,8 @@ namespace mkfit {
 
     const int n_seeds = end_seed - start_seed;
 
-    std::vector<std::pair<int, int>> seed_cand_idx, seed_cand_update_idx;
+    std::vector<std::pair<int, int>> seed_cand_idx;
+    std::vector<UpdateIndices> seed_cand_update_idx;
     seed_cand_idx.reserve(n_seeds * params.maxCandsPerSeed);
     seed_cand_update_idx.reserve(n_seeds * params.maxCandsPerSeed);
 
@@ -1108,9 +1109,9 @@ namespace mkfit {
       for (int itrack = 0; itrack < theEndUpdater; itrack += NN) {
         const int end = std::min(itrack + NN, theEndUpdater);
 
-        mkfndr->inputTracksAndHitIdx(eoccs.refCandidates(), seed_cand_update_idx, itrack, end, true);
+        mkfndr->inputTracksAndHits(eoccs.refCandidates(), layer_of_hits, seed_cand_update_idx, itrack, end, true);
 
-        mkfndr->updateWithLastHit(layer_of_hits, end - itrack, fnd_foos);
+        mkfndr->updateWithLoadedHit(end - itrack, fnd_foos);
 
         // copy_out the updated track params, errors only (hit-idcs and chi2 already set)
         mkfndr->copyOutParErr(eoccs.refCandidates_nc(), end - itrack, false);

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -137,8 +137,8 @@ namespace mkfit {
       m_CandIdx(imp, 0, 0) = idxs[i].cand_idx;
 
       const Hit &hit = layer_of_hits.refHit(idxs[i].hit_idx);
-      m_msErr.copyIn(i, hit.errArray());
-      m_msPar.copyIn(i, hit.posArray());
+      m_msErr.copyIn(imp, hit.errArray());
+      m_msPar.copyIn(imp, hit.posArray());
     }
   }
 

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1520,7 +1520,7 @@ namespace mkfit {
       if (LI.is_barrel()) {
         propagateTracksToHitR(m_msPar, N_proc, m_prop_config->backward_fit_pflags);
 
-        kalmanOperation(KFO_Calculate_Chi2 | KFO_Update_Params,
+        kalmanOperation(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
                         m_Err[iP],
                         m_Par[iP],
                         m_msErr,
@@ -1682,7 +1682,7 @@ namespace mkfit {
       if (LI.is_barrel()) {
         propagateTracksToHitR(m_msPar, N_proc, m_prop_config->backward_fit_pflags, &no_mat_effs);
 
-        kalmanOperation(KFO_Calculate_Chi2 | KFO_Update_Params,
+        kalmanOperation(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
                         m_Err[iP],
                         m_Par[iP],
                         m_msErr,

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -208,7 +208,6 @@ namespace mkfit {
       m_NInsideMinusOneHits(mslot, 0, 0) = trk.nInsideMinusOneHits();
       m_NTailMinusOneHits(mslot, 0, 0) = trk.nTailMinusOneHits();
 
-      m_LastHoT[mslot] = trk.getLastHitOnTrack();
       m_CombCand[mslot] = trk.combCandidate();
       m_TrkStatus[mslot] = trk.getStatus();
     }
@@ -304,7 +303,6 @@ namespace mkfit {
     MPlexQI m_NTailMinusOneHits;        // sub: before we copied all hit idcs and had a loop counting them only
     MPlexQI m_LastHitCcIndex;           // add: index of last hit in m_CombCand hit tree, STD only
     TrackBase::Status m_TrkStatus[NN];  // STD only, status bits
-    HitOnTrack m_LastHoT[NN];
     CombCandidate *m_CombCand[NN];
     // const TrackCand *m_TrkCand[NN]; // hmmh, could get all data through this guy ... but scattered
     // storing it in now for bkfit debug printouts

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -28,6 +28,15 @@ namespace mkfit {
   class Event;
 #endif
 
+  struct UpdateIndices
+  {
+    int seed_idx;
+    int cand_idx;
+    int hit_idx;
+
+    UpdateIndices(int si, int ci, int hi) : seed_idx(si), cand_idx(ci), hit_idx(hi) {}
+  };
+
   class MkFinder : public MkBase {
     friend class MkBuilder;
 
@@ -64,6 +73,13 @@ namespace mkfit {
                               int beg,
                               int end,
                               bool inputProp);
+
+    void inputTracksAndHits(const std::vector<CombCandidate> &tracks,
+                            const LayerOfHits &layer_of_hits,
+                            const std::vector<UpdateIndices> &idxs,
+                            int beg,
+                            int end,
+                            bool inputProp);
 
     void inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                               const std::vector<std::pair<int, IdxChi2List>> &idxs,
@@ -119,7 +135,7 @@ namespace mkfit {
                                    const int N_proc,
                                    const FindingFoos &fnd_foos);
 
-    void updateWithLastHit(const LayerOfHits &layer_of_hits, int N_proc, const FindingFoos &fnd_foos);
+    void updateWithLoadedHit(int N_proc, const FindingFoos &fnd_foos);
 
     void copyOutParErr(std::vector<CombCandidate> &seed_cand_vec, int N_proc, bool outputProp) const;
 

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -28,8 +28,7 @@ namespace mkfit {
   class Event;
 #endif
 
-  struct UpdateIndices
-  {
+  struct UpdateIndices {
     int seed_idx;
     int cand_idx;
     int hit_idx;

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -249,7 +249,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
 #pragma omp simd
       for (int n = nmin; n < nmax; ++n) {
         oor0[n - nmin] =
-            (r0[n - nmin] > 0.f && std::abs(r[n - nmin] - r0[n - nmin]) < 0.0001f) ? 1.f / r0[n - nmin] : 0.f;
+            (r0[n - nmin] > 0.f && std::abs(r[n - nmin] - r0[n - nmin]) > 0.0001f) ? 1.f / r0[n - nmin] : 0.f;
       }
 #pragma omp simd
       for (int n = nmin; n < nmax; ++n) {


### PR DESCRIPTION
- consistent handling of seeds sorting, which affected iterations that do not have seed merging (pixelLess)
- Fixes in the candCloner:
    - properly trace the overlap hits, to not be used in the Kalman updates (these were out of order and were used for Kalman updates)
    - do not add overlap hit chi2 to the candidate score (the overlap hits are meant to be auxiliary during building)

Based on the validation plots http://uaf-10.t2.ucsd.edu/~legianni/check-clonerFIX2/ ,
- out-of-the-box (OOB)  there impact is rather minimal
    - the efficiency is almost unchanged (small increase at very low pt)
    - fakes are up a bit (likely via pixelLess); duplicates are a bit down
    - tracks are slightly longer (more visible in the barrel)
- the initialStep built tracks are almost unchanged ; average fakes are lower (–5% in some bins) at low pt, but the average vs eta has an increase in the barrel (and some decrease in the endcaps). Tracks are longer by about 0.25 hits
- highPtTriplet built tracks have up to 5% fractional increase in the efficiency at lower pt, but fakes are up by a few % absolute scale **this iteration comparison is using trackDNN candidate/builtTracks selection** (need a check without it). Tracks are longer by 0.06 hits on average (the distribution has an increase in the shorter tracks)
- detachedQuad built tracks are mostly unchanged. Tracks are longer by 0.15 hits
- detachedTriplet built tracks have up to 10% more (fractional) efficiency below 1 GeV, the fake rate is up by about 5% at low pt as well (it is on average higher for eta < 2, and is lower for eta > 2); the fake rate increase is most visible for d0>0.1 cm. Tracks are longer by 0.13 hits, but there is an increased component of short tracks (5-7 hits).
- pixelLess is the most affected **this iteration comparison is using trackDNN candidate/builtTracks selection** (need a check without it): 
    - the efficiency is up by a few % below 2 GeV; by about 15% for large displacements (this region is known to be depressed by the DNN selections )
    - the fake rate is up by about 20% 
    - the track length is down by 0.2 on average; there is a small component of more longer tracks, but the average is overtaken by a factor of a few more short tracks

So, based on the observations, I think that this PR can not go as is
- [ ] (already clear) we need some mitigation updates in the pixelLess selections to reduce the number of fakes.
- [ ] MTV plots for running without candidate DNN are needed 
- [ ] need to get comparisons in the softQCD sample
- [ ] `extended` comparisons are needed to see more details

