### PR TITLE
Temporary fix for sl fallback + propagateHelixToPlaneMPlex call

### DIFF
--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1255,7 +1255,7 @@ namespace mkfit {
     if (propToHit) {
       MPlexLS propErr;
       MPlexLV propPar;
-      propagateHelixToPlaneMPlex(psErr, psPar, Chg, msPar, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
+      propagateHelixToPlaneMPlex(psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationPlaneLocal(KFO_Update_Params | KFO_Local_Cov,
                                 propErr,
@@ -1337,7 +1337,7 @@ namespace mkfit {
     propPar = psPar;
     if (propToHit) {
       MPlexLS propErr;
-      propagateHelixToPlaneMPlex(psErr, psPar, inChg, msPar, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
+      propagateHelixToPlaneMPlex(psErr, psPar, inChg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationPlaneLocal(KFO_Calculate_Chi2,
                                 propErr,

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -2,6 +2,7 @@
 #include "RecoTracker/MkFitCore/interface/PropagationConfig.h"
 #include "RecoTracker/MkFitCore/interface/Config.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
+#include "RecoTracker/MkFitCore/interface/cms_common_macros.h"
 
 #include "PropagationMPlex.h"
 
@@ -489,7 +490,7 @@ namespace {
                   << " std::isfinite(s[n])=" << std::isfinite(s[n]) << " std::isnormal(s[n])=" << std::isnormal(s[n])
                   << std::endl;
 #endif
-      if ((std::abs(sl[n]) > std::abs(s[n])) || std::isnormal(s[n]) == false)
+      if (0)  //(mkfit::isFinite(s[n])==false && mkfit::isFinite(sl[n])) // needs more checks because it looks worse
         s[n] = sl[n];
     }
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -432,7 +432,7 @@ namespace {
     //float s[nmax - nmin];
     //first iteration outside the loop
 #pragma omp simd
-    for (int n = 0; n < NN; ++n) {
+    for (int n = 0; n < N_proc; ++n) {
       s[n] = (std::abs(plNrm(n, 2, 0)) < 1.f ? getS(delta0[n],
                                                     delta1[n],
                                                     delta2[n],
@@ -463,7 +463,7 @@ namespace {
       // Note, sinT/cosT not updated
 
 #pragma omp simd
-      for (int n = 0; n < NN; ++n) {
+      for (int n = 0; n < N_proc; ++n) {
         s[n] += (std::abs(plNrm(n, 2, 0)) < 1.f
                      ? getS(delta0[n],
                             delta1[n],
@@ -483,14 +483,14 @@ namespace {
     }  //end Niter-1
 
     // use linear approximation if s did not converge (for very high pT tracks)
-    for (int n = 0; n < NN; ++n) {
+    for (int n = 0; n < N_proc; ++n) {
 #ifdef DEBUG
       if (debug)
         std::cout << "s[n]=" << s[n] << " sl[n]=" << sl[n] << " std::isnan(s[n])=" << std::isnan(s[n])
                   << " std::isfinite(s[n])=" << std::isfinite(s[n]) << " std::isnormal(s[n])=" << std::isnormal(s[n])
                   << std::endl;
 #endif
-      if (0)  //(mkfit::isFinite(s[n])==false && mkfit::isFinite(sl[n])) // needs more checks because it looks worse
+      if (mkfit::isFinite(s[n]) == false && mkfit::isFinite(sl[n]))  // replace with sl even if not fully correct
         s[n] = sl[n];
     }
 


### PR DESCRIPTION

This is just to fix the usage of the straight line fall back in prop to plane 

the minimal check to use the fallback is in the comment, however so far it gives me worse results on the central low pT muons
![image](https://github.com/user-attachments/assets/3de03e06-cb87-4732-824d-250aecd8800d)

vs no check at all

![image](https://github.com/user-attachments/assets/824533cb-1ebc-4084-9dcd-9490b1f3d6c1)
 
so so more investigation is needed

The other fixes the call of propagateHelixToPlaneMPlex to what is in the template and what I found in the debug code.
The differences in the physics are barely noticeable