### PR TITLE
Make propagation failure state available in steering code

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -7,11 +7,12 @@ CMS_DIR := ${SRCDIR}/RecoTracker/MkFitCMS
 LIB_CMS := ../libMicCMS.so
 MAIN    := ../mkFit
 WRMEMF  := ../writeMemoryFile
-DICTPCM := ../DictsDict_rdict.pcm
+WMF_DICT_PCM := ../WriteMemFileDict_rdict.pcm
+SHELL_DICT_PCM := ../ShellDict_rdict.pcm
 
 TGTS := ${LIB_CMS} ${MAIN}
 ifdef WITH_ROOT
-TGTS += ${WRMEMF} ${DICTPCM}
+TGTS += ${WRMEMF} ${WMF_DICT_PCM}
 endif
 
 .PHONY: all clean distclean
@@ -21,9 +22,14 @@ all: ${TGTS}
 SRCS := $(wildcard ${CMS_DIR}/src/*.cc) $(wildcard ${SACMS}/*.cc)
 ifdef WITH_ROOT
 SRCS += ${SACMS}/tkNtuple/WriteMemoryFile.cc
-DictsDict.cc ${DICTPCM}: ${SACMS}/tkNtuple/DictsLinkDef.h
-	rootcint -v3 -f $@ $<
-	mv DictsDict_rdict.pcm ${DICTPCM}
+WriteMemFileDict.cc ${WMF_DICT_PCM}: ${SACMS}/tkNtuple/DictsLinkDef.h
+	rootcling -f WriteMemFileDict.cc $<
+	mv WriteMemFileDict_rdict.pcm ${WMF_DICT_PCM}
+
+SRCS += ShellDict.cc
+ShellDict.cc ${SHELL_DICT_PCM}: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+	rootcling -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+	mv ShellDict_rdict.pcm ${SHELL_DICT_PCM}
 endif
 SRCB := $(notdir ${SRCS})
 DEPS := $(SRCB:.cc=.d)

--- a/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
+++ b/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
@@ -139,7 +139,7 @@ namespace mkfit {
       const auto label = tkcand.label();
       TrackExtra extra(label);
 
-      // track_print(tkcand, "XXX");
+      // track_print(event, tkcand, "quality_process -> track_print:");
 
       // access temp seed trk and set matching seed hits
       const auto &seed = event->seedTracks_[itrack];
@@ -187,11 +187,6 @@ namespace mkfit {
         // grep "FOUND_LABEL" | sort -n -k 8,8 -k 2,2
         // printf("FOUND_LABEL %6d  pT_mc= %8.2f eta_mc= %8.2f event= %d\n", label, pTmc, etamc, event->evtID());
       }
-
-#ifdef SELECT_SEED_LABEL
-      if (label == SELECT_SEED_LABEL)
-        track_print(tkcand, "MkBuilder::quality_process SELECT_SEED_LABEL:");
-#endif
 
       float pTcmssw = 0.f, etacmssw = 0.f, phicmssw = 0.f;
       int nfoundcmssw = -1;

--- a/RecoTracker/MkFitCMS/standalone/Shell.cc
+++ b/RecoTracker/MkFitCMS/standalone/Shell.cc
@@ -1,0 +1,546 @@
+#include "RecoTracker/MkFitCMS/standalone/Shell.h"
+
+#include "RecoTracker/MkFitCore/src/Debug.h"
+
+// #include "RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h"
+
+#include "RecoTracker/MkFitCMS/interface/runFunctions.h"
+
+#include "RecoTracker/MkFitCore/interface/HitStructures.h"
+#include "RecoTracker/MkFitCore/interface/MkBuilder.h"
+#include "RecoTracker/MkFitCore/src/MkFitter.h"
+#include "RecoTracker/MkFitCMS/interface/MkStdSeqs.h"
+#include "RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.h"
+
+#include "RecoTracker/MkFitCore/interface/Config.h"
+#include "RecoTracker/MkFitCore/standalone/ConfigStandalone.h"
+
+#include "RecoTracker/MkFitCore/standalone/Event.h"
+
+#ifndef NO_ROOT
+#include "TROOT.h"
+#include "TRint.h"
+#endif
+
+#include "oneapi/tbb/task_arena.h"
+
+#include <vector>
+
+// clang-format off
+
+namespace {
+  constexpr int algos[] = {4, 22, 23, 5, 24, 7, 8, 9, 10, 6};  // 10 iterations
+  constexpr int n_algos = sizeof(algos) / sizeof(int);
+
+  const char* b2a(bool b) { return b ? "true" : "false"; }
+}
+
+namespace mkfit {
+
+  Shell::Shell(std::vector<DeadVec> &dv, const std::string &in_file, int start_ev)
+    : m_deadvectors(dv)
+  {
+    m_eoh = new EventOfHits(Config::TrkInfo);
+    m_builder = new MkBuilder(Config::silent);
+
+    m_backward_fit = Config::backwardFit;
+
+    m_data_file = new DataFile;
+    m_evs_in_file = m_data_file->openRead(in_file, Config::TrkInfo.n_layers());
+
+    m_event = new Event(0, Config::TrkInfo.n_layers());
+    GoToEvent(start_ev);
+  }
+
+  void Shell::Run() {
+#ifndef NO_ROOT
+    std::vector<const char *> argv = { "mkFit", "-l" };
+    int argc = argv.size();
+    TRint rint("mkFit-shell", &argc, const_cast<char**>(argv.data()));
+
+    char buf[256];
+    sprintf(buf, "mkfit::Shell &s = * (mkfit::Shell*) %p;", this);
+    gROOT->ProcessLine(buf);
+    printf("Shell &s variable is set\n");
+
+    rint.Run(true);
+    printf("Shell::Run finished\n");
+#else
+    printf("Shell::Run() no root, we rot -- erroring out. Recompile with WITH_ROOT=1\n");
+    exit(1);
+#endif
+  }
+
+  void Shell::Status() {
+    printf("On event %d, selected iteration index %d, algo %d - %s\n"
+          "  debug = %s, use_dead_modules = %s\n"
+           "  clean_seeds = %s, backward_fit = %s, remove_duplicates = %s\n",
+           m_event->evtID(), m_it_index, algos[m_it_index], TrackBase::algoint_to_cstr(algos[m_it_index]),
+           b2a(g_debug), b2a(Config::useDeadModules),
+           b2a(m_clean_seeds), b2a(m_backward_fit), b2a(m_remove_duplicates));
+  }
+
+  //===========================================================================
+  // Event navigation / processing
+  //===========================================================================
+
+  void Shell::GoToEvent(int eid) {
+    if (eid < 1) {
+      fprintf(stderr, "Requested event %d is less than 1 -- 1 is the first event, %d is total number of events in file\n",
+             eid, m_evs_in_file);
+      throw std::runtime_error("event out of range");
+    }
+    if (eid > m_evs_in_file) {
+      fprintf(stderr, "Requested event %d is grater than total number of events in file %d\n",
+             eid, m_evs_in_file);
+      throw std::runtime_error("event out of range");
+    }
+
+    int pos = m_event->evtID();
+    if (eid > pos) {
+      m_data_file->skipNEvents(eid - pos - 1);
+    } else {
+      m_data_file->rewind();
+      m_data_file->skipNEvents(eid - 1);
+    }
+    m_event->reset(eid);
+    m_event->read_in(*m_data_file);
+    StdSeq::loadHitsAndBeamSpot(*m_event, *m_eoh);
+    if (Config::useDeadModules) {
+      StdSeq::loadDeads(*m_eoh, m_deadvectors);
+    }
+
+    printf("At event %d\n", eid);
+  }
+
+  void Shell::NextEvent(int skip) {
+    GoToEvent(m_event->evtID() + skip);
+  }
+
+  void Shell::ProcessEvent(SeedSelect_e seed_select, int selected_seed, int count) {
+    // count is only used for SS_IndexPreCleaning and SS_IndexPostCleaning.
+    //       There are no checks for upper bounds, ie, if requested seeds beyond the first one exist.
+
+    const IterationConfig &itconf = Config::ItrInfo[m_it_index];
+    IterationMaskIfc mask_ifc;
+    m_event->fill_hitmask_bool_vectors(itconf.m_track_algorithm, mask_ifc.m_mask_vector);
+
+    m_seeds.clear();
+    m_tracks.clear();
+
+    {
+      int n_algo = 0; // seeds are grouped by algo
+      for (auto &s : m_event->seedTracks_) {
+        if (s.algoint() == itconf.m_track_algorithm) {
+          if (seed_select == SS_UseAll || seed_select == SS_IndexPostCleaning) {
+            m_seeds.push_back(s);
+          } else if (seed_select == SS_Label && s.label() == selected_seed) {
+            m_seeds.push_back(s);
+            break;
+          } else if (seed_select == SS_IndexPreCleaning && n_algo >= selected_seed) {
+            m_seeds.push_back(s);
+            if (--count <= 0)
+              break;
+          }
+          ++n_algo;
+        } else if (n_algo > 0)
+          break;
+      }
+    }
+
+    printf("Shell::ProcessEvent running over %d seeds\n", (int) m_seeds.size());
+
+    // Equivalent to run_OneIteration(...) without MkBuilder::release_memory().
+    // If seed_select == SS_IndexPostCleaning the given seed is picked after cleaning.
+    {
+      const TrackerInfo &trackerInfo = Config::TrkInfo;
+      const EventOfHits &eoh = *m_eoh;
+      const IterationMaskIfcBase &it_mask_ifc = mask_ifc;
+      MkBuilder &builder = *m_builder;
+      TrackVec &seeds = m_seeds;
+      TrackVec &out_tracks = m_tracks;
+      bool do_seed_clean = m_clean_seeds;
+      bool do_backward_fit = m_backward_fit;
+      bool do_remove_duplicates = m_remove_duplicates;
+
+      MkJob job({trackerInfo, itconf, eoh, eoh.refBeamSpot(), &it_mask_ifc});
+
+      builder.begin_event(&job, m_event, __func__);
+
+      // Seed cleaning not done on all iterations.
+      do_seed_clean = m_clean_seeds && itconf.m_seed_cleaner;
+
+      if (do_seed_clean)
+        itconf.m_seed_cleaner(seeds, itconf, eoh.refBeamSpot());
+
+      // Check nans in seeds -- this should not be needed when Slava fixes
+      // the track parameter coordinate transformation.
+      builder.seed_post_cleaning(seeds);
+
+      if (seed_select == SS_IndexPostCleaning) {
+        if (selected_seed >= 0 && selected_seed < (int)seeds.size()) {
+          for (int i = 0; i < count; ++i)
+            seeds[i] = seeds[selected_seed + i];
+          seeds.resize(count);
+        } else {
+          seeds.clear();
+        }
+      }
+
+      if (seeds.empty()) {
+        if (seed_select != SS_UseAll)
+          printf("Shell::ProcessEvent requested seed not found among seeds of the selected iteration.\n");
+        else
+          printf("Shell::ProcessEvent no seeds found.\n");
+        return;
+      }
+
+      if (itconf.m_requires_seed_hit_sorting) {
+        for (auto &s : seeds)
+          s.sortHitsByLayer();  // sort seed hits for the matched hits (I hope it works here)
+      }
+
+      builder.find_tracks_load_seeds(seeds, do_seed_clean);
+
+      builder.findTracksCloneEngine();
+
+      printf("Shell::ProcessEvent post fwd search: %d comb-cands\n", builder.ref_eocc().size());
+
+      // Pre backward-fit filtering.
+      filter_candidates_func pre_filter;
+      if (do_backward_fit && itconf.m_pre_bkfit_filter)
+        pre_filter = [&](const TrackCand &tc, const MkJob &jb) -> bool {
+          return itconf.m_pre_bkfit_filter(tc, jb) && StdSeq::qfilter_nan_n_silly<TrackCand>(tc, jb);
+        };
+      else if (itconf.m_pre_bkfit_filter)
+        pre_filter = itconf.m_pre_bkfit_filter;
+      else if (do_backward_fit)
+        pre_filter = StdSeq::qfilter_nan_n_silly<TrackCand>;
+      // pre_filter can be null if we are not doing backward fit as nan_n_silly will be run below.
+      if (pre_filter)
+        builder.filter_comb_cands(pre_filter, true);
+
+      printf("Shell::ProcessEvent post pre-bkf-filter (%s) and nan-filter (%s) filter: %d comb-cands\n",
+             b2a(bool(itconf.m_pre_bkfit_filter)), b2a(do_backward_fit), builder.ref_eocc().size());
+
+      job.switch_to_backward();
+
+      if (do_backward_fit) {
+        if (itconf.m_backward_search) {
+          builder.compactifyHitStorageForBestCand(itconf.m_backward_drop_seed_hits, itconf.m_backward_fit_min_hits);
+        }
+
+        builder.backwardFit();
+
+        if (itconf.m_backward_search) {
+          builder.beginBkwSearch();
+          builder.findTracksCloneEngine(SteeringParams::IT_BkwSearch);
+        }
+
+        printf("Shell::ProcessEvent post backward fit / search: %d comb-cands\n", builder.ref_eocc().size());
+      }
+
+      // Post backward-fit filtering.
+      filter_candidates_func post_filter;
+      if (do_backward_fit && itconf.m_post_bkfit_filter)
+        post_filter = [&](const TrackCand &tc, const MkJob &jb) -> bool {
+          return itconf.m_post_bkfit_filter(tc, jb) && StdSeq::qfilter_nan_n_silly<TrackCand>(tc, jb);
+        };
+      else
+        post_filter = StdSeq::qfilter_nan_n_silly<TrackCand>;
+      // post_filter is always at least doing nan_n_silly filter.
+      builder.filter_comb_cands(post_filter, true);
+
+      printf("Shell::ProcessEvent post post-bkf-filter (%s) and nan-filter (true): %d comb-cands\n",
+             b2a(do_backward_fit && itconf.m_post_bkfit_filter), builder.ref_eocc().size());
+
+      if (do_backward_fit && itconf.m_backward_search)
+        builder.endBkwSearch();
+
+      builder.export_best_comb_cands(out_tracks, true);
+
+      if (do_remove_duplicates && itconf.m_duplicate_cleaner) {
+        itconf.m_duplicate_cleaner(out_tracks, itconf);
+      }
+
+      printf("Shell::ProcessEvent post remove-duplicates: %d comb-cands\n", (int) out_tracks.size());
+
+      builder.end_event();
+    }
+
+    printf("Shell::ProcessEvent found %d tracks, number of seeds at end %d\n",
+           (int) m_tracks.size(), (int) m_seeds.size());
+  }
+
+  //===========================================================================
+  // Iteration selection
+  //===========================================================================
+
+  void Shell::SelectIterationIndex(int itidx) {
+    if (itidx < 0 || itidx >= n_algos) {
+      fprintf(stderr, "Requested iteration index out of range [%d, %d)", 0, n_algos);
+      throw std::runtime_error("iteration index out of range");
+    }
+    m_it_index = itidx;
+  }
+
+  void Shell::SelectIterationAlgo(int algo) {
+    for (int i = 0; i < n_algos; ++i) {
+      if (algos[i] == algo) {
+        m_it_index = i;
+        return;
+      }
+    }
+    fprintf(stderr, "Requested algo %d not found", algo);
+    throw std::runtime_error("algo not found");
+  }
+
+  void Shell::PrintIterations() {
+    printf("Shell::PrintIterations selected index = %d, %d iterations hardcoded as\n",
+            m_it_index, n_algos);
+    for (int i = 0; i < n_algos; ++i)
+      printf("%d %2d %s\n", i, algos[i], TrackBase::algoint_to_cstr(algos[i]));
+  }
+
+  //===========================================================================
+  // Flags / status setters
+  //===========================================================================
+
+  void Shell::SetDebug(bool b) { g_debug = b; }
+  void Shell::SetCleanSeeds(bool b) { m_clean_seeds = b; }
+  void Shell::SetBackwardFit(bool b) { m_backward_fit = b; }
+  void Shell::SetRemoveDuplicates(bool b) { m_remove_duplicates = b; }
+  void Shell::SetUseDeadModules(bool b) { Config::useDeadModules = b; }
+
+  //===========================================================================
+  // Analysis helpers
+  //===========================================================================
+
+  /*
+    sim tracks are written to .bin files with a label equal to its own index.
+    reco tracks labels are seed indices.
+    seed labels are sim track indices
+    --
+    mkfit labels are seed indices in given iteration after cleaning (at seed load-time)
+  */
+
+  int Shell::LabelFromHits(Track &t, bool replace, float good_frac) {
+    std::map<int, int> lab_cnt;
+    for (int hi = 0; hi < t.nTotalHits(); ++hi) {
+      auto hot = t.getHitOnTrack(hi);
+      if (hot.index < 0)
+        continue;
+      const Hit &h = m_event->layerHits_[hot.layer][hot.index];
+      int hl = m_event->simHitsInfo_[h.mcHitID()].mcTrackID_;
+      if (hl >= 0)
+        ++lab_cnt[hl];
+    }
+    int max_c = -1, max_l = -1;
+    for (auto& x : lab_cnt) {
+      if (x.second > max_c) {
+        max_l = x.first;
+        max_c = x.second;
+      }
+    }
+    bool success = max_c >= good_frac * t.nFoundHits();
+    int relabel = success ? max_l : -1;
+    // printf("found_hits=%d, best_lab %d (%d hits), existing label=%d (replace flag=%s)\n",
+    //        t.nFoundHits(), max_l, max_c, t.label(), b2a(replace));
+    if (replace)
+        t.setLabel(relabel);
+    return relabel;
+  }
+
+  void Shell::FillByLabelMaps_CkfBase() {
+    Event &ev = *m_event;
+    const int track_algo = Config::ItrInfo[m_it_index].m_track_algorithm;
+
+    m_ckf_map.clear();
+    m_sim_map.clear();
+    m_seed_map.clear();
+    m_mkf_map.clear();
+
+    // Pick ckf tracks with right algo and a good label.
+    int rec_algo_match = 0;
+    for (auto &t : ev.cmsswTracks_) {
+      if (t.algoint() != track_algo)
+        continue;
+      ++rec_algo_match;
+      int label = LabelFromHits(t, false, 0.5);
+      if (label >= 0) {
+        m_ckf_map.insert(std::make_pair(label, &t));
+      }
+    }
+
+    // Pick sim tracks with labels found by ckf.
+    for (auto &t : ev.simTracks_) {
+      if (t.label() >= 0 && m_ckf_map.find(t.label()) != m_ckf_map.end()) {
+        m_sim_map.insert(std::make_pair(t.label(), &t));
+      }
+    }
+
+    // Pick seeds with right algo and a label found by ckf.
+    for (auto &t : ev.seedTracks_) {
+      if (t.algoint() == track_algo && t.label() >= 0 && m_ckf_map.find(t.label()) != m_ckf_map.end()) {
+        m_seed_map.insert(std::make_pair(t.label(), &t));
+      }
+    }
+    // Some seeds seem to be labeled -1, try fixing when not otherwise found.
+    for (auto &t : ev.seedTracks_) {
+      if (t.algoint() == track_algo && t.label() == -1) {
+        int lab = LabelFromHits(t, true, 0.5);
+        if (lab >= 0 && m_seed_map.find(lab) == m_seed_map.end()) {
+          if (m_ckf_map.find(lab) != m_ckf_map.end()) {
+            m_seed_map.insert(std::make_pair(t.label(), &t));
+            printf("Saved seed with label -1 -> %d\n", lab);
+          }
+        }
+      }
+    }
+
+    // Pick mkfit tracks, label by 
+    for (auto &t : m_tracks) {
+      int label = LabelFromHits(t, false, 0.5);
+      if (label >= 0) {
+        m_mkf_map.insert(std::make_pair(label, &t));
+      }
+    }
+
+    printf("Shell::FillByLabelMaps reporting tracks with label >= 0, algo=%d (%s): "
+           "ckf: %d of %d (same algo=%d)), sim: %d of %d, seed: %d of %d, mkfit: %d w/label of %d\n",
+           track_algo, TrackBase::algoint_to_cstr(track_algo),
+           (int) m_ckf_map.size(), (int) ev.cmsswTracks_.size(), rec_algo_match,
+           (int) m_sim_map.size(), (int) ev.simTracks_.size(),
+           (int) m_seed_map.size(), (int) m_seeds.size(),
+           (int) m_mkf_map.size(), (int) m_tracks.size()
+    );
+  }
+
+  bool Shell::CheckMkFitLayerPlanVsReferenceHits(const Track &mkft, const Track &reft, const std::string &name) {
+    // Check if all hit-layers of a reference track reft are in the mkfit layer plan.
+    // Returns true if all layers are in the plan.
+    // String name is printed in front of label, expected to be SIMK or CKF.
+    const IterationConfig &itconf = Config::ItrInfo[m_it_index];
+    auto lp = itconf.m_steering_params[ mkft.getEtaRegion() ].m_layer_plan;
+    bool ret = true;
+    for (int hi = 0; hi < reft.nTotalHits(); ++hi) {
+      auto hot = reft.getHitOnTrack(hi);
+      if (std::find_if(lp.begin(), lp.end(), [=](auto &x){ return x.m_layer == hot.layer; }) == lp.end())
+      {
+        printf("CheckMkfLayerPlanVsCkfHits: layer %d not in layer plan for region %d, %s label=%d\n",
+                hot.layer, mkft.getEtaRegion(), name.c_str(), reft.label());
+        ret = false;
+      }
+    }
+    return ret;
+  }
+
+  //===========================================================================
+  // Analysis drivers / main functions / Comparators
+  //===========================================================================
+
+  void Shell::Compare() {
+    Event &ev = *m_event;
+    const IterationConfig &itconf = Config::ItrInfo[m_it_index];
+
+    FillByLabelMaps_CkfBase();
+
+    printf("------------------------------------------------------\n");
+
+    const bool print_all_def = false;
+    int mkf_cnt=0, less_hits=0, more_hits=0;
+
+    // TOBTEC: look for rec-seeds with hits in tob1 and 2 only.
+    int tot_cnt = 0, no_mkf_cnt = 0;
+
+    for (auto& [l, simt_ptr]: m_sim_map)
+    {
+      auto &simt = * simt_ptr;
+      auto &ckft = * m_ckf_map[l];
+      auto mi = m_mkf_map.find(l);
+
+      bool print_all = print_all_def;
+
+      // TOBTEC: look for rec-seeds with hits in tob1 and 2 only.
+      bool select = true;
+      {
+        auto &ckf_seed = ev.seedTracks_[ckft.label()];
+        for (int hi = 0; hi < ckf_seed.nTotalHits(); ++hi) {
+          const HitOnTrack hot = ckf_seed.getHitOnTrack(hi);
+          if (hot.index >= 0 && (hot.layer < 10 || hot.layer > 13)) {
+            select = false;
+            break;
+          }
+        }
+      }
+      if ( ! select) continue;
+
+      ++tot_cnt;
+      //print_all = true;
+
+      if (mi != m_mkf_map.end())
+      {
+        auto &mkft = * mi->second;
+        mkf_cnt++;
+        if (mkft.nFoundHits() < ckft.nFoundHits()) ++less_hits;
+        if (mkft.nFoundHits() > ckft.nFoundHits()) ++more_hits;
+
+        CheckMkFitLayerPlanVsReferenceHits(mkft, ckft, "CKF");
+        // CheckMkFitLayerPlanVsReferenceHits(mkft, simt, "SIM");
+
+        (void) print_all;
+        if (/* itconf.m_track_algorithm == 10 ||*/ print_all) {
+          // ckf label is wrong when validation is on (even quality val) for mixedTriplet, pixelless and tobtec
+          // as seed tracks get removed for non-mkfit iterations and indices from rec-tracks are no longer valid.
+          auto &ckf_seed = ev.seedTracks_[ckft.label()];
+          auto &mkf_seed = m_seeds[mkft.label()];
+          print("ckf  ", 0, ckft, ev);
+          print("mkfit", 0, mkft, ev);
+          print("sim  ", 0, simt, ev);
+          print("ckf seed", 0, ckf_seed, ev);
+          print("mkf seed", 0, mkf_seed, ev);
+          printf("------------------------------------------------------\n");
+
+          TrackVec ssss;
+          ssss.push_back(mkf_seed);
+
+          IterationSeedPartition pppp(1);
+          IterationConfig::get_seed_partitioner("phase1:1:debug")(Config::TrkInfo, ssss, *m_eoh, pppp);
+
+          printf("------------------------------------------------------\n");
+          printf("\n");
+        }
+      }
+      else
+      {
+        printf("\n!!!!! No mkfit track with this label.\n\n");
+        ++no_mkf_cnt;
+
+        auto &ckf_seed = ev.seedTracks_[ckft.label()];
+        print("ckf ", 0, ckft, ev);
+        print("sim ", 0, simt, ev);
+        print("ckf seed", 0, ckf_seed, ev);
+        auto smi = m_seed_map.find(l);
+        if (smi != m_seed_map.end())
+          print("seed with matching label", 0, *smi->second, ev);
+        printf("------------------------------------------------------\n");
+      }
+    }
+
+    printf("mkFit found %d, matching_label=%d, less_hits=%d, more_hits=%d  [algo=%d (%s)]\n",
+           (int) ev.fitTracks_.size(), mkf_cnt, less_hits, more_hits,
+           itconf.m_track_algorithm, TrackBase::algoint_to_cstr(itconf.m_track_algorithm));
+
+    if (tot_cnt > 0) {
+      printf("\ntobtec tob1/2 tot=%d no_mkf=%d (%f%%)\n",
+            tot_cnt, no_mkf_cnt, 100.0 * no_mkf_cnt / tot_cnt);
+    } else {
+      printf("\nNo CKF tracks with seed hits in TOB1/2 found (need iteration idx 8, TobTec?)\n");
+    }
+
+    printf("-------------------------------------------------------------------------------------------\n");
+    printf("-------------------------------------------------------------------------------------------\n");
+    printf("\n");
+  }
+
+}

--- a/RecoTracker/MkFitCMS/standalone/Shell.h
+++ b/RecoTracker/MkFitCMS/standalone/Shell.h
@@ -1,0 +1,79 @@
+#ifndef RecoTracker_MkFitCMS_standalone_Shell_h
+#define RecoTracker_MkFitCMS_standalone_Shell_h
+
+#include "RecoTracker/MkFitCore/interface/Hit.h"
+#include "RecoTracker/MkFitCore/interface/Track.h"
+
+#include <map>
+
+namespace mkfit {
+
+  class DataFile;
+  class Event;
+  class EventOfHits;
+  class MkBuilder;
+
+  class Shell {
+  public:
+    enum SeedSelect_e { SS_UseAll = 0, SS_Label, SS_IndexPreCleaning, SS_IndexPostCleaning };
+
+    Shell(std::vector<DeadVec> &dv, const std::string &in_file, int start_ev);
+    void Run();
+
+    void Status();
+
+    void GoToEvent(int eid);
+    void NextEvent(int skip = 1);
+    void ProcessEvent(SeedSelect_e seed_select = SS_UseAll, int selected_seed = -1, int count = 1);
+
+    void SelectIterationIndex(int itidx);
+    void SelectIterationAlgo(int algo);
+    void PrintIterations();
+
+    void SetDebug(bool b);
+    void SetCleanSeeds(bool b);
+    void SetBackwardFit(bool b);
+    void SetRemoveDuplicates(bool b);
+    void SetUseDeadModules(bool b);
+
+    Event *event() { return m_event; }
+    EventOfHits *eoh() { return m_eoh; }
+    MkBuilder *builder() { return m_builder; }
+
+    // --------------------------------------------------------
+    // Analysis helpers
+
+    int LabelFromHits(Track &t, bool replace, float good_frac);
+    void FillByLabelMaps_CkfBase();
+
+    bool CheckMkFitLayerPlanVsReferenceHits(const Track &mkft, const Track &reft, const std::string &name);
+
+    // --------------------------------------------------------
+    // Analysis drivers / main functions / Comparators
+
+    void Compare();
+
+  private:
+    std::vector<DeadVec> &m_deadvectors;
+    DataFile *m_data_file = nullptr;
+    Event *m_event = nullptr;
+    EventOfHits *m_eoh = nullptr;
+    MkBuilder *m_builder = nullptr;
+    int m_evs_in_file = -1;
+    int m_it_index = 0;
+    bool m_clean_seeds = true;
+    bool m_backward_fit = true;
+    bool m_remove_duplicates = true;
+
+    TrackVec m_seeds;
+    TrackVec m_tracks;
+
+    using map_t = std::map<int, Track *>;
+    using map_i = map_t::iterator;
+
+    std::map<int, Track *> m_ckf_map, m_sim_map, m_seed_map, m_mkf_map;
+  };
+
+}  // namespace mkfit
+
+#endif

--- a/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
+++ b/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
@@ -1,0 +1,1 @@
+#pragma link C++ class mkfit::Shell;

--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -22,9 +22,11 @@
 
 //#define DEBUG
 #include "RecoTracker/MkFitCore/src/Debug.h"
+#include "RecoTracker/MkFitCMS/standalone/Shell.h"
 
 #include "oneapi/tbb/task_arena.h"
 #include "oneapi/tbb/parallel_for.h"
+#include <oneapi/tbb/global_control.h>
 
 #if defined(USE_VTUNE_PAUSE)
 #include "ittnotify.h"
@@ -39,6 +41,13 @@
 using namespace mkfit;
 
 //==============================================================================
+
+std::vector<DeadVec> deadvectors;
+
+void init_deadvectors() {
+  deadvectors.resize(Config::TrkInfo.n_layers());
+#include "RecoTracker/MkFitCMS/standalone/deadmodules.h"
+}
 
 void initGeom() {
   std::cout << "Constructing geometry '" << Config::geomPlugin << "'\n";
@@ -106,6 +115,10 @@ void initGeom() {
 
   Config::ItrInfo.setupStandardFunctionsFromNames();
 
+  // We always initialize the dead modules. Actual loading into each event is
+  // controlled via Config::useDeadModules.
+  init_deadvectors();
+
   // Test functions for ConfigJsonPatcher
   // cj.test_Direct (Config::ItrInfo[0]);
   // cj.test_Patcher(Config::ItrInfo[0]);
@@ -155,13 +168,6 @@ namespace {
 
   const char* b2a(bool b) { return b ? "true" : "false"; }
 
-  std::vector<DeadVec> deadvectors;
-
-  void init_deadvectors() {
-    deadvectors.resize(Config::TrkInfo.n_layers());
-#include "RecoTracker/MkFitCMS/standalone/deadmodules.h"
-  }
-
 }  // namespace
 
 //==============================================================================
@@ -200,26 +206,14 @@ void listOpts(const U& g_opt_map) {
 //==============================================================================
 
 void test_standard() {
-  printf("Running test_standard(), operation=\"%s\"\n", g_operation.c_str());
-  printf("  vusize=%d, num_th_sim=%d, num_th_finder=%d\n",
-         MPT_SIZE,
-         Config::numThreadsSimulation,
-         Config::numThreadsFinder);
-  printf(
-      "  sizeof(Track)=%zu, sizeof(Hit)=%zu, sizeof(SVector3)=%zu, sizeof(SMatrixSym33)=%zu, sizeof(MCHitInfo)=%zu\n",
-      sizeof(Track),
-      sizeof(Hit),
-      sizeof(SVector3),
-      sizeof(SMatrixSym33),
-      sizeof(MCHitInfo));
+  printf("Running test_standard(), operation=\"%s\", best_out_of=%d\n",
+         g_operation.c_str(),
+         Config::finderReportBestOutOfN);
 
   if (Config::seedInput == cmsswSeeds)
     printf("- reading seeds from file\n");
 
   initGeom();
-  if (Config::useDeadModules) {
-    init_deadvectors();
-  }
 
   if (Config::nEvents <= 0) {
     return;
@@ -503,6 +497,7 @@ int main(int argc, const char* argv[]) {
   for (int i = 1; i < argc; ++i) {
     mArgs.push_back(argv[i]);
   }
+  bool run_shell = false;
 
   lStr_i i = mArgs.begin();
   while (i != mArgs.end()) {
@@ -524,10 +519,11 @@ int main(int argc, const char* argv[]) {
           "  --read-cmssw-tracks      read external cmssw reco tracks if available (def: %s)\n"
           "  --read-simtrack-states   read in simTrackStates for pulls in validation (def: %s)\n"
           "  --num-events     <int>   number of events to run over or simulate (def: %d)\n"
-          "                             if using --input-file, must be enabled AFTER on command line\n"
+          "                           if using --input-file, must be enabled AFTER on command line\n"
           "  --start-event    <int>   event number to start at when reading from a file (def: %d)\n"
           "  --loop-over-file         after reaching the end of the file, start over from the beginning until "
-          "<num-events> events have been processed\n"
+          "                           <num-events> events have been processed\n"
+          "  --shell                  start interactive shell instead of running test_standard()\n"
           "\n"
           "If no --input-file is specified, will trigger simulation\n"
           "  --num-tracks     <int>   number of tracks to generate for each event (def: %d)\n"
@@ -820,6 +816,8 @@ int main(int argc, const char* argv[]) {
       g_start_event = atoi(i->c_str());
     } else if (*i == "--loop-over-file") {
       Config::loopOverFile = true;
+    } else if (*i == "--shell") {
+      run_shell = true;
     } else if (*i == "--num-tracks") {
       next_arg_or_die(mArgs, i);
       Config::nTracks = atoi(i->c_str());
@@ -1020,24 +1018,38 @@ int main(int argc, const char* argv[]) {
     mArgs.erase(start, ++i);
   }
 
+  // clang-format off
+
   // Do some checking of options before going...
   if (Config::seedCleaning != cleanSeedsPure &&
       (Config::cmsswMatchingFW == labelBased || Config::cmsswMatchingBK == labelBased)) {
-    std::cerr << "What have you done?!? Can't mix cmssw label matching without pure seeds! Exiting..." << std::endl;
+    std::cerr << "What have you done?!? Can't mix cmssw label matching without pure seeds! Exiting...\n";
     exit(1);
   } else if (Config::mtvLikeValidation && Config::inclusiveShorts) {
-    std::cerr
-        << "What have you done?!? Short reco tracks are already accounted for in the MTV-Like Validation! Inclusive "
-           "shorts is only an option for the standard simval, and will break the MTV-Like simval! Exiting..."
-        << std::endl;
+    std::cerr << "What have you done?!? Short reco tracks are already accounted for in the MTV-Like Validation! Inclusive "
+                 "shorts is only an option for the standard simval, and will break the MTV-Like simval! Exiting...\n";
     exit(1);
   }
 
   Config::recalculateDependentConstants();
 
-  printf("Running with n_threads=%d, best_out_of=%d\n", Config::numThreadsFinder, Config::finderReportBestOutOfN);
+  printf("mkFit configuration complete.\n"
+         "  vusize=%d, num_thr_events=%d, num_thr_finder=%d\n"
+         "  sizeof(Track)=%zu, sizeof(Hit)=%zu, sizeof(SVector3)=%zu, sizeof(SMatrixSym33)=%zu, sizeof(MCHitInfo)=%zu\n",
+         MPT_SIZE, Config::numThreadsEvents, Config::numThreadsFinder,
+         sizeof(Track), sizeof(Hit), sizeof(SVector3), sizeof(SMatrixSym33), sizeof(MCHitInfo));
 
-  test_standard();
+  if (run_shell) {
+    tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, Config::numThreadsFinder);
+
+    initGeom();
+    Shell s(deadvectors, g_input_file, g_start_event);
+    s.Run();
+  } else {
+    test_standard();
+  }
+
+  // clang-format on
 
   return 0;
 }

--- a/RecoTracker/MkFitCMS/standalone/tkNtuple/WriteMemoryFile.cc
+++ b/RecoTracker/MkFitCMS/standalone/tkNtuple/WriteMemoryFile.cc
@@ -45,6 +45,7 @@ void printHelp(const char* av0) {
   printf(
       "Usage: %s [options]\n"
       "Options:\n"
+      "  --help                    print help and exit\n"
       "  --input          <str>    input file\n"
       "  --output         <str>    output file\n"
       "  --geo            <file>   binary TrackerInfo geometry (def: CMS-phase1.bin)\n"
@@ -54,7 +55,8 @@ void printHelp(const char* av0) {
       "  --write-all-events        write all events (def: skip events with 0 simtracks or seeds)\n"
       "  --write-rec-tracks        write rec tracks (def: not written)\n"
       "  --apply-ccc               apply cluster charge cut to strip hits (def: false)\n"
-      "  --all-seeds               merge all seeds from the input file (def: false)\n",
+      "  --all-seeds               write all seeds from the input file, not only initialStep and hltIter0 (def: "
+      "false)\n",
       av0);
 }
 
@@ -88,6 +90,7 @@ int main(int argc, char* argv[]) {
 
     if (*i == "-h" || *i == "-help" || *i == "--help") {
       printHelp(argv[0]);
+      exit(0);
     } else if (*i == "--input") {
       next_arg_or_die(mArgs, i);
       inputFileName = *i;

--- a/RecoTracker/MkFitCore/interface/Config.h
+++ b/RecoTracker/MkFitCore/interface/Config.h
@@ -3,18 +3,26 @@
 
 namespace mkfit {
 
-  enum PropagationFlagsEnum { PF_none = 0, PF_use_param_b_field = 0x1, PF_apply_material = 0x2 };
+  enum PropagationFlagsEnum {
+    PF_none = 0,
+    PF_use_param_b_field = 0x1,
+    PF_apply_material = 0x2,
+    PF_copy_input_state_on_fail = 0x4
+  };
 
   struct PropagationFlags {
     bool use_param_b_field : 1;
     bool apply_material : 1;
+    bool copy_input_state_on_fail : 1;
     // Could add: bool use_trig_approx       -- now Config::useTrigApprox = true
     // Could add: int  n_prop_to_r_iters : 8 -- now Config::Niter = 5
 
-    PropagationFlags() : use_param_b_field(false), apply_material(false) {}
+    PropagationFlags() : use_param_b_field(false), apply_material(false), copy_input_state_on_fail(false) {}
 
     PropagationFlags(int pfe)
-        : use_param_b_field(pfe & PF_use_param_b_field), apply_material(pfe & PF_apply_material) {}
+        : use_param_b_field(pfe & PF_use_param_b_field),
+          apply_material(pfe & PF_apply_material),
+          copy_input_state_on_fail(pfe & PF_copy_input_state_on_fail) {}
   };
 
   class PropagationConfig {

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -51,7 +51,7 @@ namespace mkfit {
     void import_seeds(const TrackVec &in_seeds, const bool seeds_sorted, std::function<insert_seed_foo> insert_seed);
 
     // filter for rearranging cands that will / will not do backward search.
-    int filter_comb_cands(filter_candidates_func filter);
+    int filter_comb_cands(filter_candidates_func filter, bool attempt_all_cands);
 
     void find_min_max_hots_size();
 
@@ -69,6 +69,8 @@ namespace mkfit {
     // MIMI hack to export tracks for BH
     const TrackVec &ref_tracks() const { return m_tracks; }
     TrackVec &ref_tracks_nc() { return m_tracks; }
+
+    const EventOfCombCandidates &ref_eocc() const { return m_event_of_comb_cands; }
 
     // --------
 

--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <map>
+#include <limits>
 
 namespace mkfit {
 
@@ -601,7 +602,7 @@ namespace mkfit {
   }
 
   inline float getScoreWorstPossible() {
-    return -1e16;  // somewhat arbitrary value, used for handling of best short track during finding (will try to take it out)
+    return -std::numeric_limits<float>::max();  // used for handling of best short track during finding
   }
 
   inline float getScoreCand(const track_score_func& score_func,
@@ -656,8 +657,8 @@ namespace mkfit {
   }
 
   void print(const TrackState& s);
-  void print(std::string label, int itrack, const Track& trk, bool print_hits = false);
-  void print(std::string label, const TrackState& s);
+  void print(std::string pfx, int itrack, const Track& trk, bool print_hits = false);
+  void print(std::string pfx, const TrackState& s);
 
 }  // end namespace mkfit
 #endif

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -372,6 +372,10 @@ namespace mkfit {
       m_hots.reserve(expected_num_hots);
       m_hots_size = 0;
       m_hots.clear();
+
+      m_lastHitIdx_before_bkwsearch = -1;
+      m_nInsideMinusOneHits_before_bkwsearch = -1;
+      m_nTailMinusOneHits_before_bkwsearch = -1;
     }
 
     void importSeed(const Track& seed, const track_score_func& score_func, int region);
@@ -388,7 +392,8 @@ namespace mkfit {
 
     void compactifyHitStorageForBestCand(bool remove_seed_hits, int backward_fit_min_hits);
     void beginBkwSearch();
-    void endBkwSearch();
+    void repackCandPostBkwSearch(int i);
+    // not needed for CombCand::endBkwSearch(), reinit performed in reset() for a new event.
 
     // Accessors
     //-----------
@@ -634,10 +639,11 @@ namespace mkfit {
     void beginBkwSearch() {
       for (int i = 0; i < m_size; ++i)
         m_candidates[i].beginBkwSearch();
+      m_cands_in_backward_rep = true;
     }
     void endBkwSearch() {
-      for (int i = 0; i < m_size; ++i)
-        m_candidates[i].endBkwSearch();
+      // There is no CombCand::endBkwSearch(), setup correctly in CombCand::reset().
+      m_cands_in_backward_rep = false;
     }
 
     // Accessors
@@ -646,6 +652,8 @@ namespace mkfit {
     const CombCandidate& operator[](int i) const { return m_candidates[i]; }
     CombCandidate& operator[](int i) { return m_candidates[i]; }
     CombCandidate& cand(int i) { return m_candidates[i]; }
+
+    bool cands_in_backward_rep() const { return m_cands_in_backward_rep; }
 
     // Direct access for vectorized functions in MkBuilder / MkFinder
     const std::vector<CombCandidate>& refCandidates() const { return m_candidates; }
@@ -659,6 +667,7 @@ namespace mkfit {
     int m_capacity = 0;
     int m_size = 0;
     int m_n_seeds_inserted = 0;
+    bool m_cands_in_backward_rep = false;
   };
 
 }  // namespace mkfit

--- a/RecoTracker/MkFitCore/interface/TrackerInfo.h
+++ b/RecoTracker/MkFitCore/interface/TrackerInfo.h
@@ -7,7 +7,7 @@
 
 namespace mkfit {
 
-  enum WithinSensitiveRegion_e { WSR_Undef = -1, WSR_Inside = 0, WSR_Edge, WSR_Outside };
+  enum WithinSensitiveRegion_e { WSR_Undef = -1, WSR_Inside = 0, WSR_Edge, WSR_Outside, WSR_Failed };
 
   struct WSR_Result {
     // Could also store XHitSize count equivalent here : 16;

--- a/RecoTracker/MkFitCore/interface/cms_common_macros.h
+++ b/RecoTracker/MkFitCore/interface/cms_common_macros.h
@@ -5,6 +5,24 @@
 #define CMS_SA_ALLOW
 #else
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #endif
+
+namespace mkfit {
+
+  constexpr bool isFinite(float x) {
+#ifdef MKFIT_STANDALONE
+    const unsigned int mask = 0x7f800000;
+    union {
+      unsigned int l;
+      float d;
+    } v = {.d = x};
+    return (v.l & mask) != mask;
+#else
+    return edm::isFinite(x);
+#endif
+  }
+
+}  // namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/src/Debug.cc
+++ b/RecoTracker/MkFitCore/src/Debug.cc
@@ -1,0 +1,3 @@
+namespace mkfit {
+  bool g_debug = true;
+}

--- a/RecoTracker/MkFitCore/src/Debug.h
+++ b/RecoTracker/MkFitCore/src/Debug.h
@@ -1,4 +1,9 @@
 #ifndef RecoTracker_MkFitCore_src_Debug_h
+
+namespace mkfit {
+  extern bool g_debug;
+}
+
 #ifdef DEBUG
 #define RecoTracker_MkFitCore_src_Debug_h
 
@@ -36,7 +41,7 @@
   All are protected by a file scope mutex to avoid mixed printouts.
   This mutex can also be acquired within a block via dmutex_guard:
 
-  if (debug) {
+  if (debug && g_debug) {
     dmutex_guard;
     [do complicated stuff]
   }
@@ -48,30 +53,30 @@
 
 #define dmutex_guard std::lock_guard<std::mutex> dlock(debug_mutex)
 #define dprint(x)                \
-  if (debug) {                   \
+  if (debug && g_debug) {        \
     dmutex_guard;                \
     std::cout << x << std::endl; \
   }
 #define dprint_np(n, x)                       \
-  if (debug && n < N_proc) {                  \
+  if (debug && g_debug && n < N_proc) {       \
     dmutex_guard;                             \
     std::cout << n << ": " << x << std::endl; \
   }
-#define dcall(x)  \
-  if (debug) {    \
-    dmutex_guard; \
-    x;            \
+#define dcall(x)          \
+  if (debug && g_debug) { \
+    dmutex_guard;         \
+    x;                    \
   }
-#define dprintf(...)     \
-  if (debug) {           \
-    dmutex_guard;        \
-    printf(__VA_ARGS__); \
+#define dprintf(...)      \
+  if (debug && g_debug) { \
+    dmutex_guard;         \
+    printf(__VA_ARGS__);  \
   }
-#define dprintf_np(n, ...)   \
-  if (debug && n < N_proc) { \
-    dmutex_guard;            \
-    std::cout << n << ": ";  \
-    printf(__VA_ARGS__);     \
+#define dprintf_np(n, ...)              \
+  if (debug && g_debug && n < N_proc) { \
+    dmutex_guard;                       \
+    std::cout << n << ": ";             \
+    printf(__VA_ARGS__);                \
   }
 
 namespace {

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -9,11 +9,11 @@ namespace mkfit {
 
 #define COMPUTE_CHI2_ARGS                                                                                    \
   const MPlexLS &, const MPlexLV &, const MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLV &, \
-      const int, const PropagationFlags, const bool
+      MPlexQI &, const int, const PropagationFlags, const bool
 
 #define UPDATE_PARAM_ARGS                                                                                         \
-  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, const int, \
-      const PropagationFlags, const bool
+  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, MPlexQI &, \
+      const int, const PropagationFlags, const bool
 
   class FindingFoos {
   public:

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -477,6 +477,7 @@ namespace mkfit {
                                 const MPlexHV& msPar,
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
+                                MPlexQI& outFailFlag,
                                 const int N_proc,
                                 const PropagationFlags propFlags,
                                 const bool propToHit) {
@@ -489,7 +490,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperation(
           KFO_Update_Params | KFO_Local_Cov, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
@@ -524,6 +525,7 @@ namespace mkfit {
                                      const MPlexHV& msPar,
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
+                                     MPlexQI& outFailFlag,
                                      const int N_proc,
                                      const PropagationFlags propFlags,
                                      const bool propToHit) {
@@ -536,7 +538,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, N_proc, propFlags);
+      propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperation(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {
@@ -743,6 +745,7 @@ namespace mkfit {
                                       const MPlexHV& msPar,
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
+                                      MPlexQI& outFailFlag,
                                       const int N_proc,
                                       const PropagationFlags propFlags,
                                       const bool propToHit) {
@@ -755,7 +758,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationEndcap(KFO_Update_Params, propErr, propPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     } else {
@@ -788,6 +791,7 @@ namespace mkfit {
                                            const MPlexHV& msPar,
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
+                                           MPlexQI& outFailFlag,
                                            const int N_proc,
                                            const PropagationFlags propFlags,
                                            const bool propToHit) {
@@ -800,7 +804,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = msPar.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, N_proc, propFlags);
+      propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationEndcap(KFO_Calculate_Chi2, propErr, propPar, msErr, msPar, dummy_err, dummy_par, outChi2, N_proc);
     } else {

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -27,6 +27,7 @@ namespace mkfit {
                                 const MPlexHV& msPar,
                                 MPlexLS& outErr,
                                 MPlexLV& outPar,
+                                MPlexQI& outFailFlag,
                                 const int N_proc,
                                 const PropagationFlags propFlags,
                                 const bool propToHit);
@@ -46,6 +47,7 @@ namespace mkfit {
                                      const MPlexHV& msPar,
                                      MPlexQF& outChi2,
                                      MPlexLV& propPar,
+                                     MPlexQI& outFailFlag,
                                      const int N_proc,
                                      const PropagationFlags propFlags,
                                      const bool propToHit);
@@ -77,6 +79,7 @@ namespace mkfit {
                                       const MPlexHV& msPar,
                                       MPlexLS& outErr,
                                       MPlexLV& outPar,
+                                      MPlexQI& outFailFlag,
                                       const int N_proc,
                                       const PropagationFlags propFlags,
                                       const bool propToHit);
@@ -96,6 +99,7 @@ namespace mkfit {
                                            const MPlexHV& msPar,
                                            MPlexQF& outChi2,
                                            MPlexLV& propPar,
+                                           MPlexQI& outFailFlag,
                                            const int N_proc,
                                            const PropagationFlags propFlags,
                                            const bool propToHit);

--- a/RecoTracker/MkFitCore/src/MkBase.h
+++ b/RecoTracker/MkFitCore/src/MkBase.h
@@ -33,7 +33,7 @@ namespace mkfit {
         msRad.At(n, 0, 0) = r;
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
 
     void propagateTracksToHitR(const MPlexHV& par,
@@ -46,7 +46,8 @@ namespace mkfit {
         msRad.At(n, 0, 0) = std::hypot(par.constAt(n, 0, 0), par.constAt(n, 1, 0));
       }
 
-      propagateHelixToRMPlex(m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToRMPlex(
+          m_Err[iC], m_Par[iC], m_Chg, msRad, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf, noMatEffPtr);
     }
 
     //----------------------------------------------------------------------------
@@ -58,7 +59,7 @@ namespace mkfit {
         msZ.At(n, 0, 0) = z;
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
 
     void propagateTracksToHitZ(const MPlexHV& par,
@@ -71,7 +72,8 @@ namespace mkfit {
         msZ.At(n, 0, 0) = par.constAt(n, 2, 0);
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf, noMatEffPtr);
+      propagateHelixToZMPlex(
+          m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf, noMatEffPtr);
     }
 
     void propagateTracksToPCAZ(const int N_proc, const PropagationFlags pf) {
@@ -85,8 +87,10 @@ namespace mkfit {
                           (1 + slope * slope);  // PCA to origin
       }
 
-      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], N_proc, pf);
+      propagateHelixToZMPlex(m_Err[iC], m_Par[iC], m_Chg, msZ, m_Err[iP], m_Par[iP], m_FailFlag, N_proc, pf);
     }
+
+    void clearFailFlag() { m_FailFlag.setVal(0); }
 
     //----------------------------------------------------------------------------
 
@@ -94,6 +98,7 @@ namespace mkfit {
     MPlexLS m_Err[2];
     MPlexLV m_Par[2];
     MPlexQI m_Chg;
+    MPlexQI m_FailFlag;
   };
 
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -25,9 +25,6 @@
 #include "oneapi/tbb/parallel_for.h"
 #include "oneapi/tbb/parallel_for_each.h"
 
-// Set this to select a single track for deep debugging:
-//#define SELECT_SEED_LABEL -494
-
 namespace mkfit {
 
   //==============================================================================
@@ -147,7 +144,7 @@ namespace {
     }
   }
 
-  void print_seeds(const EventOfCombCandidates &event_of_comb_cands) {
+  [[maybe_unused]] void print_seeds(const EventOfCombCandidates &event_of_comb_cands) {
     for (int iseed = 0; iseed < event_of_comb_cands.size(); iseed++) {
       print_seed2(event_of_comb_cands[iseed].front());
     }
@@ -301,15 +298,30 @@ namespace mkfit {
 
   //------------------------------------------------------------------------------
 
-  int MkBuilder::filter_comb_cands(filter_candidates_func filter) {
+  int MkBuilder::filter_comb_cands(filter_candidates_func filter, bool attempt_all_cands) {
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     int i = 0, place_pos = 0;
 
-    dprintf("MkBuilder::filter_comb_cands Entering filter size eoccsm_size=%d\n", eoccs.size());
+    dprintf("MkBuilder::filter_comb_cands Entering filter size eoccs.size=%d\n", eoccs.size());
 
     std::vector<int> removed_cnts(m_job->num_regions());
     while (i < eoccs.size()) {
-      if (filter(eoccs[i].front(), *m_job)) {
+      if (eoccs.cands_in_backward_rep())
+        eoccs[i].repackCandPostBkwSearch(0);
+      bool passed = filter(eoccs[i].front(), *m_job);
+
+      if (!passed && attempt_all_cands) {
+        for (int j = 1; j < (int)eoccs[i].size(); ++j) {
+          if (eoccs.cands_in_backward_rep())
+            eoccs[i].repackCandPostBkwSearch(j);
+          if (filter(eoccs[i][j], *m_job)) {
+            eoccs[i][0] = eoccs[i][j];  // overwrite front, no need to std::swap() them
+            passed = true;
+            break;
+          }
+        }
+      }
+      if (passed) {
         if (place_pos != i)
           std::swap(eoccs[place_pos], eoccs[i]);
         ++place_pos;
@@ -336,7 +348,7 @@ namespace mkfit {
 
     eoccs.resizeAfterFiltering(n_removed);
 
-    dprintf("MkBuilder::filter_comb_cands n_removed = %d, eoccsm_size=%d\n", n_removed, eoccs.size());
+    dprintf("MkBuilder::filter_comb_cands n_removed = %d, eoccs.size=%d\n", n_removed, eoccs.size());
 
     return n_removed;
   }
@@ -373,9 +385,6 @@ namespace mkfit {
     const EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     out_vec.reserve(out_vec.size() + eoccs.size());
     for (int i = 0; i < eoccs.size(); i++) {
-      // See MT-RATS comment below.
-      assert(!eoccs[i].empty() && "BackwardFitBH requires output tracks to align with seeds.");
-
       // Take the first candidate, if it exists.
       if (!eoccs[i].empty()) {
         const TrackCand &bcand = eoccs[i].front();
@@ -396,25 +405,6 @@ namespace mkfit {
   //------------------------------------------------------------------------------
 
   void MkBuilder::seed_post_cleaning(TrackVec &tv) {
-#ifdef SELECT_SEED_LABEL
-    {  // Select seed with the defined label for detailed debugging.
-      for (int i = 0; i < (int)tv.size(); ++i) {
-        if (tv[i].label() == SELECT_SEED_LABEL) {
-          printf("Preselect seed with label %d - found on pos %d\n", SELECT_SEED_LABEL, i);
-          if (i != 0)
-            tv[0] = tv[i];
-          tv.resize(1);
-          print("Label", tv[0].label(), tv[0], true);
-          break;
-        }
-      }
-      if (tv.size() != 1) {
-        printf("Preselect seed with label %d - NOT FOUND. Cleaning out seeds.\n", SELECT_SEED_LABEL);
-        tv.clear();
-      }
-    }
-#endif
-
     if (Const::nan_n_silly_check_seeds) {
       int count = 0;
 
@@ -555,6 +545,7 @@ namespace mkfit {
 
             dcall(pre_prop_print(curr_layer, mkfndr.get()));
 
+            mkfndr->clearFailFlag();
             (mkfndr.get()->*fnd_foos.m_propagate_foo)(
                 layer_info.propagate_to(), curr_tridx, prop_config.finding_inter_layer_pflags);
 
@@ -846,6 +837,7 @@ namespace mkfit {
             //propagate to layer
             dcall(pre_prop_print(curr_layer, mkfndr.get()));
 
+            mkfndr->clearFailFlag();
             (mkfndr.get()->*fnd_foos.m_propagate_foo)(
                 layer_info.propagate_to(), end - itrack, prop_config.finding_inter_layer_pflags);
 
@@ -987,8 +979,6 @@ namespace mkfit {
     cloner.begin_eta_bin(&eoccs, &seed_cand_update_idx, &extra_cands, start_seed, n_seeds);
 
     // Loop over layers, starting from after the seed.
-    // Note that we do a final pass with curr_layer = -1 to update parameters
-    // and output final tracks.
 
     auto layer_plan_it = st_par.make_iterator(iteration_dir);
 
@@ -1075,6 +1065,7 @@ namespace mkfit {
 #endif
 
         // propagate to current layer
+        mkfndr->clearFailFlag();
         (mkfndr->*fnd_foos.m_propagate_foo)(
             layer_info.propagate_to(), end - itrack, prop_config.finding_inter_layer_pflags);
 
@@ -1155,10 +1146,18 @@ namespace mkfit {
   // BackwardFit
   //==============================================================================
 
-  // MT-RATS - eta separators can be screwed after copy out with possibly empty CombCands.
-  // I added asserts to two applicable places above (both here in MkBuilder.cc).
-  // One could also re-calculate / adjust m_seedEtaSeparators, during export iself, probably.
-  // Or use separate seed / track vectors for every region -- which would be prettier.
+#ifdef DEBUG_FINAL_FIT
+  namespace {
+    // clang-format off
+    void dprint_tcand(const TrackCand &t, int i) {
+      dprintf("  %4d with q=%+d chi2=%7.3f pT=%7.3f eta=% 7.3f x=%.3f y=%.3f z=%.3f"
+              " nHits=%2d  label=%4d findable=%d\n",
+              i, t.charge(), t.chi2(), t.pT(), t.momEta(), t.x(), t.y(), t.z(),
+              t.nFoundHits(), t.label(), t.isFindable());
+      }
+    // clang-format on
+  }  // namespace
+#endif
 
   void MkBuilder::backwardFitBH() {
     tbb::parallel_for_each(m_job->regions_begin(), m_job->regions_end(), [&](int region) {
@@ -1184,28 +1183,16 @@ namespace mkfit {
     const PropagationConfig &prop_config = PropagationConfig::get_default();
 #ifdef DEBUG_FINAL_FIT
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
+    bool debug = true;
 #endif
 
     for (int icand = start_cand; icand < end_cand; icand += NN) {
       const int end = std::min(icand + NN, end_cand);
 
 #ifdef DEBUG_FINAL_FIT
-      printf("Pre Final fit for %d - %d\n", icand, end);
+      dprintf("Pre Final fit for %d - %d\n", icand, end);
       for (int i = icand; i < end; ++i) {
-        const TrackCand &t = eoccs[i][0];
-        printf(
-            "  %4d with q=%+d chi2=%7.3f pT=%7.3f eta=% 7.3f x=%.3f y=%.3f z=%.3f nHits=%2d  label=%4d findable=%d\n",
-            i,
-            t.charge(),
-            t.chi2(),
-            t.pT(),
-            t.momEta(),
-            t.x(),
-            t.y(),
-            t.z(),
-            t.nFoundHits(),
-            t.label(),
-            t.isFindable());
+        dprint_tcand(eoccs[i][0], i);
       }
 #endif
 
@@ -1239,32 +1226,16 @@ namespace mkfit {
                icand,
                1.0f / mkfndr->m_Par[MkBase::iP].At(0, 3, 0),
                mkfndr->m_Chi2(0, 0, 0) / (eoccs[icand][0].nFoundHits() * 3 - 6));
-        printf(
-            "CHIHDR %3s %10s %10s %10s %10s %10s %11s %11s %11s %10s %10s %10s %10s %11s %11s %11s %10s %10s %10s %10s "
-            "%10s %11s %11s\n",
-            "lyr",
-            "chi2",
-            "x_h",
-            "y_h",
-            "z_h",
-            "r_h",
-            "sx_h",
-            "sy_h",
-            "sz_h",
-            "x_t",
-            "y_t",
-            "z_t",
-            "r_t",
-            "sx_t",
-            "sy_t",
-            "sz_t",
-            "pt",
-            "phi",
-            "theta",
-            "phi_h",
-            "phi_t",
-            "d_xy",
-            "d_z");
+        // clang-format off
+        printf("CHIHDR %3s %10s"
+              " %10s %10s %10s %10s %11s %11s %11s"
+              " %10s %10s %10s %10s %11s %11s %11s"
+              " %10s %10s %10s %10s %10s %11s %11s\n",
+              "lyr", "chi2",
+              "x_h", "y_h", "z_h", "r_h", "sx_h", "sy_h", "sz_h",
+              "x_t", "y_t", "z_t", "r_t", "sx_t", "sy_t", "sz_t",
+              "pt", "phi", "theta", "phi_h", "phi_t", "d_xy", "d_z");
+        // clang-format on
         goto redo_fit;
       }
 #endif
@@ -1273,22 +1244,9 @@ namespace mkfit {
       mkfndr->bkFitOutputTracks(m_tracks, icand, end, prop_config.backward_fit_to_pca);
 
 #ifdef DEBUG_FINAL_FIT
-      printf("Post Final fit for %d - %d\n", icand, end);
+      dprintf("Post Final fit for %d - %d\n", icand, end);
       for (int i = icand; i < end; ++i) {
-        const TrackCand &t = eoccs[i][0];
-        printf(
-            "  %4d with q=%+d chi2=%7.3f pT=%7.3f eta=% 7.3f x=%.3f y=%.3f z=%.3f nHits=%2d  label=%4d findable=%d\n",
-            i,
-            t.charge(),
-            t.chi2(),
-            t.pT(),
-            t.momEta(),
-            t.x(),
-            t.y(),
-            t.z(),
-            t.nFoundHits(),
-            t.label(),
-            t.isFindable());
+        dprint_tcand(eoccs[i][0], i);
       }
 #endif
     }
@@ -1325,35 +1283,21 @@ namespace mkfit {
     for (int icand = start_cand; icand < end_cand; icand += step) {
       int end = std::min(icand + NN, end_cand);
 
-#ifdef DEBUG_FINAL_FIT
-      printf("Pre Final fit for %d - %d\n", icand, end);
-      for (int i = icand; i < end; ++i) {
-        const TrackCand &t = eoccs[i][0];
-        printf(
-            "  %4d with q=%+d chi2=%7.3f pT=%7.3f eta=% 7.3f x=%.3f y=%.3f z=%.3f nHits=%2d  label=%4d findable=%d\n",
-            i,
-            t.charge(),
-            t.chi2(),
-            t.pT(),
-            t.momEta(),
-            t.x(),
-            t.y(),
-            t.z(),
-            t.nFoundHits(),
-            t.label(),
-            t.isFindable());
-      }
-#endif
-
       bool chi_debug = false;
-#ifdef DEBUG_BACKWARD_FIT
+
+#ifdef DEBUG_FINAL_FIT
+      bool debug = true;
+      dprintf("Pre Final fit for %d - %d\n", icand, end);
+      for (int i = icand; i < end; ++i) {
+        dprint_tcand(eoccs[i][0], i);
+      }
       chi_debug = true;
       static bool first = true;
       if (first) {
         // ./mkFit ... | perl -ne 'if (/^BKF_OVERLAP/) { s/^BKF_OVERLAP //og; print; }' > bkf_ovlp.rtt
-        printf(
+        dprintf(
             "BKF_OVERLAP event/I:label/I:prod_type/I:is_findable/I:layer/I:is_stereo/I:is_barrel/I:"
-            "pt/F:eta/F:phi/F:chi2/F:isnan/I:isfin/I:gtzero/I:hit_label/I:"
+            "pt/F:pt_cur/F:eta/F:phi/F:phi_cur/F:r_cur/F:z_cur/F:chi2/F:isnan/I:isfin/I:gtzero/I:hit_label/I:"
             "sx_t/F:sy_t/F:sz_t/F:d_xy/F:d_z/F\n");
         first = false;
       }
@@ -1374,22 +1318,9 @@ namespace mkfit {
       mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
 
 #ifdef DEBUG_FINAL_FIT
-      printf("Post Final fit for %d - %d\n", icand, end);
+      dprintf("Post Final fit for %d - %d\n", icand, end);
       for (int i = icand; i < end; ++i) {
-        const TrackCand &t = eoccs[i][0];
-        printf(
-            "  %4d with q=%+d chi2=%7.3f pT=%7.3f eta=% 7.3f x=%.3f y=%.3f z=%.3f nHits=%2d  label=%4d findable=%d\n",
-            i,
-            t.charge(),
-            t.chi2(),
-            t.pT(),
-            t.momEta(),
-            t.x(),
-            t.y(),
-            t.z(),
-            t.nFoundHits(),
-            t.label(),
-            t.isFindable());
+        dprint_tcand(eoccs[i][0], i);
       }
 #endif
     }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1,11 +1,10 @@
 #include "MkFinder.h"
 
-#include "CandCloner.h"
+#include "RecoTracker/MkFitCore/interface/cms_common_macros.h"
 #include "RecoTracker/MkFitCore/interface/IterationConfig.h"
+#include "CandCloner.h"
 #include "FindingFoos.h"
-
 #include "KalmanUtilsMPlex.h"
-
 #include "MatriplexPackers.h"
 
 //#define DEBUG
@@ -15,21 +14,7 @@
 #include "RecoTracker/MkFitCore/standalone/Event.h"
 #endif
 
-#ifndef MKFIT_STANDALONE
-#include "FWCore/Utilities/interface/isFinite.h"
-#endif
-
 #include <algorithm>
-
-namespace {
-  bool isFinite(float x) {
-#ifndef MKFIT_STANDALONE
-    return edm::isFinite(x);
-#else
-    return std::isfinite(x);
-#endif
-  }
-}  // namespace
 
 namespace mkfit {
 
@@ -404,6 +389,14 @@ namespace mkfit {
     // Vectorizing this makes it run slower!
     //#pragma omp simd
     for (int itrack = 0; itrack < N_proc; ++itrack) {
+      // PROP-FAIL-ENABLE The following to be enabled when propagation failure
+      // detection is properly implemented in propagate-to-R/Z.
+      // if (m_FailFlag[itrack]) {
+      //   m_XWsrResult[itrack].m_wsr = WSR_Failed;
+      //   m_XHitSize[itrack] = -1;
+      //   continue;
+      // }
+
       if (m_XWsrResult[itrack].m_wsr == WSR_Outside) {
         m_XHitSize[itrack] = -1;
         continue;
@@ -738,6 +731,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV tmpPropPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -745,6 +739,7 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      tmpPropPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -823,6 +818,7 @@ namespace mkfit {
     // are already done when computing chi2. Not sure it's worth caching them?)
 
     dprint("update parameters");
+    clearFailFlag();
     (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                    m_Par[iP],
                                    m_Chg,
@@ -830,6 +826,7 @@ namespace mkfit {
                                    m_msPar,
                                    m_Err[iC],
                                    m_Par[iC],
+                                   m_FailFlag,
                                    N_proc,
                                    m_prop_config->finding_intra_layer_pflags,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -952,6 +949,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV propPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -959,6 +957,7 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      propPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -1006,6 +1005,7 @@ namespace mkfit {
 
       if (oneCandPassCut) {
         MPlexQI tmpChg = m_Chg;
+        clearFailFlag();
         (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                        m_Par[iP],
                                        tmpChg,
@@ -1013,6 +1013,7 @@ namespace mkfit {
                                        m_msPar,
                                        m_Err[iC],
                                        m_Par[iC],
+                                       m_FailFlag,
                                        N_proc,
                                        m_prop_config->finding_intra_layer_pflags,
                                        m_prop_config->finding_requires_propagation_to_hit_pos);
@@ -1195,6 +1196,7 @@ namespace mkfit {
       //now compute the chi2 of track state vs hit
       MPlexQF outChi2;
       MPlexLV propPar;
+      clearFailFlag();
       (*fnd_foos.m_compute_chi2_foo)(m_Err[iP],
                                      m_Par[iP],
                                      m_Chg,
@@ -1202,19 +1204,23 @@ namespace mkfit {
                                      m_msPar,
                                      outChi2,
                                      propPar,
+                                     m_FailFlag,
                                      N_proc,
                                      m_prop_config->finding_intra_layer_pflags,
                                      m_prop_config->finding_requires_propagation_to_hit_pos);
 
 #pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
       for (int itrack = 0; itrack < N_proc; ++itrack) {
-        // make sure the hit was in the compatiblity window for the candidate
-
-        float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
-
-        if (hit_cnt < m_XHitSize[itrack]) {
-          // XXX-NUM-ERR assert(chi2 >= 0);
+        // We can be in failed state from the initial propagation before selectHitIndices
+        // and there hit_count for track is set to -1 and WSR state to Failed, handled below.
+        // Or we might have hit it here in propagate-to-hit.
+        // PROP-FAIL-ENABLE FailFlag check to be enabled when propagation failure
+        // detection is properly implemented in propagate-to-R/Z.
+        if (/*!m_FailFlag[itrack] &&*/ hit_cnt < m_XHitSize[itrack]) {
+          // make sure the hit was in the compatiblity window for the candidate
+          const float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
           const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
+          // XXX-NUM-ERR assert(chi2 >= 0);
 
           dprint("chi2=" << chi2 << " for trkIdx=" << itrack << " hitIdx=" << m_XHitArr.At(itrack, hit_cnt, 0));
           if (chi2 < max_c2) {
@@ -1316,6 +1322,13 @@ namespace mkfit {
         fake_hit_idx = Hit::kHitMaxClusterIdx;
       }
 
+      // PROP-FAIL-ENABLE The following to be enabled when propagation failure
+      // detection is properly implemented in propagate-to-R/Z.
+      // // Override for failed propagation, this trumps all other cases.
+      // if (m_XWsrResult[itrack].m_wsr == WSR_Failed) {
+      //   fake_hit_idx = Hit::kHitStopIdx;
+      // }
+
       IdxChi2List tmpList;
       tmpList.trkIdx = m_CandIdx(itrack, 0, 0);
       tmpList.hitIdx = fake_hit_idx;
@@ -1335,12 +1348,13 @@ namespace mkfit {
   }
 
   //==============================================================================
-  // UpdateWithLastHit
+  // UpdateWithLoadedHit
   //==============================================================================
 
   void MkFinder::updateWithLoadedHit(int N_proc, const FindingFoos &fnd_foos) {
     // See comment in MkBuilder::find_tracks_in_layer() about intra / inter flags used here
     // for propagation to the hit.
+    clearFailFlag();
     (*fnd_foos.m_update_param_foo)(m_Err[iP],
                                    m_Par[iP],
                                    m_Chg,
@@ -1348,9 +1362,20 @@ namespace mkfit {
                                    m_msPar,
                                    m_Err[iC],
                                    m_Par[iC],
+                                   m_FailFlag,
                                    N_proc,
                                    m_prop_config->finding_inter_layer_pflags,
                                    m_prop_config->finding_requires_propagation_to_hit_pos);
+
+    // PROP-FAIL-ENABLE The following to be enabled when propagation failure
+    // detection is properly implemented in propagate-to-R/Z.
+    // for (int i = 0; i < N_proc; ++i) {
+    //   if (m_FailFlag[i]) {
+    //     dprintf("MkFinder::updateWithLoadedHit fail in update, recovering.\n");
+    //     m_Err[iC].copySlot(i, m_Err[iP]);
+    //     m_Par[iC].copySlot(i, m_Par[iP]);
+    //   }
+    // }
   }
 
   //==============================================================================
@@ -1620,6 +1645,22 @@ namespace mkfit {
 
   //------------------------------------------------------------------------------
 
+  void MkFinder::print_par_err(int corp, int mslot) const {
+#ifdef DEBUG
+    printf("Parameters:\n");
+    for (int i = 0; i < 6; ++i) {
+      printf("  %12.4g", m_Par[corp].constAt(mslot, i, 0));
+    }
+    printf("\nError matrix\n");
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+        printf("  %12.4g", m_Err[corp].constAt(mslot, i, j));
+      }
+      printf("\n");
+    }
+#endif
+  }
+
   void MkFinder::bkFitFitTracks(const EventOfHits &eventofhits,
                                 const SteeringParams &st_par,
                                 const int N_proc,
@@ -1630,10 +1671,18 @@ namespace mkfit {
     // Layers should be collected during track finding and list all layers that have actual hits.
     // Then we could avoid checking which layers actually do have hits.
 
+    // bool debug = true;
+
     MPlexQF tmp_chi2;
     MPlexQI no_mat_effs;
     float tmp_err[6] = {666, 0, 666, 0, 0, 666};
     float tmp_pos[3];
+
+#if defined(DEBUG_PROP_UPDATE)
+    const int DSLOT = 0;
+    printf("bkfit entry, track in slot %d\n", DSLOT);
+    print_par_err(iC, DSLOT);
+#endif
 
     for (auto lp_iter = st_par.make_iterator(SteeringParams::IT_BkwFit); lp_iter.is_valid(); ++lp_iter) {
       const int layer = lp_iter.layer();
@@ -1641,7 +1690,6 @@ namespace mkfit {
       const LayerOfHits &L = eventofhits[layer];
       const LayerInfo &LI = *L.layer_info();
 
-      // XXXX
 #if defined(DEBUG_BACKWARD_FIT)
       const Hit *last_hit_ptr[NN];
 #endif
@@ -1697,6 +1745,10 @@ namespace mkfit {
 
       // ZZZ Could add missing hits here, only if there are any actual matches.
 
+      clearFailFlag();
+
+      // PROP-FAIL-ENABLE Once always "copy input to output on fail" is removed from
+      // propagateToR one might want to enable this for barrel or endcap or both.
       if (LI.is_barrel()) {
         propagateTracksToHitR(m_msPar, N_proc, m_prop_config->backward_fit_pflags, &no_mat_effs);
 
@@ -1723,16 +1775,69 @@ namespace mkfit {
                               N_proc);
       }
 
-      //fixup invpt sign and charge
-      for (int n = 0; n < N_proc; ++n) {
-        if (m_Par[iC].At(n, 3, 0) < 0) {
-          m_Chg.At(n, 0, 0) = -m_Chg.At(n, 0, 0);
-          m_Par[iC].At(n, 3, 0) = -m_Par[iC].At(n, 3, 0);
+#if defined(DEBUG_PROP_UPDATE)
+      printf("\nbkfit at layer %d, track in slot %d -- fail=%d, had hit=%d (%g, %g, %g)\n",
+             LI.layer_id(),
+             DSLOT,
+             m_FailFlag[DSLOT],
+             1 - no_mat_effs[DSLOT],
+             m_msPar(DSLOT, 0, 0),
+             m_msPar(DSLOT, 1, 0),
+             m_msPar(DSLOT, 2, 0));
+      printf("Propagated:\n");
+      print_par_err(iP, DSLOT);
+      printf("Updated:\n");
+      print_par_err(iC, DSLOT);
+#endif
+
+      // Fixup for failed propagation or invpt sign and charge.
+      for (int i = 0; i < N_proc; ++i) {
+        // PROP-FAIL-ENABLE The following to be enabled when propagation failure
+        // detection is properly implemented in propagate-to-R/Z.
+        // 1. The following code was only expecting barrel state to be restored.
+        //      auto barrel_pf(m_prop_config->backward_fit_pflags);
+        //      barrel_pf.copy_input_state_on_fail = true;
+        // 2. There is also check on chi2, commented out to keep physics changes minimal.
+        /*
+        if (m_FailFlag[i] && LI.is_barrel()) {
+          // Barrel pflags are set to include PF_copy_input_state_on_fail.
+          // Endcap errors are immaterial here (relevant for fwd search), with prop error codes
+          // one could do other things.
+          // Are there also fail conditions in KalmanUpdate?
+#ifdef DEBUG
+          if (debug && g_debug) {
+            dprintf("MkFinder::bkFitFitTracks prop fail: chi2=%f, layer=%d, label=%d. Recovering.\n",
+                    tmp_chi2[i], LI.layer_id(), m_Label[i]);
+            print_par_err(iC, i);
+          }
+#endif
+          m_Err[iC].copySlot(i, m_Err[iP]);
+          m_Par[iC].copySlot(i, m_Par[iP]);
+        } else if (tmp_chi2[i] > 200 || tmp_chi2[i] < 0) {
+#ifdef DEBUG
+          if (debug && g_debug) {
+            dprintf("MkFinder::bkFitFitTracks chi2 fail: chi2=%f, layer=%d, label=%d. Recovering.\n",
+                    tmp_chi2[i], LI.layer_id(), m_Label[i]);
+            print_par_err(iC, i);
+          }
+#endif
+          // Go back to propagated state (at the current hit, the previous one is lost).
+          m_Err[iC].copySlot(i, m_Err[iP]);
+          m_Par[iC].copySlot(i, m_Par[iP]);
+        }
+        */
+        // Fixup invpt sign and charge.
+        if (m_Par[iC].At(i, 3, 0) < 0) {
+          m_Chg.At(i, 0, 0) = -m_Chg.At(i, 0, 0);
+          m_Par[iC].At(i, 3, 0) = -m_Par[iC].At(i, 3, 0);
         }
       }
 
-      for (int i = 0; i < N_proc; ++i) {
 #if defined(DEBUG_BACKWARD_FIT)
+      // clang-format off
+      bool debug = true;
+      const char beg_cur_sep = '/'; // set to ' ' root parsable printouts
+      for (int i = 0; i < N_proc; ++i) {
         if (chiDebug && last_hit_ptr[i]) {
           TrackCand &bb = *m_TrkCand[i];
           int ti = iP;
@@ -1742,43 +1847,40 @@ namespace mkfit {
 #if defined(MKFIT_STANDALONE)
           const MCHitInfo &mchi = m_event->simHitsInfo_[last_hit_ptr[i]->mcHitID()];
 
-          printf(
-              "BKF_OVERLAP %d %d %d %d %d %d %d "
-              "%f %f %f %f %d %d %d %d "
-              "%f %f %f %f %f\n",
+          dprintf("BKF_OVERLAP %d %d %d %d %d %d %d "
+                  "%f%c%f %f %f%c%f %f %f %f %d %d %d %d "
+                  "%f %f %f %f %f\n",
               m_event->evtID(),
 #else
-          printf(
-              "BKF_OVERLAP %d %d %d %d %d %d "
-              "%f %f %f %f %d %d %d "
-              "%f %f %f %f %f\n",
+          dprintf("BKF_OVERLAP %d %d %d %d %d %d "
+                  "%f%c%f %f %f%c%f %f %f %f %d %d %d "
+                  "%f %f %f %f %f\n",
 #endif
-              bb.label(),
-              (int)bb.prodType(),
-              bb.isFindable(),
-              layer,
-              L.is_stereo(),
-              L.is_barrel(),
-              bb.pT(),
+              bb.label(), (int)bb.prodType(), bb.isFindable(),
+              layer, L.is_stereo(), L.is_barrel(),
+              bb.pT(), beg_cur_sep, 1.0f / m_Par[ti].At(i, 3, 0),
               bb.posEta(),
-              bb.posPhi(),
+              bb.posPhi(), beg_cur_sep, std::atan2(m_Par[ti].At(i, 1, 0), m_Par[ti].At(i, 0, 0)),
+              std::hypot(m_Par[ti].At(i, 0, 0), m_Par[ti].At(i, 1, 0)),
+              m_Par[ti].At(i, 2, 0),
               chi_prnt,
-              std::isnan(chi),
-              std::isfinite(chi),
-              chi > 0,
+              std::isnan(chi), std::isfinite(chi), chi > 0,
 #if defined(MKFIT_STANDALONE)
               mchi.mcTrackID(),
 #endif
-              e2s(m_Err[ti].At(i, 0, 0)),
-              e2s(m_Err[ti].At(i, 1, 1)),
-              e2s(m_Err[ti].At(i, 2, 2)),  // sx_t sy_t sz_t -- track errors
+              // The following three can get negative / prouce nans in e2s.
+              // std::abs the args for FPE hunt.
+              e2s(std::abs(m_Err[ti].At(i, 0, 0))),
+              e2s(std::abs(m_Err[ti].At(i, 1, 1))),
+              e2s(std::abs(m_Err[ti].At(i, 2, 2))),  // sx_t sy_t sz_t -- track errors
               1e4f * std::hypot(m_msPar.At(i, 0, 0) - m_Par[ti].At(i, 0, 0),
                                 m_msPar.At(i, 1, 0) - m_Par[ti].At(i, 1, 0)),  // d_xy
               1e4f * (m_msPar.At(i, 2, 0) - m_Par[ti].At(i, 2, 0))             // d_z
           );
         }
-#endif
       }
+      // clang-format on
+#endif
 
       // update chi2
       m_Chi2.add(tmp_chi2);

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -272,6 +272,8 @@ namespace mkfit {
 
     int num_inside_minus_one_hits(const int mslot) const { return m_NInsideMinusOneHits(mslot, 0, 0); }
 
+    void print_par_err(int corp, int mslot) const;
+
     //----------------------------------------------------------------------------
 
     MPlexQF m_Chi2;

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.h
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.h
@@ -36,6 +36,7 @@ namespace mkfit {
                               const MPlexQF& msRad,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr = nullptr);
@@ -45,6 +46,7 @@ namespace mkfit {
                                        const MPlexQF& msRad,
                                        MPlexLV& outPar,
                                        MPlexLL& errorProp,
+                                       MPlexQI& outFailFlag,
                                        const int N_proc);
 
   void helixAtRFromIterativeCCS(const MPlexLV& inPar,
@@ -62,6 +64,7 @@ namespace mkfit {
                               const MPlexQF& msZ,
                               MPlexLS& outErr,
                               MPlexLV& outPar,
+                              MPlexQI& outFailFlag,
                               const int N_proc,
                               const PropagationFlags pflags,
                               const MPlexQI* noMatEffPtr = nullptr);
@@ -71,6 +74,7 @@ namespace mkfit {
                 const MPlexQF& msZ,
                 MPlexLV& outPar,
                 MPlexLL& errorProp,
+                MPlexQI& outFailFlag,
                 const int N_proc,
                 const PropagationFlags pflags);
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -171,7 +171,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
       r0[n - nmin] = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
     }
 
-    // Use one over dot produce of transverse momentum and radial
+    // Use one over dot product of transverse momentum and radial
     // direction to scale the step. Propagation is prevented from reaching
     // too close to the apex (dotp > 0.2).
     // - Can / should we come up with a better approximation?
@@ -188,6 +188,10 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
       if (oodotp[n - nmin] > 5.0f || oodotp[n - nmin] < 0)  // 0.2 is 78.5 deg
       {
         outFailFlag(n, 0, 0) = 1;
+        oodotp[n - nmin] = 0.0f;
+      } else if (r[n - nmin] - r0[n - nmin] < 0.0f && pt[n - nmin] < 1.0f) {
+        // Scale down the correction for low-pT ingoing tracks.
+        oodotp[n - nmin] = 1.0f + (oodotp[n - nmin] - 1.0f) * pt[n - nmin];
       }
     }
 
@@ -195,8 +199,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
     for (int n = nmin; n < nmax; ++n) {
       // Can we come up with a better approximation?
       // Should take +/- curvature into account.
-      id[n - nmin] =
-          (oodotp[n - nmin] > 5.0f || oodotp[n - nmin] < 0) ? 0.0f : (r[n - nmin] - r0[n - nmin]) * oodotp[n - nmin];
+      id[n - nmin] = (r[n - nmin] - r0[n - nmin]) * oodotp[n - nmin];
     }
 
 #pragma omp simd
@@ -236,7 +239,8 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                     << " pz=" << pt[n - nmin] * std::tan(theta[n - nmin]) << " q=" << inChg(n, 0, 0) << std::endl
                     << "   r=" << std::setprecision(9) << r[n - nmin] << " r0=" << std::setprecision(9) << r0[n - nmin]
                     << " id=" << std::setprecision(9) << id[n - nmin] << " dr=" << std::setprecision(9)
-                    << r[n - nmin] - r0[n - nmin] << " cosa=" << cosa[n - nmin] << " sina=" << sina[n - nmin]);
+                    << r[n - nmin] - r0[n - nmin] << " cosa=" << cosa[n - nmin] << " sina=" << sina[n - nmin]
+                    << " dir_cos(rad,pT)=" << 1.0f / oodotp[n]);
     }
 
     //update derivatives on total distance
@@ -452,8 +456,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
 
   for (int n = nmin; n < nmax; ++n) {
     dprint_np(n,
-              "propagation end, dump parameters"
-                  << std::endl
+              "propagation end, dump parameters\n"
                   << "   pos = " << outPar(n, 0, 0) << " " << outPar(n, 1, 0) << " " << outPar(n, 2, 0) << "\t\t r="
                   << std::sqrt(outPar(n, 0, 0) * outPar(n, 0, 0) + outPar(n, 1, 0) * outPar(n, 1, 0)) << std::endl
                   << "   mom = " << std::cos(outPar(n, 4, 0)) / outPar(n, 3, 0) << " "
@@ -463,7 +466,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
 
 #ifdef DEBUG
   for (int n = nmin; n < nmax; ++n) {
-    if (n < N_proc) {
+    if (debug && g_debug && n < N_proc) {
       dmutex_guard;
       std::cout << n << ": jacobian" << std::endl;
       printf("%5f %5f %5f %5f %5f %5f\n",

--- a/RecoTracker/MkFitCore/src/Track.cc
+++ b/RecoTracker/MkFitCore/src/Track.cc
@@ -1,3 +1,4 @@
+#include "RecoTracker/MkFitCore/interface/cms_common_macros.h"
 #include "RecoTracker/MkFitCore/interface/Track.h"
 #include "Matrix.h"
 
@@ -155,7 +156,7 @@ namespace mkfit {
     bool is_silly = false;
     for (int i = 0; i < LL; ++i) {
       for (int j = 0; j <= i; ++j) {
-        if ((i == j && state_.errors.At(i, j) < 0) || !std::isfinite(state_.errors.At(i, j))) {
+        if ((i == j && state_.errors.At(i, j) < 0) || !isFinite(state_.errors.At(i, j))) {
           if (!is_silly) {
             is_silly = true;
             if (dump)
@@ -177,7 +178,7 @@ namespace mkfit {
     bool is_silly = false;
     for (int i = 0; i < LL; ++i) {
       for (int j = 0; j <= i; ++j) {
-        if ((i == j && state_.errors.At(i, j) < 0) || !std::isfinite(state_.errors.At(i, j))) {
+        if ((i == j && state_.errors.At(i, j) < 0) || !isFinite(state_.errors.At(i, j))) {
           is_silly = true;
           return is_silly;
         }
@@ -407,8 +408,10 @@ namespace mkfit {
     std::cout << std::endl;
   }
 
-  void print(std::string label, int itrack, const Track& trk, bool print_hits) {
-    std::cout << std::endl << label << ": " << itrack << " hits: " << trk.nFoundHits() << " State" << std::endl;
+  void print(std::string pfx, int itrack, const Track& trk, bool print_hits) {
+    std::cout << std::endl
+              << pfx << ": " << itrack << " hits: " << trk.nFoundHits() << " label: " << trk.label() << " State"
+              << std::endl;
     print(trk.state());
     if (print_hits) {
       for (int i = 0; i < trk.nTotalHits(); ++i)
@@ -416,8 +419,8 @@ namespace mkfit {
     }
   }
 
-  void print(std::string label, const TrackState& s) {
-    std::cout << label << std::endl;
+  void print(std::string pfx, const TrackState& s) {
+    std::cout << pfx << std::endl;
     print(s);
   }
 

--- a/RecoTracker/MkFitCore/src/TrackStructures.cc
+++ b/RecoTracker/MkFitCore/src/TrackStructures.cc
@@ -226,11 +226,15 @@ namespace mkfit {
     tc.setNTailMinusOneHits(0);
   }
 
-  void CombCandidate::endBkwSearch() {
+  void CombCandidate::repackCandPostBkwSearch(int i) {
+    // Called during filtering following backward search when a TrackCand's
+    // front hits need to be reindexed.
     // mergeCandsAndBestShortOne() has already been called (from MkBuilder::FindXxx()).
-    // We have to fixup the best candidate.
+    // NOTES:
+    // 1. Should only be called once for each i (flag/bit to allow multiple calls can be added).
+    // 2. Alternatively, CombCand could provide hit iterator/exporter that would handle this correctly.
 
-    TrackCand &tc = m_trk_cands[0];
+    TrackCand &tc = m_trk_cands[i];
 
     int curr_idx = tc.lastCcIndex();
     if (curr_idx != 0) {
@@ -248,9 +252,6 @@ namespace mkfit {
     tc.setLastCcIndex(m_lastHitIdx_before_bkwsearch);
     tc.setNInsideMinusOneHits(m_nInsideMinusOneHits_before_bkwsearch + tc.nInsideMinusOneHits());
     tc.setNTailMinusOneHits(m_nTailMinusOneHits_before_bkwsearch + tc.nTailMinusOneHits());
-    m_lastHitIdx_before_bkwsearch = -1;
-    m_nInsideMinusOneHits_before_bkwsearch = -1;
-    m_nTailMinusOneHits_before_bkwsearch = -1;
   }
 
 }  // namespace mkfit

--- a/RecoTracker/MkFitCore/standalone/ConformalUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/standalone/ConformalUtilsMPlex.cc
@@ -251,7 +251,7 @@ namespace mkfit {
           (fitting ? Config::thetaerr049 * Config::thetaerr049 : Config::thetaerr012 * Config::thetaerr012);
     }
 
-    if (debug) {
+    if (debug && g_debug) {
       for (int n = 0; n < N; ++n) {
         dprintf("afterCF seedID: %1u \n", seedID.constAt(n, 0, 0));
         // do a dumb copy out

--- a/RecoTracker/MkFitCore/standalone/Event.h
+++ b/RecoTracker/MkFitCore/standalone/Event.h
@@ -111,6 +111,8 @@ namespace mkfit {
     int openRead(const std::string &fname, int expected_n_layers);
     void openWrite(const std::string &fname, int n_layers, int n_ev, int extra_sections = 0);
 
+    void rewind();
+
     int advancePosToNextEvent(FILE *fp);
 
     void skipNEvents(int n_to_skip);
@@ -118,6 +120,8 @@ namespace mkfit {
     void close();
     void CloseWrite(int n_written);  //override nevents in the header and close
   };
+
+  void print(std::string pfx, int itrack, const Track &trk, const Event &ev);
 
 }  // end namespace mkfit
 #endif


### PR DESCRIPTION
### Changes

Added  MPlexQI MkBase::m_FailFlag (parent class of MkFinder). One has to
manually clear it when desired (before propagation).
* Now only 0 and 1 are used ... could have differnt error codes, eg.
  failed to reach, step too large, etc.

The fail-flag mplex is passed into all propagation and propaget+kalman_op
functions (barrel and endcap - there was limited handling with forced restore
for barrel propagation before, state was not visible outside).
* Are there some error states in KalmanOp? We could pass that in as well.

Added WSR_Failed as member of enum WithinSensitiveRegion_e
* Handled in selectHitIndices() and findTracksCloneEngine() -> stop the candidate.

With this we can now stop also endcap tracks when they are about to reach
apex. Until now endcap tracks went on looping. Another check done is how large
the helix angle along the step was attempted (pi/2 forces error).
* Other propToR/Z checks can be added / tried. fail codes, kamlnaOp fail

In backward fit the endcap fails are somewhat accidental -- trying to fix them
does not really help as hits are already chosen. So we only do rollback in barrel.

In MkBuilder::filter_comb_cands() add a flag allowing other TrackCands to be tested, not just the best one. If a later one passes, copy it over the first one as that will be the one used for backward fit/search or for export.
* This is now used for nan-checks before and after the final fit but could also be used for other filters or a combination of them.

### Other things to check, maybe

We can probably remove "can-reach-radius" check in MkBuilder::fund_track_unroll_candidates()

Config::useTrigApprox = true now -- should we do false?
* Was causing FPE in helixAtRFromIterativeCCS_impl()
* Make iteration specific?
* Test alpha of all tracks in vector unit?

Retry backward-search with non-swapped first/second layers in the plan?
  b-tagging efficiency / resolution / number of hits
