### PR TITLE
silence clang vectorization warnings

### DIFF
--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -660,7 +660,7 @@ namespace mkfit {
               continue;
             }
             // Check if the candidate is close to it's max_r, pi/2 - 0.2 rad (11.5 deg)
-            if (iteration_dir == SteeringParams::IT_FwdSearch && ccand[ic].pT() < 1.2) {
+            if (iteration_dir == SteeringParams::IT_FwdSearch && ccand[ic].pT() < 1.2f) {
               const float dphi = std::abs(ccand[ic].posPhi() - ccand[ic].momPhi());
               if (ccand[ic].posRsq() > 625.f && dphi > 1.371f && dphi < 4.512f) {
                 // printf("Stopping cand at r=%f, posPhi=%.1f momPhi=%.2f pt=%.2f emomEta=%.2f\n",

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -1001,20 +1001,22 @@ namespace mkfit {
 
       const TrackerInfo& tinfo = *pflags.tracker_info;
 
+#if !defined(__clang__)
 #pragma omp simd
+#endif
       for (int n = 0; n < NN; ++n) {
         if (n < N_proc) {
           if (outFailFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
             hitsRl(n, 0, 0) = 0.f;
             hitsXi(n, 0, 0) = 0.f;
           } else {
-            auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), msRad(n, 0, 0));
+            const auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), msRad(n, 0, 0));
             hitsRl(n, 0, 0) = mat.radl;
             hitsXi(n, 0, 0) = mat.bbxi;
           }
           const float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
           const float r = msRad(n, 0, 0);
-          propSign(n, 0, 0) = (r > r0 ? 1. : -1.);
+          propSign(n, 0, 0) = (r > r0 ? 1.f : -1.f);
         }
       }
       MPlexHV plNrm;

--- a/RecoTracker/MkFitCore/src/PropagationMPlexEndcap.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexEndcap.cc
@@ -129,14 +129,16 @@ namespace mkfit {
 
       const TrackerInfo& tinfo = *pflags.tracker_info;
 
+#if !defined(__clang__)
 #pragma omp simd
+#endif
       for (int n = 0; n < NN; ++n) {
         if (n >= N_proc || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
           hitsRl(n, 0, 0) = 0.f;
           hitsXi(n, 0, 0) = 0.f;
         } else {
-          const float hypo = std::hypot(outPar(n, 0, 0), outPar(n, 1, 0));
-          auto mat = tinfo.material_checked(std::abs(msZ(n, 0, 0)), hypo);
+          const auto hypo = std::hypot(outPar(n, 0, 0), outPar(n, 1, 0));
+          const auto mat = tinfo.material_checked(std::abs(msZ(n, 0, 0)), hypo);
           hitsRl(n, 0, 0) = mat.radl;
           hitsXi(n, 0, 0) = mat.bbxi;
         }

--- a/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlexPlane.cc
@@ -651,14 +651,16 @@ namespace mkfit {
 
       const TrackerInfo& tinfo = *pflags.tracker_info;
 
+#if !defined(__clang__)
 #pragma omp simd
+#endif
       for (int n = 0; n < NN; ++n) {
         if (n >= N_proc || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
           hitsRl(n, 0, 0) = 0.f;
           hitsXi(n, 0, 0) = 0.f;
         } else {
           const float hypo = std::hypot(outPar(n, 0, 0), outPar(n, 1, 0));
-          auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), hypo);
+          const auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), hypo);
           hitsRl(n, 0, 0) = mat.radl;
           hitsXi(n, 0, 0) = mat.bbxi;
         }


### PR DESCRIPTION
#### PR description:

Silences a few new LLVM vectorization warnings, plus some other trivia.  Resolves https://github.com/cms-sw/cmssw/issues/46932.

#### PR validation:

Compiles, purely technical.
