### PR TITLE
mkFit: standalone build fixes 2

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -9,10 +9,11 @@ MAIN    := ../mkFit
 WRMEMF  := ../writeMemoryFile
 WMF_DICT_PCM := ../WriteMemFileDict_rdict.pcm
 SHELL_DICT_PCM := ../ShellDict_rdict.pcm
+ROOTOUT := WriteMemFileDict.cc ShellDict.cc
 
 TGTS := ${LIB_CMS} ${MAIN}
 ifdef WITH_ROOT
-TGTS += ${WRMEMF} ${WMF_DICT_PCM}
+TGTS += ${WRMEMF} ${WMF_DICT_PCM} ${SHELL_DICT_PCM}
 endif
 
 .PHONY: all clean distclean
@@ -45,7 +46,7 @@ include ${DEPS}
 endif
 
 clean-local:
-	-rm -f ${TGTS} *.d *.o *.om *.so *.pcm
+	-rm -f ${TGTS} *.d *.o *.om *.so *.pcm ${ROOTOUT}
 	-rm -rf main.dSYM
 	-rm -rf plotting/*.so plotting/*.d plotting/*.pcm
 

--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -22,13 +22,14 @@ all: ${TGTS}
 SRCS := $(wildcard ${CMS_DIR}/src/*.cc) $(wildcard ${SACMS}/*.cc)
 ifdef WITH_ROOT
 SRCS += ${SACMS}/tkNtuple/WriteMemoryFile.cc
-WriteMemFileDict.cc ${WMF_DICT_PCM}: ${SACMS}/tkNtuple/DictsLinkDef.h
+WriteMemFileDict.cc: ${SACMS}/tkNtuple/DictsLinkDef.h
 	rootcling -I=${SRCDIR} -f WriteMemFileDict.cc $<
+${WMF_DICT_PCM}: WriteMemFileDict.cc
 	mv WriteMemFileDict_rdict.pcm ${WMF_DICT_PCM}
-
 SRCS += ShellDict.cc
-ShellDict.cc ${SHELL_DICT_PCM}: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+ShellDict.cc: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
 	rootcling -I=${SRCDIR} -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+${SHELL_DICT_PCM}: ShellDict.cc
 	mv ShellDict_rdict.pcm ${SHELL_DICT_PCM}
 endif
 SRCB := $(notdir ${SRCS})


### PR DESCRIPTION
This is in response to issue #121 from @slava77. I believe it takes care of the Makefile problem where putting 2 targets on the same line might result in the rule for those targets being run simultaneously by 2 threads (as @slava77 hypothesized in Skype). The issue seems to occur twice in the Makefile; this PR fixes both. It also addresses the incomplete cleanup issue, where a couple of `.cc` source files that are created by `rootcling` during `make` get left behind by `make distclean`. I tested the documented procedure in`README_buildFromCMSSW.txt`, and the new Makefile works both on a fresh clone and a directory tree cleaned by `make distclean`. I leave it to @osschar to check on the goodness of my solution.

If we decide to make this PR into a further PR to cms-sw, then I propose that we also consider changing the default compilation for standalone builds to `-Ofast -fno-reciprocal-math -mrecip=none`, since this combination has been approved by CMSSW as not harming reproducibility between AMD and Intel platforms. See cms-sw/cmsdist#8280. This combination of options improves the performance of mkFit by quite a lot: my little test with InitialStep runs almost 20% faster when the above options are provided through `CXXUSERFLAGS`. In general I think our default standalone build should match the default options for the full CMSSW build... but I can't tell if these flags are now the default for CMSSW builds. Can someone please comment on that? 