### PR TITLE
Use ofast-flag rather than fast-math for mkFit

### DIFF
--- a/RecoTracker/MkFitCore/BuildFile.xml
+++ b/RecoTracker/MkFitCore/BuildFile.xml
@@ -1,8 +1,8 @@
 <use name="rootsmatrix"/>
 <use name="json"/>
 <use name="tbb"/>
+<use name="ofast-flag"/>
 <flags CXXFLAGS="-fopenmp-simd"/>
-<flags CXXFLAGS="-ffast-math"/>
 <flags ADD_SUBDIR="1"/>
 <export>
   <lib name="RecoTrackerMkFitCore"/>

--- a/RecoTracker/MkFitCore/standalone/Makefile.config
+++ b/RecoTracker/MkFitCore/standalone/Makefile.config
@@ -130,6 +130,7 @@ endif
 ifeq ($(CXX), g++)
   CXXFLAGS += -std=c++1z -ftree-vectorize -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Wstrict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
   CXXFLAGS += -fdiagnostics-color=auto -fdiagnostics-show-option -pthread -pipe -fopenmp-simd
+  CXXFLAGS += -Ofast -fno-reciprocal-math -mrecip=none
 endif
 
 # Try to find a new enough TBB


### PR DESCRIPTION
### PR description:

As per title, this PR is meant to switch to `ofast-flag` rather than `fast-math` for mkFit building, as this was proven to allow for improved stability across different architectures.
An analogous change is applied to the standalone mkFit `Makefile`.

### PR validation:

This PR is not meant to affect physics performance, except for compilation-driven effects. Technical performance is not affected either.
This is validated in: http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/testFastMath/MTV_ttbarPU_cgpu-1_fastmath_vs_ofast/ (red/black vs. blue)