### PR TITLE
scan differences in phase-1 track ntuples: scanTC checks track candidates

### DIFF
--- a/Validation/RecoTrack/python/ntuple/ntupleScans.py
+++ b/Validation/RecoTrack/python/ntuple/ntupleScans.py
@@ -1,0 +1,81 @@
+import math
+def scanTC(ta, tb, minSimPt=0., nEv=10, iteration=9):
+  for iE in range(ta.GetEntries()):
+    if iE > nEv: continue
+    nb = ta.GetEntry(iE)
+    nb = tb.GetEntry(iE)
+    taa = ta.tcand_algo
+    tab = tb.tcand_algo
+    tca = ta.tcand_bestSimTrkIdx
+    tcb = tb.tcand_bestSimTrkIdx
+    l9a = [(i,v) for i,v in enumerate(tca) if v>=0 and taa[i]==iteration]
+    l9b = [(i,v) for i,v in enumerate(tcb) if v>=0 and tab[i]==iteration]
+    v9a = [v for i,v in l9a]
+    v9b = [v for i,v in l9b]
+    for i,v in l9a:
+      if v not in v9b:
+        for iT in ta.sim_trkIdx[v]:
+          # there is no direct map to tcand except from see
+          iST = ta.trk_seedIdx[iT]
+          if ta.see_tcandIdx[iST] != i: continue
+          if not ta.trk_isHP[iT]: continue
+          if ta.tcand_bestSimTrkShareFrac[i] < 1: continue
+          print(iE,"tc ",i," sim ",v," only in a")
+          t = ta
+          if t.sim_pt[v] < minSimPt: continue
+          algLast = -1
+          iLab = -1
+          for iis,alg in enumerate(ta.see_algo):
+            if alg != algLast:
+              algLast = alg
+              iLab = -1
+            iLab = iLab + 1
+            if iis == iST: break
+          print(f'see {iST:3d} {iLab:3d} {t.see_pt[iST]: 6.4f} {t.see_eta[iST]: 6.4f} {t.see_phi[iST]: 6.4f} {t.see_nValid[iST]:2d} {t.see_stateTrajGlbX[iST]: 6.4f} {t.see_stateTrajGlbY[iST]: 6.4f} {t.see_stateTrajGlbZ[iST]: 6.4f} {t.see_stateTrajGlbPx[iST]: 6.4f} {t.see_stateTrajGlbPy[iST]: 6.4f} {t.see_stateTrajGlbPz[iST]: 6.4f}')
+          for iSO in (iiSO for iiSO in t.sim_seedIdx[v] if iiSO!=iST):
+            print(f'seeO {iSO:3d} {t.see_pt[iSO]: 6.4f} {t.see_eta[iSO]: 6.4f} {t.see_phi[iSO]: 6.4f} {t.see_nValid[iSO]:2d} {t.see_stateTrajGlbX[iSO]: 6.4f} {t.see_stateTrajGlbY[iSO]: 6.4f} {t.see_stateTrajGlbZ[iSO]: 6.4f} {t.see_stateTrajGlbPx[iSO]: 6.4f} {t.see_stateTrajGlbPy[iSO]: 6.4f} {t.see_stateTrajGlbPz[iSO]: 6.4f}')
+          sehs = []
+          for (ih,ht) in enumerate(t.see_hitType[iST]):
+            iS = t.see_hitIdx[iST][ih]
+            sehs.append(iS)
+            if (ht == 0): print(f'P {iS:4d} {t.pix_subdet[iS]: 2d} {t.pix_layer[iS]: 3d} ({t.pix_x[iS]: 6.2f} {t.pix_y[iS]: 6.2f} {t.pix_z[iS]: 6.2f}) cm {sh: 4d}')
+            if (ht == 1): print(f'S {iS:4d} {t.str_subdet[iS]:2d} {t.str_layer[iS]:3d} {t.str_isStereo[iS]:2d} ({t.str_x[iS]: 6.2f} {t.str_y[iS]: 6.2f} {t.str_z[iS]: 6.2f}) cm')
+            if (ht == 2):
+              sh=t.glu_stereoIdx[iS]
+              mh=t.glu_monoIdx[iS]
+              sehs.append(sh)
+              sehs.append(mh)
+              print(f'g {iS:4d} {t.glu_subdet[iS]:2d} {t.glu_layer[iS]:3d} ({t.glu_x[iS]: 6.2f} {t.glu_y[iS]: 6.2f} {t.glu_z[iS]: 6.2f}) cm {t.glu_xx[iS]: 6.2e} {t.glu_xy[iS]: 6.2e} {t.glu_yy[iS]: 6.2e} m {mh:4d} ({t.str_x[mh]: 6.2f} {t.str_y[mh]: 6.2f} {t.str_z[mh]: 6.2f}) s {sh:4d} ({t.str_x[sh]: 6.2f} {t.str_y[sh]: 6.2f} {t.str_z[sh]: 6.2f})')
+          print(f'tcand {i:4d} {iST:4d} {t.tcand_x[i]: 6.4f} {t.tcand_y[i]: 6.4f} {t.tcand_pca_pt[i]:6.4f} {t.tcand_pca_eta[i]: 6.4f} {t.tcand_pca_phi[i]: 6.4f} {t.tcand_nValid[i]:2d} {t.tcand_nPixel[i]:2d} {t.tcand_bestSimTrkIdx[i]:3d} {t.sim_pdgId[v]: 5d} {t.sim_parentVtxIdx[v]:3d} {t.tcand_bestSimTrkShareFrac[i]:4.3f} {t.sim_pt[v]:6.4f} {t.sim_eta[v]: 6.4f}')
+          tchs = []
+          for (ih,ht) in enumerate(t.tcand_hitType[i]):
+            iS = t.tcand_hitIdx[i][ih]
+            sehSt = "SH" if iS in sehs else ""
+            tchs.append([ht,iS])
+            if (ht == 0):
+              shs = [s for s in t.pix_simHitIdx[iS] if s in t.sim_simHitIdx[v]]
+              sh = -1 if len(shs)==0 else shs[0]
+              shr = [0, 0, 0] if sh == -1 else [t.simhit_x[sh], t.simhit_y[sh], t.simhit_z[sh]]
+              shp = [0, 0, 0] if sh == -1 else [t.simhit_particle[sh], math.sqrt(t.simhit_px[sh]*t.simhit_px[sh]+t.simhit_py[sh]*t.simhit_py[sh]), t.simhit_pz[sh]]
+              print(f'P {iS:4d} {t.pix_subdet[iS]: 2d} {t.pix_layer[iS]: 3d} ({t.pix_x[iS]: 6.2f} {t.pix_y[iS]: 6.2f} {t.pix_z[iS]: 6.2f}) cm {sh: 4d} ({shr[0]: 6.2f} {shr[1]: 6.2f} {shr[2]: 6.2f}) {shp[0]: 5d} ({shp[1]: 6.2f} {shp[2]: 6.2f}) {sehSt}')
+            if (ht == 1):
+              shs = [s for s in t.str_simHitIdx[iS] if s in t.sim_simHitIdx[v]]
+              sh = -1 if len(shs)==0 else shs[0]
+              shr = [0, 0, 0] if sh == -1 else [t.simhit_x[sh], t.simhit_y[sh], t.simhit_z[sh]]
+              shp = [0, 0, 0] if sh == -1 else [t.simhit_particle[sh], math.sqrt(t.simhit_px[sh]*t.simhit_px[sh]+t.simhit_py[sh]*t.simhit_py[sh]), t.simhit_pz[sh]]
+              print(f'S {iS:4d} {t.str_subdet[iS]:2d} {t.str_layer[iS]:3d} {t.str_isStereo[iS]:2d} ({t.str_x[iS]: 6.2f} {t.str_y[iS]: 6.2f} {t.str_z[iS]: 6.2f}) cm {sh:4d}  ({shr[0]: 6.2f} {shr[1]: 6.2f} {shr[2]: 6.2f}) {shp[0]: 5d} ({shp[1]: 6.2f} {shp[2]: 6.2f}) {sehSt}')
+          for sh in t.sim_simHitIdx[v]:
+            shr = [t.simhit_x[sh], t.simhit_y[sh], t.simhit_z[sh]]
+            shp = [t.simhit_particle[sh], math.sqrt(t.simhit_px[sh]*t.simhit_px[sh]+t.simhit_py[sh]*t.simhit_py[sh]), t.simhit_pz[sh]]
+            if (shp[1]<0.05): continue
+            for (ih,ht) in enumerate(t.simhit_hitType[sh]):
+              iS = t.simhit_hitIdx[sh][ih]
+              if ([ht,iS] in tchs): continue
+              if (ht == 0):
+                print(f'P {iS:4d} {t.pix_subdet[iS]: 2d} {t.pix_layer[iS]: 3d} ({t.pix_x[iS]: 6.2f} {t.pix_y[iS]: 6.2f} {t.pix_z[iS]: 6.2f}) cm {sh: 4d} ({shr[0]: 6.2f} {shr[1]: 6.2f} {shr[2]: 6.2f}) {shp[0]: 5d} ({shp[1]: 6.2f} {shp[2]: 6.2f})  extra')
+              if (ht == 1):
+                print(f'S {iS:4d} {t.str_subdet[iS]:2d} {t.str_layer[iS]:3d} {t.str_isStereo[iS]:2d} ({t.str_x[iS]: 6.2f} {t.str_y[iS]: 6.2f} {t.str_z[iS]: 6.2f}) cm {sh:4d}  ({shr[0]: 6.2f} {shr[1]: 6.2f} {shr[2]: 6.2f}) {shp[0]: 5d} ({shp[1]: 6.2f} {shp[2]: 6.2f}) extra')
+    for i,v in l9b:
+      if v not in v9a:
+        if tb.sim_trkIdx[v].size()>0:
+          print(iE,"tc ",i," sim ",v," only in B")


### PR DESCRIPTION
this is not yet meant for merging to cmssw

In the context of comparing to tracks found in CKF but not in mkFit I was using this script to select reasonably good cases to follow.

The default formatting includes details of the seed and the track candidate with reco and simhit info.
```scanTC(ta, tb, minSimPt=0., nEv=10, iteration=9)```
would printout differences for the first 10 events looking at tracks in iter 9 (pixelLess).

The hardcoded logic for the detailed printouts requires that the CKF track passed the high purity selections and has all hits matched to sim


The column headings are missing.

A somewhat random example with my comments added after # 
```
# event 5 tc idx 3324 from sim track idx 20548
5 tc  3324  sim  20548  only in a
# seed idx 16620 label 7931 pt eta phi 0.6477  2.0136  0.8917  nhits 2 last hit xyz 12.7604  37.0352  151.1987 px py pz ...
see 16620 7931  0.6477  2.0136  0.8917  2  12.7604  37.0352  151.1987 -0.0112  0.6476  2.3825
# if present, other seeds matching to the same sim will be printed as well
# glued hit from the seed (P and S would be for single pixel and strip hits) at idx 57475 subdet layer 6 1  (x y z) cm err xx yy zz "m"ono idx 71533 (x y z) "s"tereo idx 71527 (x y z)
g 57475  6   1 ( 12.62  32.98  137.20) cm  2.48e-04  7.43e-04  2.30e-03 m 71533 ( 13.12  34.30  137.04) s 71527 ( 12.96  34.24  137.36)
g 60043  6   2 ( 12.67  36.72  151.20) cm  2.52e-04  8.36e-04  2.86e-03 m 74812 ( 11.99  34.76  151.03) s 74802 ( 12.13  34.49  151.36)
# track candidate idx 3324 seed idx 16620 x y 10.3173  21.1181 pca Pt Eta Phi 0.4922  2.0317  0.7104 nhits 15 npixel 0 sim Idx 20548 pdgId 11 vtxId 7823 match fraction 1.000 simpt simeta 0.4781  2.0458
tcand 3324 16620  10.3173  21.1181 0.4922  2.0317  0.7104 15  0 20548	11 7823 1.000 0.4781  2.0458
#partial printout of hits follows
# "S"trip idx 25492 subdet layer side 4   2  0 (x y z) cm simIdx 10685 (x y z) hitpdgId 11 (simpt simpz) [SH for seed hit]
S 25492  4   2  0 ( 12.60  25.83  90.62) cm 10685  ( 10.32  21.17  90.62)	11 (  0.47   1.81)
S 25487  4   2  1 ( 11.96  25.90  90.86) cm 10684  ( 10.34  21.23  90.86)	11 (  0.48   1.81)
S 27208  4   3  0 ( 12.12  26.11  103.57) cm 10683  ( 11.34  24.42  103.57)	11 (  0.48   1.81)
S 27204  4   3  1 ( 11.85  25.95  103.81) cm 10680  ( 10.08  23.71  103.80)	22 (  0.00  -0.00)
S 71533  6   1  0 L27 ( 13.12  34.30  137.04) cm 10686  ( 12.70  33.18  137.04)	11 (  0.48   1.79) SH
...
# additional hits matching to the same simtrack are printed at the end
S 27206  4   3  1 ( 10.89  26.39  103.81) cm 10681  ( 11.35  24.49  103.81)	11 (  0.48   1.81) extra
```

