### PR TITLE
correct multiple scattering in CCS frame

### DIFF
--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -242,13 +242,14 @@ namespace mkfit {
     const float theta = std::abs(m_Par[ipar].At(itrk, 5, 0) - Const::PIOver2);
 
     float max_invpt = invpt;
-    if (invpt > 10.0)
-      max_invpt = 10.0;
+    if (invpt > 10.0f)
+      max_invpt = 10.0f;
 
     float this_c2 = ILC.c_c2_0 * max_invpt + ILC.c_c2_1 * theta + ILC.c_c2_2;
     // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
     if ((ILC.c_c2_sf) * this_c2 > minChi2Cut)
-      return ILC.c_c2_sf * this_c2;
+      //clamp the parametric cut to twice the default
+      return std::min(ILC.c_c2_sf * this_c2, 2.f * minChi2Cut);
     else
       return minChi2Cut;
   }

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -992,8 +992,11 @@ namespace mkfit {
       if (radL < 1e-13f)
         continue;  //ugly, please fixme
       const float theta = outPar.constAt(n, 5, 0);
-      const float pt = 1.f / outPar.constAt(n, 3, 0);  //fixme, make sure it is positive?
+      const float ipt = outPar.constAt(n, 3, 0);
+      const float pt = 1.f / ipt;
+      const float ipt2 = ipt * ipt;
       const float p = pt / std::sin(theta);
+      const float pz = p * std::cos(theta);
       const float p2 = p * p;
       constexpr float mpi = 0.140;       // m=140 MeV, pion
       constexpr float mpi2 = mpi * mpi;  // m=140 MeV, pion
@@ -1011,8 +1014,9 @@ namespace mkfit {
       // const float thetaMSC2 = thetaMSC*thetaMSC;
       const float thetaMSC = 0.0136f * (1.f + 0.038f * std::log(radL)) / (beta * p);  // eq 32.15
       const float thetaMSC2 = thetaMSC * thetaMSC * radL;
-      outErr.At(n, 4, 4) += thetaMSC2;
-      // outErr.At(n, 4, 5) += thetaMSC2;
+      outErr.At(n, 3, 3) += thetaMSC2 * pz * pz * ipt2 * ipt2;
+      outErr.At(n, 3, 5) -= thetaMSC2 * pz * ipt2;
+      outErr.At(n, 4, 4) += thetaMSC2 * p2 * ipt2;
       outErr.At(n, 5, 5) += thetaMSC2;
       //std::cout << "beta=" << beta << " p=" << p << std::endl;
       //std::cout << "multiple scattering thetaMSC=" << thetaMSC << " thetaMSC2=" << thetaMSC2 << " radL=" << radL << std::endl;


### PR DESCRIPTION
While debugging the candidates I had a feeling that the multiple scattering is not coming out quite right.

Before this PR we simply have `θ^2` added in both φ and θ diagonal elements of the covariance. This is missing the part that pt can change via scattering (only p is fixed) and also that the unit area in φ effectively increases as cotθ.

The updated cov for multiple scattering  is
```
           /  pz^2/pt^4      0      -pz/pt^2  \
θ_mul^2  * |       0      p^2/pt^2      0      |
           \  -pz/pt^2       0          1     /
```

The derivation is fairly simple in a tangent frame defined by (normalized) vectors `vecτ = vecp/p; vecκ = vecz x vecτ * p/pt = (-τ_y, τ_x, 0) * p/pt;  vecλ = vecτ x vecκ * p/pt = (-τ_x * τ_z *p/pt, -τ_y * τ_z *p/pt, pt/p)`.
The multiple scattering in the tangent frame is just `diag(0, p^2*θ_mul^2, p^2*θ_mul^2)`. From here the rotation to the Cartesian frame is `R = (vecτ^T, vecκ^T, vecλ^T)` and the Jacobian from Cartesian to CCS is
```
-τ_x *p/pt^3   -τ_y *p/pt^3      0
κ_x /pt           κ_y /pt     κ_z /pt
-λ_x /p          -λ_y /p      λ_z /p
```
and from here the Jacobian from the tangent to CCS is
```
-1/(p*pt)    0      pz/(p*pt^2)
0           1/pt      0
0            0      -1/p
```


clearly, this affects all iterations, but the impact will be decreasing with increasing pt.
From the plots below, it's another case of conceptually significant change leading to fairly little change in the efficiency

Here are some comparisons with ckf as a reference  
<img width="256" alt="image" src="https://user-images.githubusercontent.com/4676718/185706008-c0f5a388-aae0-4480-93f8-10edcb7b78d3.png">
look for orange->pink for the old default mkf6 setup (with pixelLess mkfit) or red->black for the new mkf5 (pixelLess CKF)

in ttbar https://slava77.web.cern.ch/slava77/mic/CMSSW_12_4_0-pixmkf/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/mtv-ckf-pixckf-mkfit-6-pr102-mul-aebeb65/
- initial step built tracks: there are a bit more fakes, a bit less eff pt < 0.9 GeV; more visible improvements are in nhits: missing outer 1.94 -> 1.69; nHits 14.0 -> 14.5 <img width="1224" alt="image" src="https://user-images.githubusercontent.com/4676718/185705027-931e6783-af9d-409f-902d-2b637d6c3695.png">
- pixel-less built tracks have some loss of efficiency (and increase in fakes) for high |eta|>2 <img width="1228" alt="image" src="https://user-images.githubusercontent.com/4676718/185705523-ea6e5b0c-405c-4c38-bc01-02cf0322dd59.png">
- all tracks OOB show some improvement in resolution <img width="284" alt="image" src="https://user-images.githubusercontent.com/4676718/185708776-7daec2ca-dfa6-49c5-8ecf-df371f85ed6d.png"> 


soft QCD https://slava77.web.cern.ch/slava77/mic/CMSSW_12_4_0-pixmkf/SoftQCD_XiFilter/mtv-ckf-pixckf-mkfit-6-pr102-mul-aebeb65/
- mkFit iterations have longer tracks, similar to ttbar
- pixelLess built track efficiency is a bit worse (similar pattern as in ttbar), "all tracks by originalAlgo" have much smaller changes  <img width="1230" alt="image" src="https://user-images.githubusercontent.com/4676718/185707846-77e34334-b27f-4332-956d-41c0a6f787fd.png">
    - from left to right: built tracks (1), allByOriginalAlgo (2-4) with eff vs vtx pos pt>0.9 GeV (3) and  vtx pos pt<0.9 GeV (4). **There is only a tiny improvement in (3) while more would be needed to re-enable pixelLess with mkFIt**
- for the pixelLess (built tracks) probably the clearest improvement is in the pickup of the pixel hits: it is almost recovered for |eta|>1 . <img width="1226" alt="image" src="https://user-images.githubusercontent.com/4676718/185706381-60497559-bb92-429f-8fc5-5a595c23251b.png">
    - note that the track loss |eta|>2 does not balance with fake increase, which suggests that this may be fixable (~but still needs debugging~):
        - (upd [Aug 25, see below](https://github.com/trackreco/cmssw/pull/106#issuecomment-1227844685)): the apparent loss of efficiency here is driven by a reduction in the input seeding, the track building is actually improving overall

Since the multiple scattering is generally increased, I expect that at lower pt the chi2 windows will need to be revisited and likely reduced. 
So, I'm leaving this as a draft PR initially.

P.S. Considering the improvement in the resolution, perhaps this can fix at least one problem with the low-pt iterations? @mmasciov 