### PR TITLE
disable -Ofast for IterationConfig.cc for json.hpp

### DIFF
--- a/RecoTracker/MkFitCore/BuildFile.xml
+++ b/RecoTracker/MkFitCore/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="ofast-flag"/>
 <flags CXXFLAGS="-fopenmp-simd"/>
 <flags ADD_SUBDIR="1"/>
+<flags REM_CXXFLAGS="-Ofast" FILE="IterationConfig.cc"/>
 <export>
   <lib name="RecoTrackerMkFitCore"/>
 </export>


### PR DESCRIPTION
#### PR description:

nlohmann/json.hpp uses IEEE infinity and NaN which are not handled by `-Ofast`.  This PR disables `-Ofast` for IterationConfig.cc, the only module that includes the full json.hpp header.  Clients of the IterationConfig should not depend on the handling of infinities etc. by the JSON parser, so this should be safe.

#### PR validation:

Compiles, purely technical, will be submitted as a CMSSW PR if no objections.