### PR TITLE
Do not compute Q probability in SiPixel template CPE for iterative tracking

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -124,7 +124,7 @@ public:
       if (prob > 1.0f && prob <= 1.0f + std::numeric_limits<float>::epsilon()) {
         prob = 1;
       } else if (prob < 0.0f || prob > 1.0f + std::numeric_limits<float>::epsilon()) {
-        warningOutOfBoundProb("Q", prob, qualWord);
+        //warningOutOfBoundProb("Q", prob, qualWord);
         prob = 0;
       }
       double draw = (prob <= 1E-5) ? 255 : -log((double)prob) * probY_1_over_log_units;

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -123,7 +123,7 @@ public:
     inline void setProbabilityQ(float prob, QualWordType& qualWord) const {
       if (prob > 1.0f && prob <= 1.0f + std::numeric_limits<float>::epsilon()) {
         prob = 1;
-      } else if (prob == -1) {
+      } else if (prob == -1.0f) {
         // default prob in absence of Q probability computation is -1 --> set to 0
         prob = 0;
       } else if (prob < 0.0f || prob > 1.0f + std::numeric_limits<float>::epsilon()) {

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -123,8 +123,11 @@ public:
     inline void setProbabilityQ(float prob, QualWordType& qualWord) const {
       if (prob > 1.0f && prob <= 1.0f + std::numeric_limits<float>::epsilon()) {
         prob = 1;
+      } else if (prob == -1) {
+        // default prob in absence of Q probability computation is -1 --> set to 0
+        prob = 0;
       } else if (prob < 0.0f || prob > 1.0f + std::numeric_limits<float>::epsilon()) {
-        //warningOutOfBoundProb("Q", prob, qualWord);
+        warningOutOfBoundProb("Q", prob, qualWord);
         prob = 0;
       }
       double draw = (prob <= 1E-5) ? 255 : -log((double)prob) * probY_1_over_log_units;

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEClusterRepair_cfi.py
@@ -2,4 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.SiPixelRecHits._templates2_default_cfi import _templates2_default
 templates2 = _templates2_default.clone()
-
+templates2_speed0 = _templates2_default.clone(
+    ComponentName = "PixelCPEClusterRepairWithoutProbQ",
+    speed = 0
+)

--- a/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
+++ b/RecoTracker/TrackProducer/python/TrackProducerIterativeDefault_cfi.py
@@ -5,4 +5,5 @@ TrackProducer = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
     useSimpleMF = cms.bool(True),
     SimpleMagneticField = cms.string("ParabolicMf"),
     Propagator = cms.string('PropagatorWithMaterialParabolicMf'),
+    TTRHBuilder = cms.string('WithAngleAndTemplateWithoutProbQ')
 )

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -8,6 +8,8 @@ TTRHBuilderAngleAndTemplate = tkTransientTrackingRecHitBuilderESProducer.clone(S
                                                                                Matcher = 'StandardMatcher',
                                                                                ComputeCoarseLocalPositionFromDisk = False)
 
+TTRHBuilderAngleAndTemplateWithoutProbQ = TTRHBuilderAngleAndTemplate.clone(ComponentName = 'WithAngleAndTemplateWithoutProbQ')
+
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, 
                              Phase2StripCPE = 'Phase2StripCPE',
@@ -16,6 +18,7 @@ trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate,
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
+phase1Pixel.toModify(TTRHBuilderAngleAndTemplateWithoutProbQ, PixelCPE = 'PixelCPEClusterRepairWithoutProbQ')
 
 # Turn off template reco for phase 2 (when not supported)
 from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -8,8 +8,6 @@ TTRHBuilderAngleAndTemplate = tkTransientTrackingRecHitBuilderESProducer.clone(S
                                                                                Matcher = 'StandardMatcher',
                                                                                ComputeCoarseLocalPositionFromDisk = False)
 
-TTRHBuilderAngleAndTemplateWithoutProbQ = TTRHBuilderAngleAndTemplate.clone(ComponentName = 'WithAngleAndTemplateWithoutProbQ')
-
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, 
                              Phase2StripCPE = 'Phase2StripCPE',
@@ -18,9 +16,11 @@ trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate,
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEClusterRepair')
+
+TTRHBuilderAngleAndTemplateWithoutProbQ = TTRHBuilderAngleAndTemplate.clone(ComponentName = 'WithAngleAndTemplateWithoutProbQ')
 phase1Pixel.toModify(TTRHBuilderAngleAndTemplateWithoutProbQ, PixelCPE = 'PixelCPEClusterRepairWithoutProbQ')
 
 # Turn off template reco for phase 2 (when not supported)
 from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
 PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = 'PixelCPEGeneric')
-
+PixelCPEGeneric.toModify(TTRHBuilderAngleAndTemplateWithoutProbQ, PixelCPE = 'PixelCPEGeneric')


### PR DESCRIPTION
### PR description:

As per title, using option `speed=0` for SiPixel template CPE with cluster repair (default for phase-1), that disables the computation of Q probability.
In particular, a new instance of transient track recHit builder is defined with option `speed=0`, and only used in main iterative tracking.
At the same time, a number of warnings are commented out, that do not foresee the possibility to not compute Q probability.

### PR validation:

As shown in [report](https://indico.cern.ch/event/1199474/#1-follow-up-on-pixel-cpe-speed), disabling the Q probability computation does not affect physics (zero impact), while it allows to reduce the track final fit time by about 15-20%.
