### PR TITLE
Draft PR for prototype final fit

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -562,6 +562,12 @@ namespace mkfit {
 
         builder.export_tracks(ev.fitTracks_);
       }
+
+      ////main call to fit - this is where you can measure the time as for findTracksCloneEngine
+      //builder.fittracks();
+      ////export tracks as "fit" tracks instead of the ones coming from backward fit (should remove the export above)
+      //builder.export_tracks(ev.fitTracks_);
+
       ev.resetCurrentSeedTracks();
 
       builder.end_event();

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -116,6 +116,12 @@ namespace mkfit {
     void backwardFit();
     void fit_cands(MkFinder *mkfndr, int start_cand, int end_cand, int region);
 
+    //refit
+
+    void fittracks();
+    void fit_tracks(MkFinder *mkfndr, int nFoundTracks, std::vector<int> inds, int start_trk, int end_trk);
+    void check_tracks(std::vector<int> inds, int start_trk, int end_trk);
+
   private:
     void fit_one_seed_set(TrackVec &simtracks, int itrack, int end, MkFitter *mkfttr, const bool is_brl[]);
 

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1310,12 +1310,13 @@ namespace mkfit {
                                             const int N_proc,
                                             const PropagationFlags& propFlags,
                                             const bool propToHit,
-                                            const MPlexQI *noMatEffPtr) {
+                                            const MPlexQI* noMatEffPtr) {
     if (propToHit) {
       MPlexLS propErr;
       MPlexLV propPar;
 
-      propagateHelixToPlaneMPlex(psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags, noMatEffPtr);
+      propagateHelixToPlaneMPlex(
+          psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags, noMatEffPtr);
 
       kalmanOperationPlaneLocal(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
                                 propErr,

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1255,7 +1255,7 @@ namespace mkfit {
     if (propToHit) {
       MPlexLS propErr;
       MPlexLV propPar;
-      propagateHelixToPlaneMPlex(psErr, psPar, Chg, msPar, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
+      propagateHelixToPlaneMPlex(psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationPlaneLocal(KFO_Update_Params | KFO_Local_Cov,
                                 propErr,
@@ -1283,6 +1283,67 @@ namespace mkfit {
                                 outErr,
                                 outPar,
                                 dummy_chi2,
+                                N_proc);
+    }
+    for (int n = 0; n < NN; ++n) {
+      if (outPar.At(n, 3, 0) < 0) {
+        Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
+        outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
+      }
+    }
+  }
+
+  //------------------------------------------------------------------------------
+
+  void kalmanPropagateAndUpdateAndChi2Plane(const MPlexLS& psErr,
+                                            const MPlexLV& psPar,
+                                            MPlexQI& Chg,
+                                            const MPlexHS& msErr,
+                                            const MPlexHV& msPar,
+                                            const MPlexHV& plNrm,
+                                            const MPlexHV& plDir,
+                                            const MPlexHV& plPnt,
+                                            MPlexLS& outErr,
+                                            MPlexLV& outPar,
+                                            MPlexQI& outFailFlag,
+                                            MPlexQF& outChi2,
+                                            const int N_proc,
+                                            const PropagationFlags& propFlags,
+                                            const bool propToHit,
+                                            const MPlexQI *noMatEffPtr) {
+    if (propToHit) {
+      MPlexLS propErr;
+      MPlexLV propPar;
+
+      propagateHelixToPlaneMPlex(psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags, noMatEffPtr);
+
+      kalmanOperationPlaneLocal(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
+                                propErr,
+                                propPar,
+                                Chg,
+                                msErr,
+                                msPar,
+                                plNrm,
+                                plDir,
+                                plPnt,
+                                outErr,
+                                outPar,
+                                outChi2,
+                                N_proc);
+
+    } else {
+      kalmanOperationPlaneLocal(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
+                                psErr,
+                                psPar,
+                                Chg,
+                                msErr,
+                                msPar,
+                                plNrm,
+                                plDir,
+                                plPnt,
+                                outErr,
+                                outPar,
+                                outChi2,
                                 N_proc);
     }
     for (int n = 0; n < NN; ++n) {
@@ -1337,7 +1398,7 @@ namespace mkfit {
     propPar = psPar;
     if (propToHit) {
       MPlexLS propErr;
-      propagateHelixToPlaneMPlex(psErr, psPar, inChg, msPar, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
+      propagateHelixToPlaneMPlex(psErr, psPar, inChg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags);
 
       kalmanOperationPlaneLocal(KFO_Calculate_Chi2,
                                 propErr,

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -143,6 +143,23 @@ namespace mkfit {
                                      const PropagationFlags& propFlags,
                                      const bool propToHit);
 
+  void kalmanPropagateAndUpdateAndChi2Plane(const MPlexLS& psErr,
+                                            const MPlexLV& psPar,
+                                            MPlexQI& Chg,
+                                            const MPlexHS& msErr,
+                                            const MPlexHV& msPar,
+                                            const MPlexHV& plNrm,
+                                            const MPlexHV& plDir,
+                                            const MPlexHV& plPnt,
+                                            MPlexLS& outErr,
+                                            MPlexLV& outPar,
+                                            MPlexQI& outFailFlag,
+                                            MPlexQF& outChi2,
+                                            const int N_proc,
+                                            const PropagationFlags& propFlags,
+                                            const bool propToHit,
+                                            const MPlexQI *noMatEffPtr = nullptr);
+
   void kalmanComputeChi2Plane(const MPlexLS& psErr,
                               const MPlexLV& psPar,
                               const MPlexQI& inChg,

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -158,7 +158,7 @@ namespace mkfit {
                                             const int N_proc,
                                             const PropagationFlags& propFlags,
                                             const bool propToHit,
-                                            const MPlexQI *noMatEffPtr = nullptr);
+                                            const MPlexQI* noMatEffPtr = nullptr);
 
   void kalmanComputeChi2Plane(const MPlexLS& psErr,
                               const MPlexLV& psPar,

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -19,6 +19,7 @@
 #endif
 
 //#define DEBUG
+//#define DEBUG_FIT
 #include "Debug.h"
 //#define DEBUG_FINAL_FIT
 
@@ -1420,15 +1421,14 @@ namespace mkfit {
     for (int icand = start_trk; icand < end_trk; icand += NN) {
       const int end = std::min(icand + NN, end_trk);
 
-      bool chi_debug = false;
-
-      std::cout << end << " " << chi_debug << std::endl;
-
       // input candidate tracks
       mkfndr->fwdFitInputTracks(m_tracks, inds, icand, end);
 
+      //prepare indices
+      std::vector<std::vector<int>> indices_R2 = mkfndr->reFitIndices(m_job->m_event_of_hits, end - icand, nFoundHits);
+
       // fit the tracks from the input in fwd direction
-      mkfndr->fwdFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, chi_debug);
+      mkfndr->fwdFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, indices_R2);
 
       // fwdFitOutput
       mkfndr->reFitOutputTracks(m_tracks, inds, icand, end, nFoundHits);
@@ -1437,7 +1437,7 @@ namespace mkfit {
       mkfndr->bkReFitInputTracks(m_tracks, inds, icand, end);
 
       // fit the tracks from the input in bkw direction
-      mkfndr->bkReFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, chi_debug);
+      mkfndr->bkReFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, indices_R2);
 
       // fwdFitOutput
       mkfndr->reFitOutputTracks(m_tracks, inds, icand, end, nFoundHits, true);
@@ -1450,15 +1450,15 @@ namespace mkfit {
     for (int icand = start_trk; icand < end_trk; icand += NN) {
       const int end = std::min(icand + NN, end_trk);
 
-      std::cout << " this is the region "
-                << " strt " << start_trk << " end " << end_trk << " end " << end_trk - start_trk << " NN " << NN
+      std::cout << "BEGIN CHECKs" << std::endl;
+      std::cout << " strt " << start_trk << " end " << end_trk << " end " << end_trk - start_trk << " NN " << NN
                 << std::endl;
+
       for (int i = start_trk; i < end; ++i) {
         const Track &trk = m_tracks[inds[i]];
 
         std::cout << "trk pt " << trk.pT() << " trk eta " << trk.momEta() << " trk phi " << trk.momPhi() << std::endl;
         std::cout << "trk nTotalHits " << trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
-
         std::cout << "END CHECK" << std::endl;
       }
     }
@@ -1473,11 +1473,11 @@ namespace mkfit {
     std::map<int, std::vector<int>> mapFoundHits;
     for (auto &t : m_tracks) {
 #ifdef DEBUG_FIT
-      std::cout << "nhits " << N << " NNN " << t.nFoundHits() << std::endl;
+      std::cout << "______________ " << std::endl;
+      std::cout << "track N " << N << " nhits " << t.nFoundHits() << std::endl;
       std::cout << "trk pt " << t.pT() << " trk eta " << t.momEta() << std::endl;
       std::cout << "trk nTotalHits " << t.nTotalHits() << " trk nFoundHits " << t.nFoundHits() << std::endl;
       std::cout << "trk last l " << t.getLastFoundHitLyr() << " trk last idx " << t.getLastFoundHitIdx() << std::endl;
-      std::cout << "______________ " << std::endl;
       for (int i = 0; i < t.nTotalHits(); i++) {
         std::cout << "index " << t.getHitIdx(i) << " layer " << t.getHitLyr(i) << std::endl;
       }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -9,6 +9,7 @@
 #include "MiniPropagators.h"
 
 //#define DEBUG
+// #define DEBUG_FIT
 #include "Debug.h"
 
 #if defined(MKFIT_STANDALONE)
@@ -1981,6 +1982,66 @@ namespace mkfit {
     m_Err[iC].scale(100.0f);
   }
 
+
+  void MkFinder::fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end) {
+    // Uses HitOnTrack vector from Track directly + a local cursor array to current hit.
+#ifdef DEBUG_FIT_BKW
+    std::cout <<" -- fwdFitInputTracks " << std::endl;
+#endif
+    MatriplexTrackPacker mtp(&cands[inds[beg]]);
+
+    int itrack = 0;
+
+    for (int i = beg; i < end; ++i, ++itrack) {
+      const Track &trk = cands[inds[i]];
+      m_Chg(itrack, 0, 0) = trk.charge();
+      m_CurHit[itrack] = trk.nTotalHits() - 1; //I have to use in reverse... otherwise n hits unknown
+      m_HoTArr[itrack] = trk.getHitsOnTrackArray();
+#ifdef DEBUG_FIT
+      std::cout <<"trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      std::cout <<"trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+      mtp.addInput(trk);
+    }
+
+    m_Chi2.setVal(0);
+    mtp.pack(m_Err[iC], m_Par[iC]);
+    m_Err[iC].scale(100.0f);
+
+  }
+
+
+  void MkFinder::bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end) {
+    // Uses HitOnTrack vector from Track directly + a local cursor array to current hit.
+#ifdef DEBUG_FIT_BKW
+    std::cout <<" -- bkReFitInputTracks " << std::endl;
+#endif
+    MatriplexTrackPacker mtp(&cands[inds[beg]]);
+
+    int itrack = 0;
+
+    for (int i = beg; i < end; ++i, ++itrack) {
+      const Track &trk = cands[inds[i]];
+      m_Chg(itrack, 0, 0) = trk.charge();
+      m_CurHit[itrack] = trk.nTotalHits() - 1;
+      m_HoTArr[itrack] = trk.getHitsOnTrackArray();
+#ifdef DEBUG_FIT_BKW
+      std::cout <<"trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      std::cout <<"trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+      mtp.addInput(trk);
+    }
+
+    m_Chi2.setVal(0);
+
+    int index;
+    if (cands[inds[beg]].nFoundHits()%2==0)  index=iC;
+    else index = iP;
+
+    mtp.pack(m_Err[index], m_Par[index]);
+    m_Err[index].scale(100.0f);
+  }
+
   void MkFinder::bkFitInputTracks(EventOfCombCandidates &eocss, int beg, int end) {
     // Could as well use HotArrays from tracks directly + a local cursor array to last hit.
 
@@ -2030,6 +2091,33 @@ namespace mkfit {
       if (isFinite(trk.chi2())) {
         trk.setScore(getScoreCand(m_steering_params->m_track_scorer, trk));
       }
+    }
+  }
+
+  void MkFinder::reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw) {
+    // Only copy out track params / errors / chi2
+    if(bkw) nFoundHits=nFoundHits*2;
+    int iO;
+    if (nFoundHits%2==0) iO = iC;
+    else iO = iP;
+
+    int itrack = 0;
+    for (int i = beg; i < end; ++i, ++itrack) {
+      Track &trk = cands[inds[i]];
+      m_Err[iO].copyOut(itrack, trk.errors_nc().Array());
+      m_Par[iO].copyOut(itrack, trk.parameters_nc().Array());
+
+#ifdef DEBUG_FIT_BKW
+      if (bkw) std::cout <<"oout trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      if (bkw) std::cout <<"oout trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+
+#ifdef DEBUG_FIT
+      if (!bkw) std::cout <<"oout trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      if (!bkw) std::cout <<"oout trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+
+      trk.setChi2(m_Chi2(itrack, 0, 0));
     }
   }
 
@@ -2440,6 +2528,425 @@ namespace mkfit {
       m_Chi2.add(tmp_chi2);
     }
   }
+
+  //------------------------------------------------------------------------------
+
+  std::vector<std::vector<int>> MkFinder::reFitIndices(const EventOfHits &eventofhits,
+                                                       const int N_proc,
+                                                       int nFoundHits) {
+    std::vector<std::vector<int>> indices_R2Z;
+
+    for (int i = 0; i < N_proc; ++i) {
+      std::vector<std::pair<float, float>> r2z;
+      std::vector<int> indices;
+
+      int local_m = m_CurHit[i];
+      while (local_m >= 0) {
+#ifdef DEBUG_FITi
+        std::cout << " i layer " << m_HoTArr[i][local_m].layer << " i index " << m_HoTArr[i][local_m].index
+                  << std::endl;
+#endif
+        if (m_HoTArr[i][local_m].index >= 0) {
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][local_m].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][local_m].index);
+
+          float x, y, z;
+          x = hit.posArray()[0];
+          y = hit.posArray()[1];
+          z = hit.posArray()[2];
+          float R2 = x * x + y * y;  // + z * z;
+#ifdef DEBUG_FIT
+          std::cout << "x " << x << " y " << y << " z " << z << std::endl;
+          std::cout << L.is_barrel() << " layer of hits is barrel ... " << m_HoTArr[i][local_m].layer << std::endl;
+          std::cout << R2 << " R2 -- z " << z << " index " << local_m << " i/Nproc " << i << " / " << N_proc
+                    << std::endl;
+#endif
+          int sign = L.is_barrel() > 0 ? 1 : -1;
+          r2z.push_back(std::make_pair(sign * R2, z));
+          indices.push_back(local_m);
+        }
+        local_m--;
+      }
+      //continue working with the track
+      std::vector<int> sorted_indices;
+      float z0 = r2z.back().second;
+      bool barrel_prev = false;
+      std::map<float, int> index_RorZ;
+
+      for (int i = 0; i < (int)indices.size(); i++) {
+        bool barrel = r2z[i].first > 0;
+        float sorting;
+#ifdef DEBUG_FIT
+        std::cout << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z0 << std::endl;
+#endif
+        if (barrel)
+          sorting = -std::fabs(r2z[i].first);
+        else
+          sorting = -std::fabs(r2z[i].second - z0);
+
+        if (i == 0) {
+          index_RorZ[sorting] = indices[i];
+        } else {
+          if (barrel == barrel_prev)  //add to segment in barrel or endcap
+            index_RorZ[sorting] = indices[i];
+          else  //switch barrel to endcap
+          {
+            for (auto iRZ : index_RorZ)
+              sorted_indices.push_back(iRZ.second);                  //push back indices sorted for segment
+            index_RorZ.erase(index_RorZ.begin(), index_RorZ.end());  //empty the map
+            index_RorZ[sorting] = indices[i];                        //start new segment
+          }
+        }
+        barrel_prev = barrel;
+      }
+      for (auto iRZ : index_RorZ)  //final segment
+        sorted_indices.push_back(iRZ.second);
+#ifdef DEBUG_FIT
+      for (auto ii : indices) {
+        std::cout << " indices ii " << ii << std::endl;
+      }
+      for (auto ii : sorted_indices) {
+        std::cout << " indices ssii " << ii << std::endl;
+      }
+#endif
+      indices_R2Z.push_back(sorted_indices);  //sorted_indices
+    }
+    return indices_R2Z;
+  }
+
+  void MkFinder::fwdFitFitTracks(const EventOfHits &eventofhits,
+                                 const int N_proc,
+                                 int nFoundHits,
+                                 std::vector<std::vector<int>> indices_R2Z) {
+    MPlexQF outChi2(0.0f);
+    MPlexLV propPar;
+
+    MPlexHV norm, dir, pnt;
+
+    MPlexQI no_mat_effs;
+
+    no_mat_effs.setVal(0);
+#ifdef DEBUG_FIT
+    const int DSLOT = 0;
+    printf("fit entry, track in slot %d\n", DSLOT);
+    print_par_err(iC, DSLOT);
+    print_par_err(iC, 1);
+    printf("\ninitial fit , track in slot %d --- (%g, %g, %g)\n",
+           DSLOT,
+           m_msPar(DSLOT, 0, 0),
+           m_msPar(DSLOT, 1, 0),
+           m_msPar(DSLOT, 2, 0));
+    printf(
+        "\ninitial fit , track in slot %d --- (%g, %g, %g)\n", 1, m_msPar(1, 0, 0), m_msPar(1, 1, 0), m_msPar(1, 2, 0));
+    printf(
+        "\ninitial fit , track in slot %d --- (%g, %g, %g)\n", 2, m_msPar(2, 0, 0), m_msPar(2, 1, 0), m_msPar(2, 2, 0));
+#endif
+
+    int i1 = iC;  //local copy
+    int i2 = iP;  //local copy
+
+    int hitIndex[N_proc] = {0};
+
+    for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+    {
+      hitIndex[i] = indices_R2Z[i].size();
+    }
+
+    for (int h = 0; h < nFoundHits; ++h)  //first loop over the group - need to use the mplex here
+    {
+#ifdef DEBUG_FIT
+      std::cout << "MY HIT " << h << " nFoundHits " << nFoundHits << std::endl;
+#endif
+      no_mat_effs.setVal(0);
+
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        auto &indices = indices_R2Z[i];
+        int index = indices[hitIndex[i] - 1];
+#ifdef DEBUG_FIT
+        std::cout << "DEBUG hitIndex " << hitIndex[i] << std::endl;
+        std::cout << "DEBUG i " << index << std::endl;
+        std::cout << "DEBUG i layer " << m_HoTArr[i][index].layer << std::endl;
+        std::cout << "DEBUG i index " << m_HoTArr[i][index].index << std::endl;
+#endif
+        if (m_HoTArr[i][index].index >= 0) {  //should be a redundant check
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][index].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][index].index);
+#ifdef DEBUG_FIT
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          m_msErr.copyIn(i, hit.errArray());
+          m_msPar.copyIn(i, hit.posArray());
+#ifdef DEBUG_FIT
+          std::cout << "hit.posArray()[0] " << hit.posArray()[0] << " hit.posArray()[1] " << hit.posArray()[1]
+                    << " hit.posArray()[2] " << hit.posArray()[2] << std::endl;
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          unsigned int mid = hit.detIDinLayer();
+          const ModuleInfo &mi = L.layer_info().module_info(mid);
+          norm.At(i, 0, 0) = mi.zdir[0];
+          norm.At(i, 1, 0) = mi.zdir[1];
+          norm.At(i, 2, 0) = mi.zdir[2];
+          dir.At(i, 0, 0) = mi.xdir[0];
+          dir.At(i, 1, 0) = mi.xdir[1];
+          dir.At(i, 2, 0) = mi.xdir[2];
+          pnt.At(i, 0, 0) = mi.pos[0];
+          pnt.At(i, 1, 0) = mi.pos[1];
+          pnt.At(i, 2, 0) = mi.pos[2];
+#ifdef DEBUG_FIT
+          std::cout << "mi.pos[0] " << mi.pos[0] << " mi.pos[1] " << mi.pos[1] << " mi.pos[2] " << mi.pos[2]
+                    << std::endl;
+          std::cout << "pnt[0] " << pnt(i, 0, 0) << " pnt[1] " << pnt(i, 1, 0) << " pnt[2] " << pnt(i, 2, 0)
+                    << std::endl;
+          std::cout << "at the track " << i << " / " << N_proc << " check the material " << std::endl;
+#endif
+          if (hitIndex[i] < (int)indices.size() &&
+              m_HoTArr[i][index].layer == m_HoTArr[i][indices[hitIndex[i]]].layer) {
+            no_mat_effs[i] = 1;
+#ifdef DEBUG_FIT
+            std::cout << "at the hit " << index << " Remove the material because it was applied in hit "
+                      << indices[hitIndex[i]] << std::endl;
+            std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                      << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+#endif
+          }
+#ifdef DEBUG_FIT
+          else {
+            std::cout << "at the hit " << index << " Don't remove the material" << std::endl;
+            if (hitIndex[i] < (int)indices.size())
+              std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                        << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+          }
+#endif
+        }
+        hitIndex[i]--;
+      }  //end of track by track loop
+
+#ifdef DEBUG_FIT
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right before propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "tmp_chi2[i]" << outChi2[i] << std::endl;
+        std::cout << norm.At(i, 0, 0) << " " << norm.At(i, 1, 0) << " " << norm.At(i, 2, 0) << " "
+                  << "NORM" << std::endl;
+        std::cout << dir.At(i, 0, 0) << " " << dir.At(i, 1, 0) << " " << dir.At(i, 2, 0) << " "
+                  << "DIR" << std::endl;
+        std::cout << pnt.At(i, 0, 0) << " " << pnt.At(i, 1, 0) << " " << pnt.At(i, 2, 0) << " "
+                  << "PNT" << std::endl;
+        std::cout << "index / Nproc " << i << " material flag " << no_mat_effs[i] << std::endl;
+      }
+#endif
+
+      kalmanPropagateAndUpdateAndChi2Plane(m_Err[i1],
+                                           m_Par[i1],
+                                           m_Chg,
+                                           m_msErr,
+                                           m_msPar,
+                                           norm,
+                                           dir,
+                                           pnt,
+                                           m_Err[i2],
+                                           m_Par[i2],
+                                           m_FailFlag,
+                                           outChi2,
+                                           N_proc,
+                                           *refit_flags,
+                                           true,
+                                           &no_mat_effs);
+
+#ifdef DEBUG_FIT
+      std::cout << " i1 " << i1 << " iP " << iP << " iC " << iC << std::endl;
+      std::cout << "++++++++++++++++++++++++++\n" << std::endl;
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right after propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "tmp_chi2[i]" << outChi2[i] << std::endl;
+      }
+#endif
+      std::swap(i1, i2);
+
+      // update chi2
+      m_Chi2.add(outChi2);
+    }  //end of loop over n hits
+  }  //end of fit func
+
+  void MkFinder::bkReFitFitTracks(const EventOfHits &eventofhits,
+                                  const int N_proc,
+                                  int nFoundHits,
+                                  std::vector<std::vector<int>> indices_R2Z) {
+#ifdef DEBUG_FIT_BKW
+    std::cout << "bkReFitFitTracks " << nFoundHits << std::endl;
+#endif
+    MPlexQF outChi2;
+    MPlexLV propPar;
+
+    MPlexHV norm, dir, pnt;
+
+    MPlexQI no_mat_effs;
+
+    int i1, i2;
+    if (nFoundHits % 2 == 0) {
+      i1 = iC;
+      i2 = iP;
+    } else {
+      i1 = iP;
+      i2 = iC;
+    }
+
+    int hitIndex[N_proc] = {0};
+
+    for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+    {
+      hitIndex[i] = indices_R2Z[i].size();
+    }
+
+    for (int h = 0; h < nFoundHits; ++h)  //first loop over the group - need to use the mplex here
+    {
+#ifdef DEBUG_FIT_BKW
+      std::cout << "MY HIT " << h << " nFoundHits " << nFoundHits << std::endl;
+#endif
+      no_mat_effs.setVal(0);
+
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        auto indices = indices_R2Z[i];
+        std::reverse(indices.begin(), indices.end());
+        int index = indices[hitIndex[i] - 1];
+#ifdef DEBUG_FIT_BKW
+        std::cout << "DEBUG hitIndex " << hitIndex[i] << std::endl;
+        std::cout << "DEBUG i " << index << std::endl;
+        std::cout << "DEBUG i layer " << m_HoTArr[i][index].layer << std::endl;
+        std::cout << "DEBUG i index " << m_HoTArr[i][index].index << std::endl;
+#endif
+        if (m_HoTArr[i][index].index >= 0) {  //should be a redundant check
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][index].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][index].index);
+#ifdef DEBUG_FIT_BKW
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          m_msErr.copyIn(i, hit.errArray());
+          m_msPar.copyIn(i, hit.posArray());
+#ifdef DEBUG_FIT_BKW
+          std::cout << "hit.posArray()[0] " << hit.posArray()[0] << " hit.posArray()[1] " << hit.posArray()[1]
+                    << " hit.posArray()[2] " << hit.posArray()[2] << std::endl;
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          unsigned int mid = hit.detIDinLayer();
+          const ModuleInfo &mi = L.layer_info().module_info(mid);
+          norm.At(i, 0, 0) = mi.zdir[0];
+          norm.At(i, 1, 0) = mi.zdir[1];
+          norm.At(i, 2, 0) = mi.zdir[2];
+          dir.At(i, 0, 0) = mi.xdir[0];
+          dir.At(i, 1, 0) = mi.xdir[1];
+          dir.At(i, 2, 0) = mi.xdir[2];
+          pnt.At(i, 0, 0) = mi.pos[0];
+          pnt.At(i, 1, 0) = mi.pos[1];
+          pnt.At(i, 2, 0) = mi.pos[2];
+#ifdef DEBUG_FIT_BKW
+          std::cout << "mi.pos[0] " << mi.pos[0] << " mi.pos[1] " << mi.pos[1] << " mi.pos[2] " << mi.pos[2]
+                    << std::endl;
+          std::cout << "pnt[0] " << pnt(i, 0, 0) << " pnt[1] " << pnt(i, 1, 0) << " pnt[2] " << pnt(i, 2, 0)
+                    << std::endl;
+          std::cout << "at the track " << i << " / " << N_proc << " check the material " << std::endl;
+#endif
+          if (hitIndex[i] < (int)indices.size() &&
+              m_HoTArr[i][index].layer == m_HoTArr[i][indices[hitIndex[i]]].layer) {
+            no_mat_effs[i] = 1;
+#ifdef DEBUG_FIT_BKW
+            std::cout << "at the hit " << index << " Remove the material because it was applied in hit "
+                      << indices[hitIndex[i]] << std::endl;
+            std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                      << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+#endif
+          }
+#ifdef DEBUG_FIT_BKW
+          else {
+            std::cout << "at the hit " << index << " Don't remove the material" << std::endl;
+            if (hitIndex[i] < (int)indices.size())
+              std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                        << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+          }
+#endif
+        }
+        hitIndex[i]--;
+      }  //end of track by track loop
+
+#ifdef DEBUG_FIT_BKW
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right before propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "outChi2 " << outChi2[i] << std::endl;
+        std::cout << norm.At(i, 0, 0) << " " << norm.At(i, 1, 0) << " " << norm.At(i, 2, 0) << " "
+                  << "NORM" << std::endl;
+        std::cout << dir.At(i, 0, 0) << " " << dir.At(i, 1, 0) << " " << dir.At(i, 2, 0) << " "
+                  << "DIR" << std::endl;
+        std::cout << pnt.At(i, 0, 0) << " " << pnt.At(i, 1, 0) << " " << pnt.At(i, 2, 0) << " "
+                  << "PNT" << std::endl;
+      }
+#endif
+
+      kalmanPropagateAndUpdateAndChi2Plane(m_Err[i1],
+                                           m_Par[i1],
+                                           m_Chg,
+                                           m_msErr,
+                                           m_msPar,
+                                           norm,
+                                           dir,
+                                           pnt,
+                                           m_Err[i2],
+                                           m_Par[i2],
+                                           m_FailFlag,
+                                           outChi2,
+                                           N_proc,
+                                           *refit_flags,
+                                           true,
+                                           &no_mat_effs);
+
+#ifdef DEBUG_FIT_BKW
+      std::cout << " i1 " << i1 << " iP " << iP << " iC " << iC << std::endl;
+
+      std::cout << "++++++++++++++++++++++++++\n" << std::endl;
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right after propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "outChi2 " << outChi2[i] << std::endl;
+      }
+#endif
+      std::swap(i1, i2);
+
+      // update chi2
+      m_Chi2.add(outChi2);
+
+    }  //end of loop over n hits
+  }  //end of fit func
 
   //------------------------------------------------------------------------------
 

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -175,6 +175,21 @@ namespace mkfit {
 
     //----------------------------------------------------------------------------
 
+    void fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
+    void fwdFitFitTracks(const EventOfHits &eventofhits,
+                         const int N_proc,
+                         int nFoundHits,
+                         std::vector<std::vector<int>> indices_R2Z);
+    void bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
+    void bkReFitFitTracks(const EventOfHits &eventofhits,
+                          const int N_proc,
+                          int nFoundHits,
+                          std::vector<std::vector<int>> indices_R2Z);
+    void reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw = false);
+    std::vector<std::vector<int>> reFitIndices(const EventOfHits &eventofhits, const int N_proc, int nFoundHits);
+
+    //----------------------------------------------------------------------------
+
   private:
     void copy_in(const Track &trk, const int mslot, const int tslot) {
       m_Err[tslot].copyIn(mslot, trk.errors().Array());
@@ -341,6 +356,7 @@ namespace mkfit {
     const SteeringParams *m_steering_params = nullptr;
     const std::vector<bool> *m_iteration_hit_mask = nullptr;
     const Event *m_event = nullptr;
+    const PropagationFlags *refit_flags = nullptr;
     int m_current_region = -1;
     bool m_in_fwd = true;
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -2,6 +2,7 @@
 #include "RecoTracker/MkFitCore/interface/PropagationConfig.h"
 #include "RecoTracker/MkFitCore/interface/Config.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
+#include "RecoTracker/MkFitCore/interface/cms_common_macros.h"
 
 #include "PropagationMPlex.h"
 
@@ -489,8 +490,10 @@ namespace {
                   << " std::isfinite(s[n])=" << std::isfinite(s[n]) << " std::isnormal(s[n])=" << std::isnormal(s[n])
                   << std::endl;
 #endif
-      if ((std::abs(sl[n]) > std::abs(s[n])) || std::isnormal(s[n]) == false)
+      if (0)  //(mkfit::isFinite(s[n])==false && mkfit::isFinite(sl[n])) // need to check if good
+      {
         s[n] = sl[n];
+      }
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
#### PR description:

The main changes are inside MkFinder.cc where the following functions are implemented

```
void fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);

void fwdFitFitTracks(const EventOfHits &eventofhits, const int N_proc, int nFoundHits, std::vector<std::vector<int>> indices_R2Z);`

void bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);

void bkReFitFitTracks(const EventOfHits &eventofhits, const int N_proc, int nFoundHits, std::vector<std::vector<int>> indices_R2Z);

void reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw = false);

std::vector<std::vector<int>> reFitIndices(const EventOfHits &eventofhits, const int N_proc, int nFoundHits);
```
A new function is added to KalmanUtilsMPlex

The function are wrapped inside MkBuilder and the call is made in RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc (commented out for now)


