### PR TITLE
Per iteration / eta region track/candidate scoring function

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
+++ b/RecoTracker/MkFitCMS/standalone/MkStandaloneSeqs.cc
@@ -3,6 +3,7 @@
 
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 #include "RecoTracker/MkFitCore/standalone/Event.h"
+#include "RecoTracker/MkFitCore/interface/IterationConfig.h"
 
 #include "RecoTracker/MkFitCore/src/Debug.h"
 
@@ -396,8 +397,9 @@ namespace mkfit {
     }
 
     void score_tracks(TrackVec &tracks) {
+      auto score_func = IterationConfig::get_track_scorer("default");
       for (auto &track : tracks) {
-        track.setScore(getScoreCand(track));
+        track.setScore(getScoreCand(score_func, track));
       }
     }
 

--- a/RecoTracker/MkFitCore/interface/FunctionTypes.h
+++ b/RecoTracker/MkFitCore/interface/FunctionTypes.h
@@ -1,0 +1,44 @@
+#ifndef RecoTracker_MkFitCore_interface_FunctionTypes_h
+#define RecoTracker_MkFitCore_interface_FunctionTypes_h
+
+#include <functional>
+
+namespace mkfit {
+
+  struct BeamSpot;
+  class EventOfHits;
+  class TrackerInfo;
+  class Track;
+  class TrackCand;
+  class MkJob;
+  class IterationConfig;
+  class IterationSeedPartition;
+
+  typedef std::vector<Track> TrackVec;
+
+  // ----------------------------------------------------------
+
+  using clean_seeds_cf = int(TrackVec &, const IterationConfig &, const BeamSpot &);
+  using clean_seeds_func = std::function<clean_seeds_cf>;
+
+  using partition_seeds_cf = void(const TrackerInfo &, const TrackVec &, const EventOfHits &, IterationSeedPartition &);
+  using partition_seeds_func = std::function<partition_seeds_cf>;
+
+  using filter_candidates_cf = bool(const TrackCand &, const MkJob &);
+  using filter_candidates_func = std::function<filter_candidates_cf>;
+
+  using clean_duplicates_cf = void(TrackVec &, const IterationConfig &);
+  using clean_duplicates_func = std::function<clean_duplicates_cf>;
+
+  using track_score_cf = float(const int nfoundhits,
+                               const int ntailholes,
+                               const int noverlaphits,
+                               const int nmisshits,
+                               const float chi2,
+                               const float pt,
+                               const bool inFindCandidates);
+  using track_score_func = std::function<track_score_cf>;
+
+}  // end namespace mkfit
+
+#endif

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -1,6 +1,7 @@
 #ifndef RecoTracker_MkFitCore_interface_IterationConfig_h
 #define RecoTracker_MkFitCore_interface_IterationConfig_h
 
+#include "RecoTracker/MkFitCore/interface/FunctionTypes.h"
 #include "RecoTracker/MkFitCore/interface/SteeringParams.h"
 
 #include "nlohmann/json_fwd.hpp"
@@ -8,15 +9,6 @@
 #include <functional>
 
 namespace mkfit {
-
-  struct BeamSpot;
-  class EventOfHits;
-  class TrackerInfo;
-  class Track;
-  class TrackCand;
-  class MkJob;
-
-  typedef std::vector<Track> TrackVec;
 
   //==============================================================================
   // Hit masks / IterationMaskIfc
@@ -129,22 +121,6 @@ namespace mkfit {
 
   class IterationConfig {
   public:
-    // Called directly.
-    using clean_seeds_cf = int(TrackVec &, const IterationConfig &, const BeamSpot &);
-    using clean_seeds_func = std::function<clean_seeds_cf>;
-    // Called from MkBuilder::find_tracks_load_seeds().
-    using partition_seeds_cf = void(const TrackerInfo &,
-                                    const TrackVec &,
-                                    const EventOfHits &,
-                                    IterationSeedPartition &);
-    using partition_seeds_func = std::function<partition_seeds_cf>;
-    // Passed to MkBuilder::filter_comb_cands().
-    using filter_candidates_cf = bool(const TrackCand &, const MkJob &);
-    using filter_candidates_func = std::function<filter_candidates_cf>;
-    // Called directly.
-    using clean_duplicates_cf = void(TrackVec &, const IterationConfig &);
-    using clean_duplicates_func = std::function<clean_duplicates_cf>;
-
     int m_iteration_index = -1;
     int m_track_algorithm = -1;
 
@@ -181,17 +157,24 @@ namespace mkfit {
     std::vector<SteeringParams> m_steering_params;
     std::vector<IterationLayerConfig> m_layer_configs;
 
-    // Standard functions
+    // *** Standard functions
+    // - seed cleaning: called directly from top-level per-iteration steering code.
     clean_seeds_func m_seed_cleaner;
+    // - seed partitioning into eta regions: called from MkBuilder::find_tracks_load_seeds().
     partition_seeds_func m_seed_partitioner;
+    // - candidate filtering: passed to MkBuilder::filter_comb_cands().
     filter_candidates_func m_pre_bkfit_filter, m_post_bkfit_filter;
+    // - duplicate cleaning: called directly from top-level per-iteration steering code.
     clean_duplicates_func m_duplicate_cleaner;
+    // - default track scoring function, can be overriden in SteeringParams for each eta region.
+    track_score_func m_default_track_scorer;
 
     // Names for Standard functions that get saved to / loaded from JSON.
     std::string m_seed_cleaner_name;
     std::string m_seed_partitioner_name;
     std::string m_pre_bkfit_filter_name, m_post_bkfit_filter_name;
     std::string m_duplicate_cleaner_name;
+    std::string m_default_track_scorer_name = "default";
 
     //----------------------------------------------------------------------------
 
@@ -275,11 +258,13 @@ namespace mkfit {
     static void register_seed_partitioner(const std::string &name, partition_seeds_func func);
     static void register_candidate_filter(const std::string &name, filter_candidates_func func);
     static void register_duplicate_cleaner(const std::string &name, clean_duplicates_func func);
+    static void register_track_scorer(const std::string &name, track_score_func func);
 
     static clean_seeds_func get_seed_cleaner(const std::string &name);
     static partition_seeds_func get_seed_partitioner(const std::string &name);
     static filter_candidates_func get_candidate_filter(const std::string &name);
     static clean_duplicates_func get_duplicate_cleaner(const std::string &name);
+    static track_score_func get_track_scorer(const std::string &name);
   };
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -208,6 +208,7 @@ namespace mkfit {
       m_pre_bkfit_filter_name = o.m_pre_bkfit_filter_name;
       m_post_bkfit_filter_name = o.m_post_bkfit_filter_name;
       m_duplicate_cleaner_name = o.m_duplicate_cleaner_name;
+      m_default_track_scorer_name = o.m_default_track_scorer_name;
     }
 
     void set_iteration_index_and_track_algorithm(int idx, int trk_alg) {

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -22,10 +22,6 @@ namespace mkfit {
   class Event;
 
   //==============================================================================
-  // MkJob
-  //==============================================================================
-
-  //==============================================================================
   // MkBuilder
   //==============================================================================
 
@@ -55,7 +51,7 @@ namespace mkfit {
     void import_seeds(const TrackVec &in_seeds, const bool seeds_sorted, std::function<insert_seed_foo> insert_seed);
 
     // filter for rearranging cands that will / will not do backward search.
-    int filter_comb_cands(IterationConfig::filter_candidates_func filter);
+    int filter_comb_cands(filter_candidates_func filter);
 
     void find_min_max_hots_size();
 

--- a/RecoTracker/MkFitCore/interface/SteeringParams.h
+++ b/RecoTracker/MkFitCore/interface/SteeringParams.h
@@ -1,6 +1,8 @@
 #ifndef RecoTracker_MkFitCore_interface_SteeringParams_h
 #define RecoTracker_MkFitCore_interface_SteeringParams_h
 
+#include "RecoTracker/MkFitCore/interface/FunctionTypes.h"
+
 #include <vector>
 #include <stdexcept>
 

--- a/RecoTracker/MkFitCore/interface/SteeringParams.h
+++ b/RecoTracker/MkFitCore/interface/SteeringParams.h
@@ -91,9 +91,11 @@ namespace mkfit {
         else
           return m_steering_params.m_layer_plan[m_end_index + 1].m_layer;
       }
-    };
+    };  // class iterator
 
     std::vector<LayerControl> m_layer_plan;
+    track_score_func m_track_scorer;
+    std::string m_track_scorer_name;
 
     int m_region;
 

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -255,7 +255,7 @@ namespace mkfit {
     return cand1.score() > cand2.score();
   }
 
-  inline float getScoreCand(const track_score_func& scoreFunc,
+  inline float getScoreCand(const track_score_func& score_func,
                             const TrackCand& cand1,
                             bool penalizeTailMissHits = false,
                             bool inFindCandidates = false) {
@@ -268,7 +268,7 @@ namespace mkfit {
     // Do not allow for chi2<0 in score calculation
     if (chi2 < 0)
       chi2 = 0.f;
-    return scoreFunc(nfoundhits, ntailmisshits, noverlaphits, nmisshits, chi2, pt, inFindCandidates);
+    return score_func(nfoundhits, ntailmisshits, noverlaphits, nmisshits, chi2, pt, inFindCandidates);
   }
 
   // CombCandidate -- a set of candidates from a given seed.

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -255,7 +255,10 @@ namespace mkfit {
     return cand1.score() > cand2.score();
   }
 
-  inline float getScoreCand(const TrackCand& cand1, bool penalizeTailMissHits = false, bool inFindCandidates = false) {
+  inline float getScoreCand(const track_score_func& scoreFunc,
+                            const TrackCand& cand1,
+                            bool penalizeTailMissHits = false,
+                            bool inFindCandidates = false) {
     int nfoundhits = cand1.nFoundHits();
     int noverlaphits = cand1.nOverlapHits();
     int nmisshits = cand1.nInsideMinusOneHits();
@@ -265,7 +268,7 @@ namespace mkfit {
     // Do not allow for chi2<0 in score calculation
     if (chi2 < 0)
       chi2 = 0.f;
-    return getScoreCalc(nfoundhits, ntailmisshits, noverlaphits, nmisshits, chi2, pt, inFindCandidates);
+    return scoreFunc(nfoundhits, ntailmisshits, noverlaphits, nmisshits, chi2, pt, inFindCandidates);
   }
 
   // CombCandidate -- a set of candidates from a given seed.
@@ -371,14 +374,17 @@ namespace mkfit {
       m_hots.clear();
     }
 
-    void importSeed(const Track& seed, int region);
+    void importSeed(const Track& seed, const track_score_func& score_func, int region);
 
     int addHit(const HitOnTrack& hot, float chi2, int prev_idx) {
       m_hots.push_back({hot, chi2, prev_idx});
       return m_hots_size++;
     }
 
-    void mergeCandsAndBestShortOne(const IterationParams& params, bool update_score, bool sort_cands);
+    void mergeCandsAndBestShortOne(const IterationParams& params,
+                                   const track_score_func& score_func,
+                                   bool update_score,
+                                   bool sort_cands);
 
     void compactifyHitStorageForBestCand(bool remove_seed_hits, int backward_fit_min_hits);
     void beginBkwSearch();
@@ -612,10 +618,10 @@ namespace mkfit {
       m_n_seeds_inserted -= n_removed;
     }
 
-    void insertSeed(const Track& seed, int region, int pos) {
+    void insertSeed(const Track& seed, const track_score_func& score_func, int region, int pos) {
       assert(pos < m_size);
 
-      m_candidates[pos].importSeed(seed, region);
+      m_candidates[pos].importSeed(seed, score_func, region);
 
       ++m_n_seeds_inserted;
     }

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -301,7 +301,7 @@ namespace mkfit {
 
   //------------------------------------------------------------------------------
 
-  int MkBuilder::filter_comb_cands(IterationConfig::filter_candidates_func filter) {
+  int MkBuilder::filter_comb_cands(filter_candidates_func filter) {
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     int i = 0, place_pos = 0;
 
@@ -527,6 +527,7 @@ namespace mkfit {
             mkfndr->setup(prop_config,
                           m_job->m_iter_config.m_params,
                           m_job->m_iter_config.m_layer_configs[curr_layer],
+                          st_par,
                           m_job->get_mask_for_layer(curr_layer));
 
             const LayerOfHits &layer_of_hits = m_job->m_event_of_hits[curr_layer];
@@ -618,7 +619,7 @@ namespace mkfit {
     m_event_of_comb_cands.reset((int)in_seeds.size(), m_job->max_max_cands());
 
     import_seeds(in_seeds, seeds_sorted, [&](const Track &seed, int region, int pos) {
-      m_event_of_comb_cands.insertSeed(seed, region, pos);
+      m_event_of_comb_cands.insertSeed(seed, m_job->steering_params(region).m_track_scorer, region, pos);
     });
   }
 
@@ -810,6 +811,7 @@ namespace mkfit {
           mkfndr->setup(prop_config,
                         iter_params,
                         m_job->m_iter_config.m_layer_configs[curr_layer],
+                        st_par,
                         m_job->get_mask_for_layer(curr_layer));
 
           dprintf("\n* Processing layer %d\n", curr_layer);
@@ -912,7 +914,7 @@ namespace mkfit {
 
         // final sorting
         for (int iseed = start_seed; iseed < end_seed; ++iseed) {
-          eoccs[iseed].mergeCandsAndBestShortOne(m_job->params(), true, true);
+          eoccs[iseed].mergeCandsAndBestShortOne(m_job->params(), st_par.m_track_scorer, true, true);
         }
       });  // end parallel-for over chunk of seeds within region
     });    // end of parallel-for-each over eta regions
@@ -1018,6 +1020,7 @@ namespace mkfit {
       mkfndr->setup(prop_config,
                     iter_params,
                     m_job->m_iter_config.m_layer_configs[curr_layer],
+                    st_par,
                     m_job->get_mask_for_layer(curr_layer));
 
       const bool pickup_only = layer_plan_it.is_pickup_only();
@@ -1144,7 +1147,7 @@ namespace mkfit {
 
     // final sorting
     for (int iseed = start_seed; iseed < end_seed; ++iseed) {
-      eoccs[iseed].mergeCandsAndBestShortOne(m_job->params(), true, true);
+      eoccs[iseed].mergeCandsAndBestShortOne(m_job->params(), st_par.m_track_scorer, true, true);
     }
   }
 
@@ -1316,7 +1319,7 @@ namespace mkfit {
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     const SteeringParams &st_par = m_job->steering_params(region);
     const PropagationConfig &prop_config = PropagationConfig::get_default();
-    mkfndr->setup_bkfit(prop_config);
+    mkfndr->setup_bkfit(prop_config, st_par);
 
     int step = NN;
     for (int icand = start_cand; icand < end_cand; icand += step) {

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -52,8 +52,9 @@ namespace mkfit {
     void setup(const PropagationConfig &pc,
                const IterationParams &ip,
                const IterationLayerConfig &ilc,
+               const SteeringParams &sp,
                const std::vector<bool> *ihm);
-    void setup_bkfit(const PropagationConfig &pc);
+    void setup_bkfit(const PropagationConfig &pc, const SteeringParams &sp);
     void release();
 
     //----------------------------------------------------------------------------
@@ -326,6 +327,7 @@ namespace mkfit {
     const PropagationConfig *m_prop_config = nullptr;
     const IterationParams *m_iteration_params = nullptr;
     const IterationLayerConfig *m_iteration_layer_config = nullptr;
+    const SteeringParams *m_steering_params = nullptr;
     const std::vector<bool> *m_iteration_hit_mask = nullptr;
 
     // Backward fit

--- a/RecoTracker/MkFitCore/src/TrackStructures.cc
+++ b/RecoTracker/MkFitCore/src/TrackStructures.cc
@@ -50,7 +50,7 @@ namespace mkfit {
   // CombCandidate
   //==============================================================================
 
-  void CombCandidate::importSeed(const Track &seed, int region) {
+  void CombCandidate::importSeed(const Track &seed, const track_score_func &score_func, int region) {
     m_trk_cands.emplace_back(TrackCand(seed, this));
 
     m_state = CombCandidate::Dormant;
@@ -71,18 +71,21 @@ namespace mkfit {
       cand.addHitIdx(hp->index, hp->layer, 0.0f);
     }
 
-    cand.setScore(getScoreCand(cand));
+    cand.setScore(getScoreCand(score_func, cand));
   }
 
-  void CombCandidate::mergeCandsAndBestShortOne(const IterationParams &params, bool update_score, bool sort_cands) {
+  void CombCandidate::mergeCandsAndBestShortOne(const IterationParams &params,
+                                                const track_score_func &score_func,
+                                                bool update_score,
+                                                bool sort_cands) {
     TrackCand *best_short = m_best_short_cand.combCandidate() ? &m_best_short_cand : nullptr;
 
     if (!empty()) {
       if (update_score) {
         for (auto &c : m_trk_cands)
-          c.setScore(getScoreCand(c));
+          c.setScore(getScoreCand(score_func, c));
         if (best_short)
-          best_short->setScore(getScoreCand(*best_short));
+          best_short->setScore(getScoreCand(score_func, *best_short));
       }
       if (sort_cands) {
         std::sort(m_trk_cands.begin(), m_trk_cands.end(), sortByScoreTrackCand);

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -1,4 +1,5 @@
 #include "Event.h"
+#include "RecoTracker/MkFitCore/interface/IterationConfig.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
 
 //#define DEBUG
@@ -538,7 +539,7 @@ namespace mkfit {
 
   void Event::print_tracks(const TrackVec &tracks, bool print_hits) const {
     const int nt = tracks.size();
-
+    auto score_func = IterationConfig::get_track_scorer("default");
     //WARNING: Printouts for hits will not make any sense if mkFit is not run with a validation flag such as --quality-val
     printf("Event::print_tracks printing %d tracks %s hits:\n", nt, (print_hits ? "with" : "without"));
     for (int it = 0; it < nt; it++) {
@@ -551,7 +552,7 @@ namespace mkfit {
              t.nFoundHits(),
              t.label(),
              t.isFindable(),
-             getScoreCand(t),
+             getScoreCand(score_func, t),
              t.chi2());
 
       if (print_hits) {

--- a/RecoTracker/MkFitCore/standalone/TTreeValidation.cc
+++ b/RecoTracker/MkFitCore/standalone/TTreeValidation.cc
@@ -1067,22 +1067,23 @@ namespace mkfit {
     auto& seedtracks = ev.seedTracks_;
     auto& candtracks = ev.candidateTracks_;
     auto& fittracks = ev.fitTracks_;
+    auto score_calc = IterationConfig::get_track_scorer("default");
 
     // first compute score...
     for (auto& seedtrack : seedtracks) {
-      seedtrack.setScore(getScoreCand(seedtrack));
+      seedtrack.setScore(getScoreCand(score_calc, seedtrack));
     }
 
     // ...then use map to set seed type to for build/fit tracks and compute scores
     for (const auto& candToSeedPair : candToSeedMapDumbCMSSW_) {
       auto& candtrack = candtracks[candToSeedPair.first];
 
-      candtrack.setScore(getScoreCand(candtrack));
+      candtrack.setScore(getScoreCand(score_calc, candtrack));
     }
     for (const auto& fitToSeedPair : fitToSeedMapDumbCMSSW_) {
       auto& fittrack = fittracks[fitToSeedPair.first];
 
-      fittrack.setScore(getScoreCand(fittrack));
+      fittrack.setScore(getScoreCand(score_calc, fittrack));
     }
   }
 


### PR DESCRIPTION
* Allow track/candidate scoring function to be defined per iteration and eta region.
* Configure through standard function catalog and JSON files.
* Default is to pick the existing scoring function so there is no need to provide new JSON files until new scoring functions are actually implemented.
