### PR TITLE
[mkFit] Mid-way support for Phase2 initialStep in CMSSW

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -26,6 +26,7 @@ numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
 numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
+numWFIB.extend([24834.702]) #2026D98 mkFit tracking (initialStep)
 numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
 numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([24834.21,25034.21,25034.9921]) #2026D98 prodlike, prodlike PU, prodlike premix stage1+stage2

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -437,6 +437,28 @@ upgradeWFs['trackingMkFit'].step3 = {
     '--procModifiers': 'trackingMkFitDevel'
 }
 
+# mkFit for phase-2 initialStep tracking
+class UpgradeWorkflow_trackingMkFitPhase2(UpgradeWorkflowTracking):
+    def setup__(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+    def condition_(self, fragment, stepList, key, hasHarvest):
+        return ('2026' in key)
+upgradeWFs['trackingMkFitPhase2'] = UpgradeWorkflow_trackingMkFitPhase2(
+    steps = [
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    PU = [],
+    suffix = '_trackingMkFitPhase2',
+    offset = 0.702,
+)
+upgradeWFs['trackingMkFitPhase2'].step3 = {
+    '--procModifiers': 'trackingMkFitCommon,trackingMkFitInitialStep'
+}
+
 #DeepCore seeding for JetCore iteration workflow
 class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -240,6 +240,7 @@ import RecoTracker.MkFit.mkFitIterationConfigESProducer_cfi as mkFitIterationCon
 import RecoTracker.MkFit.mkFitProducer_cfi as mkFitProducer_cfi
 import RecoTracker.MkFit.mkFitOutputConverter_cfi as mkFitOutputConverter_cfi
 mkFitSiPixelHits = mkFitSiPixelHitConverter_cfi.mkFitSiPixelHitConverter.clone() # TODO: figure out better place for this module?
+mkFitSiPhase2Hits = mkFitSiStripHitConverter_cfi.mkFitSiStripHitConverter.clone(rphiHits=cms.InputTag(""), stereoHits=cms.InputTag(""))
 mkFitEventOfHits = mkFitEventOfHitsProducer_cfi.mkFitEventOfHitsProducer.clone() # TODO: figure out better place for this module?
 initialStepTrackCandidatesMkFitSeeds = mkFitSeedConverter_cfi.mkFitSeedConverter.clone(
     seeds = 'initialStepSeeds',
@@ -444,10 +445,14 @@ InitialStepTask = cms.Task(initialStepSeedLayers,
                            initialStep,caloJetsForTrkTask)
 InitialStep = cms.Sequence(InitialStepTask)
 
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
 from Configuration.ProcessModifiers.trackingMkFitCommon_cff import trackingMkFitCommon
 _InitialStepTask_trackingMkFitCommon = InitialStepTask.copy()
+_InitialStepTask_trackingMkFitCommon_Phase2 = InitialStepTask.copy()
 _InitialStepTask_trackingMkFitCommon.add(mkFitSiPixelHits, mkFitEventOfHits, mkFitGeometryESProducer)
-trackingMkFitCommon.toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon)
+_InitialStepTask_trackingMkFitCommon_Phase2.add(siPhase2RecHits, mkFitSiPixelHits, mkFitSiPhase2Hits, mkFitEventOfHits, mkFitGeometryESProducer)
+(trackingMkFitCommon & (~trackingPhase2PU140)).toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon_Phase2)
+(trackingMkFitCommon & trackingPhase2PU140).toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon_Phase2)
 
 _InitialStepTask_trackingMkFit = InitialStepTask.copy()
 _InitialStepTask_trackingMkFit.add(initialStepTrackCandidatesMkFitSeeds, initialStepTrackCandidatesMkFit, initialStepTrackCandidatesMkFitConfig)
@@ -465,6 +470,11 @@ _InitialStepTask_trackingPhase2 = InitialStepTask.copyAndExclude([initialStepCla
 _InitialStepTask_trackingPhase2.replace(initialStepHitTriplets, initialStepHitQuadruplets)
 _InitialStepTask_trackingPhase2.replace(initialStep, initialStepSelector)
 trackingPhase2PU140.toReplaceWith(InitialStepTask, _InitialStepTask_trackingPhase2)
+(trackingMkFitCommon & trackingPhase2PU140).toModify(mkFitEventOfHits, stripHits=cms.InputTag('mkFitSiPhase2Hits'))
+(trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFit, stripHits=cms.InputTag('mkFitSiPhase2Hits'))
+(trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidates, mkFitStripHits=cms.InputTag('mkFitSiPhase2Hits'))
+(trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFitConfig, config='RecoTracker/MkFit/data/mkfit-phase2-initialStep.json')
+(trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFitSeeds)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 _InitialStepTask_fastSim = cms.Task(initialStepTrackingRegions

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -475,7 +475,6 @@ trackingPhase2PU140.toReplaceWith(InitialStepTask, _InitialStepTask_trackingPhas
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFit, stripHits=cms.InputTag('mkFitSiPhase2Hits'))
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidates, mkFitStripHits=cms.InputTag('mkFitSiPhase2Hits'))
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFitConfig, config='RecoTracker/MkFit/data/mkfit-phase2-initialStep.json')
-(trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFitSeeds)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 _InitialStepTask_fastSim = cms.Task(initialStepTrackingRegions

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -234,13 +234,14 @@ from Configuration.ProcessModifiers.trackingMkFitInitialStep_cff import tracking
 from RecoTracker.MkFit.mkFitGeometryESProducer_cfi import mkFitGeometryESProducer
 import RecoTracker.MkFit.mkFitSiPixelHitConverter_cfi as mkFitSiPixelHitConverter_cfi
 import RecoTracker.MkFit.mkFitSiStripHitConverter_cfi as mkFitSiStripHitConverter_cfi
+import RecoTracker.MkFit.mkFitPhase2HitConverter_cfi as mkFitPhase2HitConverter_cfi
 import RecoTracker.MkFit.mkFitEventOfHitsProducer_cfi as mkFitEventOfHitsProducer_cfi
 import RecoTracker.MkFit.mkFitSeedConverter_cfi as mkFitSeedConverter_cfi
 import RecoTracker.MkFit.mkFitIterationConfigESProducer_cfi as mkFitIterationConfigESProducer_cfi
 import RecoTracker.MkFit.mkFitProducer_cfi as mkFitProducer_cfi
 import RecoTracker.MkFit.mkFitOutputConverter_cfi as mkFitOutputConverter_cfi
 mkFitSiPixelHits = mkFitSiPixelHitConverter_cfi.mkFitSiPixelHitConverter.clone() # TODO: figure out better place for this module?
-mkFitSiPhase2Hits = mkFitSiStripHitConverter_cfi.mkFitSiStripHitConverter.clone(rphiHits=cms.InputTag(""), stereoHits=cms.InputTag(""))
+mkFitSiPhase2Hits = mkFitPhase2HitConverter_cfi.mkFitPhase2HitConverter.clone()
 mkFitEventOfHits = mkFitEventOfHitsProducer_cfi.mkFitEventOfHitsProducer.clone() # TODO: figure out better place for this module?
 initialStepTrackCandidatesMkFitSeeds = mkFitSeedConverter_cfi.mkFitSeedConverter.clone(
     seeds = 'initialStepSeeds',
@@ -451,7 +452,7 @@ _InitialStepTask_trackingMkFitCommon = InitialStepTask.copy()
 _InitialStepTask_trackingMkFitCommon_Phase2 = InitialStepTask.copy()
 _InitialStepTask_trackingMkFitCommon.add(mkFitSiPixelHits, mkFitEventOfHits, mkFitGeometryESProducer)
 _InitialStepTask_trackingMkFitCommon_Phase2.add(siPhase2RecHits, mkFitSiPixelHits, mkFitSiPhase2Hits, mkFitEventOfHits, mkFitGeometryESProducer)
-(trackingMkFitCommon & (~trackingPhase2PU140)).toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon_Phase2)
+(trackingMkFitCommon & (~trackingPhase2PU140)).toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon)
 (trackingMkFitCommon & trackingPhase2PU140).toReplaceWith(InitialStepTask, _InitialStepTask_trackingMkFitCommon_Phase2)
 
 _InitialStepTask_trackingMkFit = InitialStepTask.copy()
@@ -470,7 +471,7 @@ _InitialStepTask_trackingPhase2 = InitialStepTask.copyAndExclude([initialStepCla
 _InitialStepTask_trackingPhase2.replace(initialStepHitTriplets, initialStepHitQuadruplets)
 _InitialStepTask_trackingPhase2.replace(initialStep, initialStepSelector)
 trackingPhase2PU140.toReplaceWith(InitialStepTask, _InitialStepTask_trackingPhase2)
-(trackingMkFitCommon & trackingPhase2PU140).toModify(mkFitEventOfHits, stripHits=cms.InputTag('mkFitSiPhase2Hits'))
+(trackingMkFitCommon & trackingPhase2PU140).toModify(mkFitEventOfHits, stripHits=cms.InputTag('mkFitSiPhase2Hits'), useStripStripQualityDB=cms.bool(False))
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFit, stripHits=cms.InputTag('mkFitSiPhase2Hits'))
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidates, mkFitStripHits=cms.InputTag('mkFitSiPhase2Hits'))
 (trackingMkFitInitialStep & trackingPhase2PU140).toModify(initialStepTrackCandidatesMkFitConfig, config='RecoTracker/MkFit/data/mkfit-phase2-initialStep.json')

--- a/RecoTracker/MkFit/interface/MkFitGeometry.h
+++ b/RecoTracker/MkFit/interface/MkFitGeometry.h
@@ -31,6 +31,8 @@ public:
 
   int mkFitLayerNumber(DetId detId) const;
   mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
+  bool isPhase1() const;
+  bool isPhase2() const;
   mkfit::TrackerInfo const& trackerInfo() const { return *trackerInfo_; }
   const std::vector<const DetLayer*>& detLayers() const { return dets_; }
   unsigned int uniqueIdInLayer(int layer, unsigned int detId) const {

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -115,8 +115,8 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
           deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
       }
     }
-
-    if (useStripStripQualityDB_) {
+    // For Phase-2, disable (momentarily?) SiStrip quality check
+    if (useStripStripQualityDB_ && !mkFitGeom.isPhase2()) {
       const auto& siStripQuality = iSetup.getData(stripQualityToken_);
       const auto& badStrips = siStripQuality.getBadComponentList();
       for (const auto& bs : badStrips) {

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -72,7 +72,7 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
   if (usePixelQualityDB_) {
     pixelQualityToken_ = esConsumes();
   }
-  if (useStripStripQualityDB_) {
+  if (useStripStripQualityDB_ && !((iConfig.getParameter<edm::InputTag>("stripHits"))==edm::InputTag{"mkFitSiPhase2Hits"})) {
     stripQualityToken_ = esConsumes();
   }
 }

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -72,7 +72,7 @@ MkFitEventOfHitsProducer::MkFitEventOfHitsProducer(edm::ParameterSet const& iCon
   if (usePixelQualityDB_) {
     pixelQualityToken_ = esConsumes();
   }
-  if (useStripStripQualityDB_ && !((iConfig.getParameter<edm::InputTag>("stripHits"))==edm::InputTag{"mkFitSiPhase2Hits"})) {
+  if (useStripStripQualityDB_) {
     stripQualityToken_ = esConsumes();
   }
 }
@@ -116,7 +116,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
       }
     }
     // For Phase-2, disable (momentarily?) SiStrip quality check
-    if (useStripStripQualityDB_ && !mkFitGeom.isPhase2()) {
+    if (useStripStripQualityDB_) {
       const auto& siStripQuality = iSetup.getData(stripQualityToken_);
       const auto& badStrips = siStripQuality.getBadComponentList();
       for (const auto& bs : badStrips) {

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/TrackReco/interface/SeedStopInfo.h"
 #include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
@@ -81,6 +82,7 @@ private:
                                              const MagneticField& mf,
                                              const Propagator& propagatorAlong,
                                              const Propagator& propagatorOpposite,
+                                             const MkFitGeometry& mkFitGeom,
                                              const TkClonerImpl& hitCloner,
                                              const std::vector<const DetLayer*>& detLayers,
                                              const mkfit::TrackVec& mkFitSeeds,
@@ -243,6 +245,7 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
                                    iSetup.getData(mfToken_),
                                    iSetup.getData(propagatorAlongToken_),
                                    iSetup.getData(propagatorOppositeToken_),
+                                   iSetup.getData(mkFitGeomToken_),
                                    tkBuilder->cloner(),
                                    mkFitGeom.detLayers(),
                                    mkfitSeeds.seeds(),
@@ -262,6 +265,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const MagneticField& mf,
                                                                  const Propagator& propagatorAlong,
                                                                  const Propagator& propagatorOpposite,
+                                                                 const MkFitGeometry& mkFitGeom,
                                                                  const TkClonerImpl& hitCloner,
                                                                  const std::vector<const DetLayer*>& detLayers,
                                                                  const mkfit::TrackVec& mkFitSeeds,
@@ -370,14 +374,18 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         auto const& hits = isPixel ? pixelClusterIndexToHit.hits() : stripClusterIndexToHit.hits();
 
         auto const& thit = static_cast<BaseTrackerRecHit const&>(*hits[hitOnTrack.index]);
-        if (thit.firstClusterRef().isPixel() || thit.detUnit()->type().isEndcap()) {
-          recHits.push_back(hits[hitOnTrack.index]->clone());
+        if(mkFitGeom.isPhase1()) {
+          if (thit.firstClusterRef().isPixel() || thit.detUnit()->type().isEndcap()) {
+            recHits.push_back(hits[hitOnTrack.index]->clone());
+          } else {
+            recHits.push_back(std::make_unique<SiStripRecHit1D>(
+                thit.localPosition(),
+                LocalError(thit.localPositionError().xx(), 0.f, std::numeric_limits<float>::max()),
+                *thit.det(),
+                thit.firstClusterRef()));
+          }
         } else {
-          recHits.push_back(std::make_unique<SiStripRecHit1D>(
-              thit.localPosition(),
-              LocalError(thit.localPositionError().xx(), 0.f, std::numeric_limits<float>::max()),
-              *thit.det(),
-              thit.firstClusterRef()));
+          recHits.push_back(hits[hitOnTrack.index]->clone());
         }
         LogTrace("MkFitOutputConverter") << "  pos " << recHits.back().globalPosition().x() << " "
                                          << recHits.back().globalPosition().y() << " "

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -374,7 +374,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         auto const& hits = isPixel ? pixelClusterIndexToHit.hits() : stripClusterIndexToHit.hits();
 
         auto const& thit = static_cast<BaseTrackerRecHit const&>(*hits[hitOnTrack.index]);
-        if(mkFitGeom.isPhase1()) {
+        if (mkFitGeom.isPhase1()) {
           if (thit.firstClusterRef().isPixel() || thit.detUnit()->type().isEndcap()) {
             recHits.push_back(hits[hitOnTrack.index]->clone());
           } else {

--- a/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
@@ -47,12 +47,11 @@ private:
   const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
   const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
   const ConvertHitTraitsPhase2 convertTraits_;
-  
 };
 
 MkFitPhase2HitConverter::MkFitPhase2HitConverter(edm::ParameterSet const& iConfig)
-    : siPhase2RecHitToken_{
-          consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
+    : siPhase2RecHitToken_{consumes<Phase2TrackerRecHit1DCollectionNew>(
+          iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
       ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
           iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
       ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
@@ -85,13 +84,13 @@ void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, con
   std::vector<float> dummy;
   if (not phase2Hits.empty()) {
     stripClusterID = mkfit::convertHits(ConvertHitTraitsPhase2{},
-					phase2Hits,
-					hitWrapper.hits(),
-					clusterIndexToHit.hits(),
-					dummy,
-					ttopo,
-					ttrhBuilder,
-					mkFitGeom);
+                                        phase2Hits,
+                                        hitWrapper.hits(),
+                                        clusterIndexToHit.hits(),
+                                        dummy,
+                                        ttopo,
+                                        ttrhBuilder,
+                                        mkFitGeom);
   }
 
   hitWrapper.setClustersID(stripClusterID);

--- a/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
@@ -1,0 +1,104 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+
+#include "RecoTracker/MkFit/interface/MkFitHitWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+#include "convertHits.h"
+
+namespace {
+  class ConvertHitTraitsPhase2 {
+  public:
+    static constexpr bool applyCCC() { return false; }
+    static std::nullptr_t clusterCharge(const Phase2TrackerRecHit1D& hit, DetId hitId) { return nullptr; }
+    static bool passCCC(std::nullptr_t) { return true; }
+    static void setDetails(mkfit::Hit& mhit, const Phase2TrackerCluster1D& cluster, int shortId, std::nullptr_t) {
+      mhit.setupAsStrip(shortId, (1 << 8) - 1, cluster.size());
+    }
+  };
+}  // namespace
+
+class MkFitPhase2HitConverter : public edm::global::EDProducer<> {
+public:
+  explicit MkFitPhase2HitConverter(edm::ParameterSet const& iConfig);
+  ~MkFitPhase2HitConverter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> siPhase2RecHitToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
+  const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
+  const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
+  const ConvertHitTraitsPhase2 convertTraits_;
+  
+};
+
+MkFitPhase2HitConverter::MkFitPhase2HitConverter(edm::ParameterSet const& iConfig)
+    : siPhase2RecHitToken_{
+          consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
+      ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
+          iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
+      ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
+      mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
+      wrapperPutToken_{produces<MkFitHitWrapper>()},
+      clusterIndexPutToken_{produces<MkFitClusterIndexToHit>()},
+      clusterChargePutToken_{produces<std::vector<float>>()},
+      convertTraits_{} {}
+
+void MkFitPhase2HitConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add("siPhase2Hits", edm::InputTag{"siPhase2RecHits"});
+  desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
+
+  descriptions.add("mkFitPhase2HitConverterDefault", desc);
+}
+
+void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  const auto& ttrhBuilder = iSetup.getData(ttrhBuilderToken_);
+  const auto& ttopo = iSetup.getData(ttopoToken_);
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
+
+  MkFitHitWrapper hitWrapper;
+  MkFitClusterIndexToHit clusterIndexToHit;
+  std::vector<float> clusterCharge;
+
+  edm::ProductID stripClusterID;
+  const auto& phase2Hits = iEvent.get(siPhase2RecHitToken_);
+  std::vector<float> dummy;
+  if (not phase2Hits.empty()) {
+    stripClusterID = mkfit::convertHits(ConvertHitTraitsPhase2{},
+					phase2Hits,
+					hitWrapper.hits(),
+					clusterIndexToHit.hits(),
+					dummy,
+					ttopo,
+					ttrhBuilder,
+					mkFitGeom);
+  }
+
+  hitWrapper.setClustersID(stripClusterID);
+
+  iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
+  iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
+  iEvent.emplace(clusterChargePutToken_, std::move(clusterCharge));
+}
+
+DEFINE_FWK_MODULE(MkFitPhase2HitConverter);

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -175,7 +175,8 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
       stripContainerMask.copyMaskTo(stripMask);
     }
   } else {
-    stripClusterChargeCut(iEvent.get(stripClusterChargeToken_), stripMask);
+    if (mkFitGeom.isPhase1())
+      stripClusterChargeCut(iEvent.get(stripClusterChargeToken_), stripMask);
   }
 
   // seeds need to be mutable because of the possible cleaning

--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -147,7 +147,7 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
         LogTrace("MkFitSeedConverter") << " adding hit detid " << detId.rawId() << " index " << clusterRef.index()
                                        << " ilay " << ilay;
         ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
-      } else if (!mkFitGeom.isPhase2()) { // XXXX why is !phase2 if needed here?
+      } else if (!mkFitGeom.isPhase2()) {                   // XXXX why is !phase2 if needed here?
         auto& matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
         const OmniClusterRef* const clRefs[2] = {&matched2D.monoClusterRef(), &matched2D.stereoClusterRef()};
         const DetId detIds[2] = {matched2D.monoId(), matched2D.stereoId()};

--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -147,7 +147,7 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
         LogTrace("MkFitSeedConverter") << " adding hit detid " << detId.rawId() << " index " << clusterRef.index()
                                        << " ilay " << ilay;
         ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
-      } else if (!mkFitGeom.isPhase2()) {                   // XXXX why is !phase2 if needed here?
+      } else {
         auto& matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
         const OmniClusterRef* const clRefs[2] = {&matched2D.monoClusterRef(), &matched2D.stereoClusterRef()};
         const DetId detIds[2] = {matched2D.monoId(), matched2D.stereoId()};

--- a/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSeedConverter.cc
@@ -147,7 +147,7 @@ mkfit::TrackVec MkFitSeedConverter::convertSeeds(const edm::View<TrajectorySeed>
         LogTrace("MkFitSeedConverter") << " adding hit detid " << detId.rawId() << " index " << clusterRef.index()
                                        << " ilay " << ilay;
         ret.back().addHitIdx(clusterRef.index(), ilay, 0);  // per-hit chi2 is not known
-      } else {
+      } else if (!mkFitGeom.isPhase2()) { // XXXX why is !phase2 if needed here?
         auto& matched2D = dynamic_cast<const SiStripMatchedRecHit2D&>(recHit);
         const OmniClusterRef* const clRefs[2] = {&matched2D.monoClusterRef(), &matched2D.stereoClusterRef()};
         const DetId detIds[2] = {matched2D.monoId(), matched2D.stereoId()};

--- a/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
@@ -127,7 +127,7 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
         stripClusterID = stripStereoClusterID;
       } else if (stripClusterID != stripStereoClusterID) {
         throw cms::Exception("LogicError") << "Encountered different cluster ProductIDs for strip RPhi hits ("
-                                          << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
+                                           << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
       }
     }
   } else {

--- a/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
@@ -6,6 +6,7 @@
 
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
@@ -35,6 +36,16 @@ namespace {
   private:
     const float minGoodStripCharge_;
   };
+
+  class ConvertHitTraitsPhase2 {
+  public:
+    static constexpr bool applyCCC() { return false; }
+    static std::nullptr_t clusterCharge(const Phase2TrackerRecHit1D& hit, DetId hitId) { return nullptr; }
+    static bool passCCC(std::nullptr_t) { return true; }
+    static void setDetails(mkfit::Hit& mhit, const Phase2TrackerCluster1D& cluster, int shortId, std::nullptr_t) {
+      mhit.setupAsStrip(shortId, (1 << 8) - 1, cluster.size());
+    }
+  };
 }  // namespace
 
 class MkFitSiStripHitConverter : public edm::global::EDProducer<> {
@@ -49,6 +60,7 @@ private:
 
   const edm::EDGetTokenT<SiStripRecHit2DCollection> stripRphiRecHitToken_;
   const edm::EDGetTokenT<SiStripRecHit2DCollection> stripStereoRecHitToken_;
+  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> siPhase2RecHitToken_;
   const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
@@ -61,6 +73,8 @@ private:
 MkFitSiStripHitConverter::MkFitSiStripHitConverter(edm::ParameterSet const& iConfig)
     : stripRphiRecHitToken_{consumes<SiStripRecHit2DCollection>(iConfig.getParameter<edm::InputTag>("rphiHits"))},
       stripStereoRecHitToken_{consumes<SiStripRecHit2DCollection>(iConfig.getParameter<edm::InputTag>("stereoHits"))},
+      siPhase2RecHitToken_{
+          consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
       ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
           iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
       ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
@@ -76,6 +90,7 @@ void MkFitSiStripHitConverter::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("rphiHits", edm::InputTag{"siStripMatchedRecHits", "rphiRecHit"});
   desc.add("stereoHits", edm::InputTag{"siStripMatchedRecHits", "stereoRecHit"});
+  desc.add("siPhase2Hits", edm::InputTag{"siPhase2RecHits"});
   desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
 
   edm::ParameterSetDescription descCCC;
@@ -100,18 +115,33 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   };
 
   edm::ProductID stripClusterID;
-  const auto& stripRphiHits = iEvent.get(stripRphiRecHitToken_);
-  const auto& stripStereoHits = iEvent.get(stripStereoRecHitToken_);
-  if (not stripRphiHits.empty()) {
-    stripClusterID = convert(stripRphiHits);
-  }
-  if (not stripStereoHits.empty()) {
-    auto stripStereoClusterID = convert(stripStereoHits);
-    if (stripRphiHits.empty()) {
-      stripClusterID = stripStereoClusterID;
-    } else if (stripClusterID != stripStereoClusterID) {
-      throw cms::Exception("LogicError") << "Encountered different cluster ProductIDs for strip RPhi hits ("
-                                         << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
+  if (mkFitGeom.isPhase1()) {
+    const auto& stripRphiHits = iEvent.get(stripRphiRecHitToken_);
+    const auto& stripStereoHits = iEvent.get(stripStereoRecHitToken_);
+    if (not stripRphiHits.empty()) {
+      stripClusterID = convert(stripRphiHits);
+    }
+    if (not stripStereoHits.empty()) {
+      auto stripStereoClusterID = convert(stripStereoHits);
+      if (stripRphiHits.empty()) {
+        stripClusterID = stripStereoClusterID;
+      } else if (stripClusterID != stripStereoClusterID) {
+        throw cms::Exception("LogicError") << "Encountered different cluster ProductIDs for strip RPhi hits ("
+                                          << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
+      }
+    }
+  } else {
+    const auto& phase2Hits = iEvent.get(siPhase2RecHitToken_);
+    std::vector<float> dummy;
+    if (not phase2Hits.empty()) {
+      stripClusterID = mkfit::convertHits(ConvertHitTraitsPhase2{},
+                                          phase2Hits,
+                                          hitWrapper.hits(),
+                                          clusterIndexToHit.hits(),
+                                          dummy,
+                                          ttopo,
+                                          ttrhBuilder,
+                                          mkFitGeom);
     }
   }
 

--- a/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitSiStripHitConverter.cc
@@ -6,7 +6,6 @@
 
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
-#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
 
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
@@ -36,16 +35,6 @@ namespace {
   private:
     const float minGoodStripCharge_;
   };
-
-  class ConvertHitTraitsPhase2 {
-  public:
-    static constexpr bool applyCCC() { return false; }
-    static std::nullptr_t clusterCharge(const Phase2TrackerRecHit1D& hit, DetId hitId) { return nullptr; }
-    static bool passCCC(std::nullptr_t) { return true; }
-    static void setDetails(mkfit::Hit& mhit, const Phase2TrackerCluster1D& cluster, int shortId, std::nullptr_t) {
-      mhit.setupAsStrip(shortId, (1 << 8) - 1, cluster.size());
-    }
-  };
 }  // namespace
 
 class MkFitSiStripHitConverter : public edm::global::EDProducer<> {
@@ -60,7 +49,6 @@ private:
 
   const edm::EDGetTokenT<SiStripRecHit2DCollection> stripRphiRecHitToken_;
   const edm::EDGetTokenT<SiStripRecHit2DCollection> stripStereoRecHitToken_;
-  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> siPhase2RecHitToken_;
   const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
@@ -73,8 +61,6 @@ private:
 MkFitSiStripHitConverter::MkFitSiStripHitConverter(edm::ParameterSet const& iConfig)
     : stripRphiRecHitToken_{consumes<SiStripRecHit2DCollection>(iConfig.getParameter<edm::InputTag>("rphiHits"))},
       stripStereoRecHitToken_{consumes<SiStripRecHit2DCollection>(iConfig.getParameter<edm::InputTag>("stereoHits"))},
-      siPhase2RecHitToken_{
-          consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
       ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
           iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
       ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
@@ -90,7 +76,6 @@ void MkFitSiStripHitConverter::fillDescriptions(edm::ConfigurationDescriptions& 
 
   desc.add("rphiHits", edm::InputTag{"siStripMatchedRecHits", "rphiRecHit"});
   desc.add("stereoHits", edm::InputTag{"siStripMatchedRecHits", "stereoRecHit"});
-  desc.add("siPhase2Hits", edm::InputTag{"siPhase2RecHits"});
   desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
 
   edm::ParameterSetDescription descCCC;
@@ -115,33 +100,18 @@ void MkFitSiStripHitConverter::produce(edm::StreamID iID, edm::Event& iEvent, co
   };
 
   edm::ProductID stripClusterID;
-  if (mkFitGeom.isPhase1()) {
-    const auto& stripRphiHits = iEvent.get(stripRphiRecHitToken_);
-    const auto& stripStereoHits = iEvent.get(stripStereoRecHitToken_);
-    if (not stripRphiHits.empty()) {
-      stripClusterID = convert(stripRphiHits);
-    }
-    if (not stripStereoHits.empty()) {
-      auto stripStereoClusterID = convert(stripStereoHits);
-      if (stripRphiHits.empty()) {
-        stripClusterID = stripStereoClusterID;
-      } else if (stripClusterID != stripStereoClusterID) {
-        throw cms::Exception("LogicError") << "Encountered different cluster ProductIDs for strip RPhi hits ("
-                                           << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
-      }
-    }
-  } else {
-    const auto& phase2Hits = iEvent.get(siPhase2RecHitToken_);
-    std::vector<float> dummy;
-    if (not phase2Hits.empty()) {
-      stripClusterID = mkfit::convertHits(ConvertHitTraitsPhase2{},
-                                          phase2Hits,
-                                          hitWrapper.hits(),
-                                          clusterIndexToHit.hits(),
-                                          dummy,
-                                          ttopo,
-                                          ttrhBuilder,
-                                          mkFitGeom);
+  const auto& stripRphiHits = iEvent.get(stripRphiRecHitToken_);
+  const auto& stripStereoHits = iEvent.get(stripStereoRecHitToken_);
+  if (not stripRphiHits.empty()) {
+    stripClusterID = convert(stripRphiHits);
+  }
+  if (not stripStereoHits.empty()) {
+    auto stripStereoClusterID = convert(stripStereoHits);
+    if (stripRphiHits.empty()) {
+      stripClusterID = stripStereoClusterID;
+    } else if (stripClusterID != stripStereoClusterID) {
+      throw cms::Exception("LogicError") << "Encountered different cluster ProductIDs for strip RPhi hits ("
+                                         << stripClusterID << ") and stereo (" << stripStereoClusterID << ")";
     }
   }
 

--- a/RecoTracker/MkFit/python/mkFitPhase2HitConverter_cfi.py
+++ b/RecoTracker/MkFit/python/mkFitPhase2HitConverter_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.MkFit.mkFitPhase2HitConverterDefault_cfi import mkFitPhase2HitConverterDefault as _mkFitPhase2HitConverterDefault
+
+mkFitPhase2HitConverter = _mkFitPhase2HitConverterDefault.clone()

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -63,10 +63,6 @@ int MkFitGeometry::mkFitLayerNumber(DetId detId) const {
       detId.subdetId(), ttopo_->layer(detId), false, ttopo_->isStereo(detId), isPlusSide(*ttopo_, detId));
 }
 
-bool MkFitGeometry::isPhase1() const {
-  return lnc_->isPhase1();
-}
+bool MkFitGeometry::isPhase1() const { return lnc_->isPhase1(); }
 
-bool MkFitGeometry::isPhase2() const {
-  return lnc_->isPhase2();
-}
+bool MkFitGeometry::isPhase2() const { return lnc_->isPhase2(); }

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -62,3 +62,11 @@ int MkFitGeometry::mkFitLayerNumber(DetId detId) const {
   return lnc_->convertLayerNumber(
       detId.subdetId(), ttopo_->layer(detId), false, ttopo_->isStereo(detId), isPlusSide(*ttopo_, detId));
 }
+
+bool MkFitGeometry::isPhase1() const {
+  return lnc_->isPhase1();
+}
+
+bool MkFitGeometry::isPhase2() const {
+  return lnc_->isPhase2();
+}

--- a/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
+++ b/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
@@ -21,6 +21,8 @@ namespace mkfit {
       return 10;
     }
     TkLayout getEra() const { return lo_; }
+    bool isPhase1() const { return lo_ == TkLayout::phase1; }
+    bool isPhase2() const { return lo_ == TkLayout::phase2; }
     int convertLayerNumber(int det, int lay, bool useMatched, int isStereo, bool posZ) const {
       if (lo_ == TkLayout::phase2) {
         if (det == 1)

--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -34,8 +34,8 @@ WriteMemFileDict.cc ${WMF_DICT_PCM} &: ${SACMS}/tkNtuple/DictsLinkDef.h
 	mv WriteMemFileDict_rdict.pcm ${WMF_DICT_PCM}
 
 SRCS += ShellDict.cc
-ShellDict.cc ${SHELL_DICT_PCM} &: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
-	rootcling -I=${SRCDIR} -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+ShellDict.cc ${SHELL_DICT_PCM} &: ${SACMS}/ShellDict.h ${SACMS}/ShellLinkDef.h
+	rootcling -I=${SRCDIR} -f ShellDict.cc $^
 	mv ShellDict_rdict.pcm ${SHELL_DICT_PCM}
 endif
 

--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -70,7 +70,7 @@ ${MAIN}: ${MAIN_DEPS} mkFit.o
 	${CXX} ${CXXFLAGS} ${VEC_HOST} ${LDFLAGS} mkFit.o -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
 
 ${WRMEMF}: ${MAIN_DEPS} WriteMemoryFile.o WriteMemFileDict.o
-	${CXX} ${CXXFLAGS} ${LDFLAGS} $^ -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
+	${CXX} ${CXXFLAGS} ${LDFLAGS} WriteMemoryFile.o WriteMemFileDict.o -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
 
 ${OBJS}: %.o: %.cc %.d
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${VEC_HOST} -c -o $@ $<

--- a/RecoTracker/MkFitCMS/standalone/Shell.h
+++ b/RecoTracker/MkFitCMS/standalone/Shell.h
@@ -40,8 +40,8 @@ namespace mkfit {
     EventOfHits *eoh() { return m_eoh; }
     MkBuilder *builder() { return m_builder; }
 
-    const TrackVec& seeds() const { return m_seeds; }
-    const TrackVec& tracks() const { return m_tracks; }
+    const TrackVec &seeds() const { return m_seeds; }
+    const TrackVec &tracks() const { return m_tracks; }
 
     // --------------------------------------------------------
     // Analysis helpers

--- a/RecoTracker/MkFitCMS/standalone/Shell.h
+++ b/RecoTracker/MkFitCMS/standalone/Shell.h
@@ -40,6 +40,9 @@ namespace mkfit {
     EventOfHits *eoh() { return m_eoh; }
     MkBuilder *builder() { return m_builder; }
 
+    const TrackVec& seeds() const { return m_seeds; }
+    const TrackVec& tracks() const { return m_tracks; }
+
     // --------------------------------------------------------
     // Analysis helpers
 

--- a/RecoTracker/MkFitCMS/standalone/ShellDict.h
+++ b/RecoTracker/MkFitCMS/standalone/ShellDict.h
@@ -1,0 +1,2 @@
+#include "RecoTracker/MkFitCMS/standalone/Shell.h"
+#include "RecoTracker/MkFitCore/standalone/Event.h"

--- a/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
+++ b/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
@@ -1,1 +1,4 @@
 #pragma link C++ class mkfit::Shell;
+#pragma link C++ class mkfit::Event;
+#pragma link C++ class mkfit::Hit;
+#pragma link C++ class mkfit::Track;

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -229,7 +229,6 @@ namespace mkfit {
     bool seeds_sorted = false;
     // CCCC builder.PrepareSeeds();
     ev.setCurrentSeedTracks(ev.seedTracks_);
-    ev.simLabelForCurrentSeed(0);
 
     builder.find_tracks_load_seeds(ev.seedTracks_, seeds_sorted);
 
@@ -477,7 +476,6 @@ namespace mkfit {
       if (seeds.size() <= 0)
         continue;
       ev.setCurrentSeedTracks(seeds);
-      ev.simLabelForCurrentSeed(0);
 
       builder.find_tracks_load_seeds(seeds, do_seed_clean);
 

--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -44,7 +44,7 @@ using namespace mkfit;
 namespace mkfit::internal {
   // Filled in geometry plugin.
   std::vector<DeadVec> deadvectors;
-}
+}  // namespace mkfit::internal
 
 void initGeom() {
   std::cout << "Constructing geometry '" << Config::geomPlugin << "'\n";

--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -41,11 +41,9 @@ using namespace mkfit;
 
 //==============================================================================
 
-std::vector<DeadVec> deadvectors;
-
-void init_deadvectors() {
-  deadvectors.resize(Config::TrkInfo.n_layers());
-#include "RecoTracker/MkFitCMS/standalone/deadmodules.h"
+namespace mkfit::internal {
+  // Filled in geometry plugin.
+  std::vector<DeadVec> deadvectors;
 }
 
 void initGeom() {
@@ -113,10 +111,6 @@ void initGeom() {
   }
 
   Config::ItrInfo.setupStandardFunctionsFromNames();
-
-  // We always initialize the dead modules. Actual loading into each event is
-  // controlled via Config::useDeadModules.
-  init_deadvectors();
 
   // Test functions for ConfigJsonPatcher
   // cj.test_Direct (Config::ItrInfo[0]);
@@ -321,7 +315,7 @@ void test_standard() {
             StdSeq::loadHitsAndBeamSpot(ev, eoh);
 
             if (Config::useDeadModules) {
-              StdSeq::loadDeads(eoh, deadvectors);
+              StdSeq::loadDeads(eoh, mkfit::internal::deadvectors);
             }
 
             double t_best[NT] = {0}, t_cur[NT] = {0};
@@ -1018,7 +1012,7 @@ int main(int argc, const char* argv[]) {
     tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, Config::numThreadsFinder);
 
     initGeom();
-    Shell s(deadvectors, g_input_file, g_start_event);
+    Shell s(mkfit::internal::deadvectors, g_input_file, g_start_event);
     s.Run();
   } else {
     test_standard();

--- a/RecoTracker/MkFitCore/interface/HitStructures.h
+++ b/RecoTracker/MkFitCore/interface/HitStructures.h
@@ -112,7 +112,7 @@ namespace mkfit {
     // Geometry / LayerInfo accessors
     //--------------------------------
 
-    const LayerInfo* layer_info() const { return m_layer_info; }
+    const LayerInfo& layer_info() const { return *m_layer_info; }
     int layer_id() const { return m_layer_info->layer_id(); }
 
     bool is_barrel() const { return m_is_barrel; }

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -1,0 +1,35 @@
+#ifndef RecoTracker_MkFitCore_interface_IdxChi2List_h
+#define RecoTracker_MkFitCore_interface_IdxChi2List_h
+
+namespace mkfit {
+
+  struct IdxChi2List {
+  public:
+    unsigned int module;  // module id
+    int hitIdx;           // hit index
+    int trkIdx;           // candidate index
+    int nhits;            // number of hits (used for sorting)
+    int ntailholes;       // number of holes at the end of the track (used for sorting)
+    int noverlaps;        // number of overlaps (used for sorting)
+    int nholes;           // number of holes (used for sorting)
+    float pt;             // pt (used for sorting)
+    float chi2;           // total chi2 (used for sorting)
+    float chi2_hit;       // chi2 of the added hit
+    float score;          // score used for candidate ranking
+
+    IdxChi2List() = default;
+    IdxChi2List& operator=(const IdxChi2List&) = default;
+
+    IdxChi2List(unsigned int) { reset(); }
+
+    void reset() {
+      module = 0u;
+      hitIdx = trkIdx = 0;
+      nhits = ntailholes = noverlaps = nholes = 0;
+      pt = chi2 = chi2_hit = score = 0;
+    }
+  };
+
+}
+
+#endif

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -30,6 +30,6 @@ namespace mkfit {
     }
   };
 
-}
+}  // namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -20,6 +20,7 @@ namespace mkfit {
     IdxChi2List() = default;
     IdxChi2List& operator=(const IdxChi2List&) = default;
 
+    // Constructor with initialization to 0 (used for export to TTrees)
     IdxChi2List(unsigned int) { reset(); }
 
     void reset() {

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -20,9 +20,7 @@ namespace mkfit {
     IdxChi2List() = default;
     IdxChi2List& operator=(const IdxChi2List&) = default;
 
-    // Constructor with initialization to 0 (used for export to TTrees)
-    IdxChi2List(unsigned int) { reset(); }
-
+    // Zero initialization
     void reset() {
       module = 0u;
       hitIdx = trkIdx = 0;

--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -5,6 +5,7 @@
 #include "RecoTracker/MkFitCore/interface/MatrixSTypes.h"
 #include "RecoTracker/MkFitCore/interface/FunctionTypes.h"
 #include "RecoTracker/MkFitCore/interface/Hit.h"
+#include "RecoTracker/MkFitCore/interface/IdxChi2List.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
 
 #include <vector>
@@ -29,21 +30,6 @@ namespace mkfit {
                              const float hit2_y) {
     return ((hit2_y - hit0_y) * (hit2_x - hit1_x) > (hit2_y - hit1_y) * (hit2_x - hit0_x) ? 1 : -1);
   }
-
-  struct IdxChi2List {
-  public:
-    int trkIdx;           // candidate index
-    int hitIdx;           // hit index
-    unsigned int module;  // module id
-    int nhits;            // number of hits (used for sorting)
-    int ntailholes;       // number of holes at the end of the track (used for sorting)
-    int noverlaps;        // number of overlaps (used for sorting)
-    int nholes;           // number of holes (used for sorting)
-    float pt;             // pt (used for sorting)
-    float chi2;           // total chi2 (used for sorting)
-    float chi2_hit;       // chi2 of the added hit
-    float score;          // score used for candidate ranking
-  };
 
   //==============================================================================
   // TrackState

--- a/RecoTracker/MkFitCore/interface/TrackerInfo.h
+++ b/RecoTracker/MkFitCore/interface/TrackerInfo.h
@@ -61,6 +61,7 @@ namespace mkfit {
     void set_subdet(int sd) { m_subdet = sd; }
     void set_is_pixel(bool p) { m_is_pixel = p; }
     void set_is_stereo(bool s) { m_is_stereo = s; }
+    void set_has_charge(bool c) { m_has_charge = c; }
 
     int layer_id() const { return m_layer_id; }
     LayerType_e layer_type() const { return m_layer_type; }
@@ -77,6 +78,7 @@ namespace mkfit {
     bool is_barrel() const { return m_layer_type == Barrel; }
     bool is_pixel() const { return m_is_pixel; }
     bool is_stereo() const { return m_is_stereo; }
+    bool has_charge() const { return m_has_charge; }
 
     bool is_within_z_limits(float z) const { return z > m_zmin && z < m_zmax; }
     bool is_within_r_limits(float r) const { return r > m_rin && r < m_rout; }
@@ -141,6 +143,7 @@ namespace mkfit {
     bool m_has_r_range_hole = false;
     bool m_is_stereo = false;
     bool m_is_pixel = false;
+    bool m_has_charge = true;
 
     std::unordered_map<unsigned int, unsigned int> m_detid2sid;
     std::vector<ModuleInfo> m_modules;

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -155,6 +155,11 @@ namespace {
     return mkfit::sortByScoreTrackCand(cand1, cand2);
   }
 
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+  constexpr bool alwaysUseHitSelectionV2 = true;
+#else
+  constexpr bool alwaysUseHitSelectionV2 = false;
+#endif
 }  // end unnamed namespace
 
 //------------------------------------------------------------------------------
@@ -855,7 +860,11 @@ namespace mkfit {
             dcall(post_prop_print(curr_layer, mkfndr.get()));
 
             dprint("now get hit range");
-            mkfndr->selectHitIndices(layer_of_hits, end - itrack);
+
+            if (alwaysUseHitSelectionV2 || iter_params.useHitSelectionV2)
+              mkfndr->selectHitIndicesV2(layer_of_hits, end - itrack);
+            else
+              mkfndr->selectHitIndices(layer_of_hits, end - itrack);
 
             find_tracks_handle_missed_layers(
                 mkfndr.get(), layer_info, tmp_cands, seed_cand_idx, region, start_seed, itrack, end);
@@ -1088,7 +1097,7 @@ namespace mkfit {
 
         dprint("now get hit range");
 
-        if (iter_params.useHitSelectionV2)
+        if (alwaysUseHitSelectionV2 || iter_params.useHitSelectionV2)
           mkfndr->selectHitIndicesV2(layer_of_hits, end - itrack);
         else
           mkfndr->selectHitIndices(layer_of_hits, end - itrack);

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -401,8 +401,8 @@ namespace mkfit {
 
         const float z = m_Par[iI].constAt(itrack, 2, 0);
         const float dz = std::abs(nSigmaZ * std::sqrt(m_Err[iI].constAt(itrack, 2, 2)));
-        const float edgeCorr = std::abs(0.5f * (L.layer_info().rout() - L.layer_info().rin()) /
-                                        std::tan(m_Par[iI].constAt(itrack, 5, 0)));
+        const float edgeCorr =
+            std::abs(0.5f * (L.layer_info().rout() - L.layer_info().rin()) / std::tan(m_Par[iI].constAt(itrack, 5, 0)));
         // XXX-NUM-ERR above, m_Err(2,2) gets negative!
 
         m_XWsrResult[itrack] = L.is_within_z_sensitive_region(z, std::sqrt(dz * dz + edgeCorr * edgeCorr));

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -989,9 +989,6 @@ namespace mkfit {
               continue;
             }
 
-            if (m_XHitSize[itrack] >= MPlexHitIdxMax)
-              break;
-
             float new_q, new_phi, new_ddphi, new_ddq;
             bool prop_fail;
 
@@ -1041,8 +1038,8 @@ namespace mkfit {
                   new_q, L.hit_q_half_length(hi), L.hit_qbar(hi), new_phi,
                   hit_lbl },
                 state2pos(mp_s), state2mom(mp_s),
-                new_ddq, new_ddphi, hchi2,
-                dqdphi_presel, (sim_lbl == hit_lbl), !prop_fail
+                new_ddq, new_ddphi, hchi2, (int) hi_orig,
+                (sim_lbl == hit_lbl), dqdphi_presel, !prop_fail
               });
 
               bool new_dec = dqdphi_presel && !prop_fail;
@@ -1055,7 +1052,7 @@ namespace mkfit {
               if (new_dec)
                 pos_match_vec.emplace_back(pos_match{ new_ddphi, new_ddq, hit_out_idx++,
                                              sim_lbl == hit_lbl });
-            } // if sim_lbl is set
+            } // if cand is saved
 #endif
             // clang-format on
 
@@ -1744,6 +1741,13 @@ namespace mkfit {
 
               dprint("  adding hit with hit_cnt=" << hit_cnt << " for trkIdx=" << tmpList.trkIdx
                                                   << " orig Seed=" << m_Label(itrack, 0, 0));
+
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+              if (rnt_shi.f_h_remap[itrack] >= 0) {
+                CandInfo &ci = (*rnt_shi.ci)[rnt_shi.f_h_remap[itrack]];
+                ci.assignIdxChi2List(tmpList);
+              }
+#endif
             }
           }
         }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -770,7 +770,8 @@ namespace mkfit {
       if (m_FailFlag[i]) {
         rnt_shi.RegisterFailedProp(i, m_Par[1 - iI], m_Par[iI], m_event, m_SeedOriginIdx[i]);
       } else if (sim_lbls[i].is_set()) {
-        rnt_shi.RegisterGoodProp(i, m_Par[iI], m_event, m_SeedOriginIdx[i]);
+        CandInfo &ci = rnt_shi.RegisterGoodProp(i, m_Par[iI], m_event, m_SeedOriginIdx[i]);
+        ci.ic2list.reset(); // zero initialize
       }  // else ... could do something about the bad seeds ... probably better to collect elsewhere.
     }
     // Get BinSearch result from V1. Note -- it can clear m_FailFlag for some cands!

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -870,9 +870,7 @@ namespace mkfit {
     currentSeedSimFromHits_.clear();
   }
 
-  const Track &Event::currentSeed(int i) const {
-    return (*currentSeedTracks_)[i];
-  }
+  const Track &Event::currentSeed(int i) const { return (*currentSeedTracks_)[i]; }
 
   Event::SimLabelFromHits Event::simLabelForCurrentSeed(int i) const {
     assert(currentSeedTracks_ != nullptr);

--- a/RecoTracker/MkFitCore/standalone/Makefile.config
+++ b/RecoTracker/MkFitCore/standalone/Makefile.config
@@ -92,10 +92,10 @@ LDFLAGS_HOST :=
 CPPFLAGS += ${INWARD_FIT}
 
 # Dump hit selection window tuples
-CPPFLAGS += -DDUMPHITWINDOW # -DDUMP_HIT_PRESEL
+# CPPFLAGS += -DDUMPHITWINDOW
 # The new dumpers
 ifdef WITH_ROOT
-  CPPFLAGS += -DRNT_DUMP_MkF_SelHitIdcs
+  # CPPFLAGS += -DRNT_DUMP_MkF_SelHitIdcs
 endif
 
 ifdef USE_VTUNE_NOTIFY
@@ -117,7 +117,9 @@ ifeq ($(CXX), g++)
   # -msse3 is enabled above, if so configured (i.e., not avx)
   # -Ofast is specified above in section 3.
   # -std is set to c++1z below (was c++17 here)
-  CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
+  # MT 2023-12-11: Had to remove -Werror=missing-braces ... triggered by RNTuple/REntry
+  # CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
+  CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
   CXXFLAGS += -fdiagnostics-color=auto -fdiagnostics-show-option -fopenmp-simd
   # Disable reciprocal math for Intel/AMD consistency, see cms-sw/cmsdist#8280
   CXXFLAGS += -fno-reciprocal-math -mrecip=none

--- a/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
@@ -28,6 +28,7 @@ namespace {
     return {statep2state(s, i), s.dalpha[i], s.fail_flag[i]};
   }
 
+  RVec hit2pos(const Hit &h) { return {h.x(), h.y(), h.z()}; }
   RVec track2pos(const TrackBase &s) { return {s.x(), s.y(), s.z()}; }
   RVec track2mom(const TrackBase &s) { return {s.px(), s.py(), s.pz()}; }
   State track2state(const TrackBase &s) { return {track2pos(s), track2mom(s)}; }

--- a/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
@@ -3,10 +3,7 @@
 
 #include "RecoTracker/MkFitCore/standalone/RntDumper/RntDumper.h"
 #include "RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h"
-
-#include "RecoTracker/MkFitCore/src/Matrix.h"
-#include "RecoTracker/MkFitCore/interface/Track.h"
-#include "RecoTracker/MkFitCore/src/MiniPropagators.h"
+#include "RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h"
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -14,43 +11,7 @@
 #include <TTree.h>
 
 namespace {
-  namespace miprops = mkfit::mini_propagators;
   using namespace mkfit;
-
-  RVec state2pos(const miprops::State &s) { return {s.x, s.y, s.z}; }
-  RVec state2mom(const miprops::State &s) { return {s.px, s.py, s.pz}; }
-  State state2state(const miprops::State &s) { return {state2pos(s), state2mom(s)}; }
-
-  RVec statep2pos(const miprops::StatePlex &s, int i) { return {s.x[i], s.y[i], s.z[i]}; }
-  RVec statep2mom(const miprops::StatePlex &s, int i) { return {s.px[i], s.py[i], s.pz[i]}; }
-  State statep2state(const miprops::StatePlex &s, int i) { return {statep2pos(s, i), statep2mom(s, i)}; }
-  PropState statep2propstate(const miprops::StatePlex &s, int i) {
-    return {statep2state(s, i), s.dalpha[i], s.fail_flag[i]};
-  }
-
-  RVec hit2pos(const Hit &h) { return {h.x(), h.y(), h.z()}; }
-  RVec track2pos(const TrackBase &s) { return {s.x(), s.y(), s.z()}; }
-  RVec track2mom(const TrackBase &s) { return {s.px(), s.py(), s.pz()}; }
-  State track2state(const TrackBase &s) { return {track2pos(s), track2mom(s)}; }
-
-  SimSeedInfo evsi2ssinfo(const Event *ev, int seed_idx) {
-    SimSeedInfo ssi;
-    Event::SimLabelFromHits slfh = ev->simLabelForCurrentSeed(seed_idx);
-    if (slfh.is_set()) {
-      ssi.s_sim = track2state(ev->simTracks_[slfh.label]);
-      ssi.sim_lbl = slfh.label;
-      ssi.n_hits = slfh.n_hits;
-      ssi.n_match = slfh.n_match;
-      ssi.has_sim = true;
-    }
-    auto seed = ev->currentSeed(seed_idx);
-    ssi.s_seed = track2state(seed);
-    ssi.seed_lbl = seed.label();
-    ssi.seed_idx = seed_idx;
-    return ssi;
-  }
-
-  // --- === ---
 
   struct RntIfc_selectHitIndices {
     using RNTupleWriter = ROOT::Experimental::RNTupleWriter;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
@@ -1,0 +1,47 @@
+#ifndef RecoTracker_MkFitCore_standalone_RntDumper_RntConversions_h
+#define RecoTracker_MkFitCore_standalone_RntDumper_RRntConversions_h
+
+#include "RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h"
+
+#include "RecoTracker/MkFitCore/interface/Track.h"
+#include "RecoTracker/MkFitCore/src/Matrix.h"
+#include "RecoTracker/MkFitCore/src/MiniPropagators.h"
+
+namespace mkfit {
+  namespace miprops = mkfit::mini_propagators;
+
+  RVec state2pos(const miprops::State &s) { return {s.x, s.y, s.z}; }
+  RVec state2mom(const miprops::State &s) { return {s.px, s.py, s.pz}; }
+  State state2state(const miprops::State &s) { return {state2pos(s), state2mom(s)}; }
+
+  RVec statep2pos(const miprops::StatePlex &s, int i) { return {s.x[i], s.y[i], s.z[i]}; }
+  RVec statep2mom(const miprops::StatePlex &s, int i) { return {s.px[i], s.py[i], s.pz[i]}; }
+  State statep2state(const miprops::StatePlex &s, int i) { return {statep2pos(s, i), statep2mom(s, i)}; }
+  PropState statep2propstate(const miprops::StatePlex &s, int i) {
+    return {statep2state(s, i), s.dalpha[i], s.fail_flag[i]};
+  }
+
+  RVec hit2pos(const Hit &h) { return {h.x(), h.y(), h.z()}; }
+  RVec track2pos(const TrackBase &s) { return {s.x(), s.y(), s.z()}; }
+  RVec track2mom(const TrackBase &s) { return {s.px(), s.py(), s.pz()}; }
+  State track2state(const TrackBase &s) { return {track2pos(s), track2mom(s)}; }
+
+  SimSeedInfo evsi2ssinfo(const Event *ev, int seed_idx) {
+    SimSeedInfo ssi;
+    Event::SimLabelFromHits slfh = ev->simLabelForCurrentSeed(seed_idx);
+    if (slfh.is_set()) {
+      ssi.s_sim = track2state(ev->simTracks_[slfh.label]);
+      ssi.sim_lbl = slfh.label;
+      ssi.n_hits = slfh.n_hits;
+      ssi.n_match = slfh.n_match;
+      ssi.has_sim = true;
+    }
+    auto seed = ev->currentSeed(seed_idx);
+    ssi.s_seed = track2state(seed);
+    ssi.seed_lbl = seed.label();
+    ssi.seed_idx = seed_idx;
+    return ssi;
+  }
+}
+
+#endif

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
@@ -42,6 +42,6 @@ namespace mkfit {
     ssi.seed_idx = seed_idx;
     return ssi;
   }
-}
+}  // namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -71,17 +71,47 @@ struct BinSearch {
   BinSearch& operator=(const BinSearch&) = default;
 };
 
+struct HitInfo {
+  RVec hit_pos;
+  float hit_q, hit_qhalflen, hit_qbar, hit_phi;
+  int hit_lbl;
+
+  HitInfo() = default;
+  HitInfo& operator=(const HitInfo&) = default;
+};
+
+struct HitMatchInfo : public HitInfo {
+  RVec trk_pos, trk_mom;
+  float ddq, ddphi;
+  float chi2_true;
+  bool accept;
+  bool match;
+  bool prop_ok;
+
+  HitMatchInfo() = default;
+  HitMatchInfo& operator=(const HitMatchInfo&) = default;
+};
+
 struct CandInfo {
   SimSeedInfo ssi;
   State s_ctr;
   PropState ps_min, ps_max;
   BinSearch bso;
   BinSearch bsn;
+  std::vector<HitMatchInfo> hmi;
+  int n_all_hits = 0, n_hits_pass = 0, n_hits_match = 0, n_hits_pass_match = 0;
+  int ord_first_match = -1;
+  float dphi_first_match = -9999.0f, dq_first_match = -9999.0f;
   bool has_nans = false;
 
   CandInfo(const SimSeedInfo& s, const State& c) : ssi(s), s_ctr(c) {}
 
   void nan_check();
+  void reset_hits_match() {
+    n_all_hits = n_hits_pass = n_hits_match = n_hits_pass_match = 0;
+    ord_first_match = -1;
+    dphi_first_match = dq_first_match = -9999.0f;
+  }
 
   CandInfo() = default;
   CandInfo& operator=(const CandInfo&) = default;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -118,7 +118,7 @@ struct CandInfo {
   }
 
   bool assignIdxChi2List(const mkfit::IdxChi2List& ic2l) {
-    for (auto & hm : hmi) {
+    for (auto& hm : hmi) {
       if (hm.hit_index == ic2l.hitIdx) {
         hm.has_ic2list = true;
         hm.ic2list = ic2l;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -1,8 +1,7 @@
 #ifndef RecoTracker_MkFitCore_standalone_RntDumper_RntStructs_h
 #define RecoTracker_MkFitCore_standalone_RntDumper_RntStructs_h
 
-// Avoid MkFit includes for now to simpligy pure ROOT builds.
-// #include "RecoTracker/MkFitCore/interface/
+#include "RecoTracker/MkFitCore/interface/IdxChi2List.h"
 
 #include "ROOT/REveVector.hxx"
 #include "Math/Point3D.h"
@@ -84,9 +83,14 @@ struct HitMatchInfo : public HitInfo {
   RVec trk_pos, trk_mom;
   float ddq, ddphi;
   float chi2_true;
-  bool accept;
+  int hit_index;
   bool match;
+  bool presel;
   bool prop_ok;
+  bool has_ic2list{false};
+  mkfit::IdxChi2List ic2list{0};
+
+  bool accept() const { return presel && prop_ok; }
 
   HitMatchInfo() = default;
   HitMatchInfo& operator=(const HitMatchInfo&) = default;
@@ -111,6 +115,17 @@ struct CandInfo {
     n_all_hits = n_hits_pass = n_hits_match = n_hits_pass_match = 0;
     ord_first_match = -1;
     dphi_first_match = dq_first_match = -9999.0f;
+  }
+
+  bool assignIdxChi2List(const mkfit::IdxChi2List& ic2l) {
+    for (auto & hm : hmi) {
+      if (hm.hit_index == ic2l.hitIdx) {
+        hm.has_ic2list = true;
+        hm.ic2list = ic2l;
+        return true;
+      }
+    }
+    return false;
   }
 
   CandInfo() = default;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -88,7 +88,7 @@ struct HitMatchInfo : public HitInfo {
   bool presel;
   bool prop_ok;
   bool has_ic2list{false};
-  mkfit::IdxChi2List ic2list{0};
+  mkfit::IdxChi2List ic2list{0u};
 
   bool accept() const { return presel && prop_ok; }
 

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -88,7 +88,7 @@ struct HitMatchInfo : public HitInfo {
   bool presel;
   bool prop_ok;
   bool has_ic2list{false};
-  mkfit::IdxChi2List ic2list{0u};
+  mkfit::IdxChi2List ic2list;
 
   bool accept() const { return presel && prop_ok; }
 

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
@@ -7,6 +7,11 @@
 #pragma link C++ class SimSeedInfo + ;
 #pragma link C++ class BinSearch + ;
 
+#pragma link C++ class HitInfo+;
+#pragma link C++ class HitMatchInfo+;
+#pragma link C++ class std::vector<HitInfo>+;
+#pragma link C++ class std::vector<HitMatchInfo>+;
+
 #pragma link C++ class CandInfo + ;
 #pragma link C++ class std::vector < CandInfo> + ;
 

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
@@ -1,5 +1,7 @@
 // #pragma link C++ class ROOT::Experimental::REveVector+;
 
+#pragma link C++ class mkfit::IdxChi2List + ;
+
 #pragma link C++ class HeaderLayer + ;
 
 #pragma link C++ class State + ;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
@@ -9,10 +9,10 @@
 #pragma link C++ class SimSeedInfo + ;
 #pragma link C++ class BinSearch + ;
 
-#pragma link C++ class HitInfo+;
-#pragma link C++ class HitMatchInfo+;
-#pragma link C++ class std::vector<HitInfo>+;
-#pragma link C++ class std::vector<HitMatchInfo>+;
+#pragma link C++ class HitInfo + ;
+#pragma link C++ class HitMatchInfo + ;
+#pragma link C++ class std::vector < HitInfo> + ;
+#pragma link C++ class std::vector < HitMatchInfo> + ;
 
 #pragma link C++ class CandInfo + ;
 #pragma link C++ class std::vector < CandInfo> + ;

--- a/RecoTracker/MkFitCore/standalone/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/RecoTracker/MkFitCore/standalone/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -53,6 +53,17 @@ case ${inputBin} in
         # that does not work with MIMI at this point.
         export MKFIT_MIMI=1
         ;;
+"Mu_phase2")
+        dir=/ceph/cms/store/user/legianni/generate-phase2/10mu
+        subdir=
+        file=ntuple_pt0p1to1_eta0p0to0p4.bin
+        nevents=100
+        extraargs="--geom CMS-phase2"
+        numiters=1
+        # Pass MIMI flag to ROOT plotting functions -- some will insert STD
+        # that does not work with MIMI at this point.
+        export MKFIT_MIMI=1
+        ;;
 *)
         echo "INPUT BIN IS UNKNOWN"
         exit 12

--- a/RecoTracker/MkFitCore/standalone/validation-desc.txt
+++ b/RecoTracker/MkFitCore/standalone/validation-desc.txt
@@ -21,7 +21,7 @@ ln -s ../RecoTracker/MkFitCore/standalone/plotting .
 ln -s ../RecoTracker/MkFitCore/standalone/web .
 
 rm -rf valtree_*.root log_*.txt
-val_scripts/validation-cmssw-benchmarks-multiiter.sh forPR --mtv-like-val TTbar_Phase2
+val_scripts/validation-cmssw-benchmarks-multiiter.sh forPR --mtv-like-val TTbar_phase2
 
 web/collectBenchmarks-multi.sh Phase2-0 forPR
 

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
@@ -4,7 +4,7 @@ then
   os_arch_comp="el9_amd64_gcc13"
 elif [[ `[ -f /etc/redhat-release ] && awk '{print $1}' /etc/redhat-release` == "AlmaLinux" ]]
 then
-  os_arch_comp="el8_amd64_gcc11"
+  os_arch_comp="el8_amd64_gcc12"
 else
   os_arch_comp="slc7_amd64_gcc11"
 fi

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-if [[ `[ -f /usr/bin/lsb_release ] && lsb_release -si` == \
-        "Fedora" ||
-      `[ -f /etc/redhat-release ] && awk '{print $1}' /etc/redhat-release` == \
-        "AlmaLinux" ]]
+if [[ `[ -f /usr/bin/lsb_release ] && lsb_release -si` == "Fedora" ]]
+then
+  os_arch_comp="el9_amd64_gcc13"
+elif [[ `[ -f /etc/redhat-release ] && awk '{print $1}' /etc/redhat-release` == "AlmaLinux" ]]
 then
   os_arch_comp="el8_amd64_gcc11"
 else
   os_arch_comp="slc7_amd64_gcc11"
 fi
-  source /cvmfs/cms.cern.ch/${os_arch_comp}/lcg/root/6.26.07-e76d33b57cbf5a1c12b870df2a6ebb79/etc/profile.d/init.sh
-  export TBB_GCC=/cvmfs/cms.cern.ch/${os_arch_comp}/external/tbb/v2021.8.0-791ebc4967ab49af60ca9ad2aa021259
+
+source /cvmfs/cms.cern.ch/${os_arch_comp}/lcg/root/6.28.07-573b0d3de9894ea2ab667c0d36cf4882/etc/profile.d/init.sh
+export TBB_GCC=/cvmfs/cms.cern.ch/${os_arch_comp}/external/tbb/v2021.9.0-295412b9bb1d6b3275d2ace3e62c1faa


### PR DESCRIPTION
### PR description:

This PR adds the ability to run mkFit on Phase-2 data / geometry. Only initialStep iteration is supported so far, with a dedicated workflow (`24834.702`).

* Add CMSSW Phase-2 hit and seed converters.

* Properly support binary readout for Phase-2 strips where cluster-charge cut can
not be applied.

* Improve standalone performance monitoring & debugging tools.

**It requires also a new JSON file in cmssw/data repository:**
https://github.com/trackreco/RecoTracker-MkFit/pull/3

### PR validation:
In TTbar events, with PU:
- Phase-2 (PU200, where mkFit is only used for initialStep track building): http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/MTV_TTbarPU200_mcRun4_withTiming/
- Phase-1 (2024; no change, as expected): http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/MTV_TTbarPU_Run3_2024/

NOTE: closed in favor of PR #146.
