### PR TITLE
CA extension to strips (14_2_X)

### DIFF
--- a/Configuration/ProcessModifiers/python/stripNtupletFit_cff.py
+++ b/Configuration/ProcessModifiers/python/stripNtupletFit_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier can be used in combination with pixelNtupletFit to include strip hits in the tracks
+
+stripNtupletFit =  cms.Modifier()

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoA.cc
@@ -27,7 +27,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 template <typename T>
 class SiPixelCompareRecHitsSoA : public DQMEDAnalyzer {
 public:
@@ -246,9 +246,12 @@ void SiPixelCompareRecHitsSoA<T>::fillDescriptions(edm::ConfigurationDescription
 }
 
 using SiPixelPhase1CompareRecHitsSoA = SiPixelCompareRecHitsSoA<pixelTopology::Phase1>;
+using SiPixelPhase1StripCompareRecHitsSoA = SiPixelCompareRecHitsSoA<pixelTopology::Phase1Strip>;
 using SiPixelPhase2CompareRecHitsSoA = SiPixelCompareRecHitsSoA<pixelTopology::Phase2>;
 using SiPixelHIonPhase1CompareRecHitsSoA = SiPixelCompareRecHitsSoA<pixelTopology::HIonPhase1>;
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1CompareRecHitsSoA);
+DEFINE_FWK_MODULE(SiPixelPhase1StripCompareRecHitsSoA);
 DEFINE_FWK_MODULE(SiPixelPhase2CompareRecHitsSoA);
 DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareRecHitsSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTrackSoA.cc
@@ -22,6 +22,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousHost.h"
 #include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousDevice.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 // for string manipulations
 #include <fmt/printf.h>
 
@@ -362,7 +363,9 @@ void SiPixelCompareTrackSoA<T>::fillDescriptions(edm::ConfigurationDescriptions&
 using SiPixelPhase1CompareTrackSoA = SiPixelCompareTrackSoA<pixelTopology::Phase1>;
 using SiPixelPhase2CompareTrackSoA = SiPixelCompareTrackSoA<pixelTopology::Phase2>;
 using SiPixelHIonPhase1CompareTrackSoA = SiPixelCompareTrackSoA<pixelTopology::HIonPhase1>;
+using SiPixelPhase1StripCompareTrackSoA = SiPixelCompareTrackSoA<pixelTopology::Phase1Strip>;
 
 DEFINE_FWK_MODULE(SiPixelPhase1CompareTrackSoA);
+DEFINE_FWK_MODULE(SiPixelPhase1StripCompareTrackSoA);
 DEFINE_FWK_MODULE(SiPixelPhase2CompareTrackSoA);
 DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareTrackSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoAAlpaka.cc
@@ -189,10 +189,12 @@ void SiPixelMonitorRecHitsSoAAlpaka<T>::fillDescriptions(edm::ConfigurationDescr
 }
 
 using SiPixelPhase1MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::Phase1>;
+using SiPixelPhase1StripMonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::Phase1Strip>;
 using SiPixelPhase2MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::Phase2>;
 using SiPixelHIonPhase1MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::HIonPhase1>;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1MonitorRecHitsSoAAlpaka);
+DEFINE_FWK_MODULE(SiPixelPhase1StripMonitorRecHitsSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelPhase2MonitorRecHitsSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelHIonPhase1MonitorRecHitsSoAAlpaka);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoA.cc
@@ -22,6 +22,7 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "CUDADataFormats/Track/interface/PixelTrackUtilities.h"
 #include "CUDADataFormats/Track/interface/TrackSoAHeterogeneousHost.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 // for string manipulations
 #include <fmt/printf.h>
 
@@ -195,7 +196,9 @@ void SiPixelMonitorTrackSoA<T>::fillDescriptions(edm::ConfigurationDescriptions&
 using SiPixelPhase1MonitorTrackSoA = SiPixelMonitorTrackSoA<pixelTopology::Phase1>;
 using SiPixelPhase2MonitorTrackSoA = SiPixelMonitorTrackSoA<pixelTopology::Phase2>;
 using SiPixelHIonPhase1MonitorTrackSoA = SiPixelMonitorTrackSoA<pixelTopology::HIonPhase1>;
+using SiPixelPhase1StripMonitorTrackSoA = SiPixelMonitorTrackSoA<pixelTopology::Phase1Strip>;
 
 DEFINE_FWK_MODULE(SiPixelPhase1MonitorTrackSoA);
 DEFINE_FWK_MODULE(SiPixelPhase2MonitorTrackSoA);
 DEFINE_FWK_MODULE(SiPixelHIonPhase1MonitorTrackSoA);
+DEFINE_FWK_MODULE(SiPixelPhase1StripMonitorTrackSoA);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorTrackSoAAlpaka.cc
@@ -25,6 +25,8 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/TrackSoA/interface/TracksHost.h"
 
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
+
 template <typename T>
 class SiPixelMonitorTrackSoAAlpaka : public DQMEDAnalyzer {
 public:
@@ -195,7 +197,9 @@ void SiPixelMonitorTrackSoAAlpaka<T>::fillDescriptions(edm::ConfigurationDescrip
 using SiPixelPhase1MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka<pixelTopology::Phase1>;
 using SiPixelPhase2MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka<pixelTopology::Phase2>;
 using SiPixelHIonPhase1MonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka<pixelTopology::HIonPhase1>;
+using SiPixelPhase1StripMonitorTrackSoAAlpaka = SiPixelMonitorTrackSoAAlpaka<pixelTopology::Phase1Strip>;
 
 DEFINE_FWK_MODULE(SiPixelPhase1MonitorTrackSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelPhase2MonitorTrackSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelHIonPhase1MonitorTrackSoAAlpaka);
+DEFINE_FWK_MODULE(SiPixelPhase1StripMonitorTrackSoAAlpaka);

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
@@ -7,6 +7,7 @@ from DQM.SiPixelHeterogeneous.siPixelPhase1MonitorTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase2MonitorTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelHIonPhase1MonitorTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelMonitorVertexSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase1StripMonitorTrackSoA_cfi import *
 # Alpaka Modules
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 from DQM.SiPixelHeterogeneous.siPixelPhase1MonitorRecHitsSoAAlpaka_cfi import *
@@ -16,6 +17,8 @@ from DQM.SiPixelHeterogeneous.siPixelPhase1MonitorTrackSoAAlpaka_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase2MonitorTrackSoAAlpaka_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelHIonPhase1MonitorTrackSoAAlpaka_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelMonitorVertexSoAAlpaka_cfi import *
+
+
 
 # Run-3 sequence
 monitorpixelSoASource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA * siPixelPhase1MonitorTrackSoA * siPixelMonitorVertexSoA)
@@ -45,6 +48,7 @@ from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareRecHitsSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase1CompareTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase2CompareTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareTrackSoA_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase1StripCompareTrackSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelCompareVertexSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase1RawDataErrorComparator_cfi import *
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
@@ -210,6 +214,33 @@ siPixelVertexSoAMonitorDevice = siPixelMonitorVertexSoAAlpaka.clone(
     pixelVertexSrc = cms.InputTag("pixelVerticesAlpaka"),
     topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexDevice')
 )
+
+monitorPixelTracksAlpaka = cms.Sequence(siPixelTrackSoAMonitorSerial *
+                                        siPixelTrackSoAMonitorDevice *
+                                        siPixelPhase1CompareTrackSoA)
+
+# PixelTracks: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
+siPixelTrackSoAMonitorSerialStrip = siPixelPhase1StripMonitorTrackSoA.clone(
+    pixelTrackSrc = cms.InputTag('pixelTracksAlpakaSerial'),
+    topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackSerial')
+)
+
+# PixelTracks: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
+siPixelTrackSoAMonitorDeviceStrip = siPixelPhase1StripMonitorTrackSoA.clone(
+    pixelTrackSrc = cms.InputTag('pixelTracksAlpaka'),
+    topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackDevice')
+)
+
+monitorPixelTracksAlpakaStrip = cms.Sequence( siPixelTrackSoAMonitorSerialStrip *
+                                              siPixelTrackSoAMonitorDeviceStrip *
+                                              siPixelPhase1StripCompareTrackSoA)
+                                              
+
+from Configuration.ProcessModifiers.stripNtupletFit_cff import stripNtupletFit
+stripNtupletFit.toReplaceWith(monitorPixelTracksAlpaka, monitorPixelTracksAlpakaStrip)
+stripNtupletFit.toReplaceWith(siPixelPhase1CompareTrackSoA, siPixelPhase1StripCompareTrackSoA)
+stripNtupletFit.toReplaceWith(siPixelTrackSoAMonitorSerial, siPixelTrackSoAMonitorSerial)
+stripNtupletFit.toReplaceWith(siPixelTrackSoAMonitorDevice, siPixelTrackSoAMonitorDevice)
 
 # Run-3 sequence
 monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRawDataACPU *

--- a/DataFormats/TrackSoA/interface/TracksHost.h
+++ b/DataFormats/TrackSoA/interface/TracksHost.h
@@ -7,6 +7,7 @@
 #include "DataFormats/TrackSoA/interface/TracksSoA.h"
 #include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 // TODO: The class is created via inheritance of the PortableHostCollection.
 // This is generally discouraged, and should be done via composition.
@@ -36,6 +37,7 @@ namespace pixelTrack {
   using TracksHostPhase1 = TracksHost<pixelTopology::Phase1>;
   using TracksHostPhase2 = TracksHost<pixelTopology::Phase2>;
   using TracksHostHIonPhase1 = TracksHost<pixelTopology::HIonPhase1>;
+  using TracksHostPhase1Strip = TracksHost<pixelTopology::Phase1Strip>;
 
 }  // namespace pixelTrack
 

--- a/DataFormats/TrackSoA/interface/TracksSoA.h
+++ b/DataFormats/TrackSoA/interface/TracksSoA.h
@@ -7,6 +7,7 @@
 
 #include "HeterogeneousCore/AlpakaInterface/interface/OneToManyAssoc.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
 
@@ -66,33 +67,39 @@ namespace reco {
   struct IsTrackSoAConstView<TrackSoAConstView<pixelTopology::HIonPhase1>> : std::true_type {};
   template <>
   struct IsTrackSoAConstView<TrackSoAView<pixelTopology::HIonPhase1>> : std::true_type {};
+  template <>
+  struct IsTrackSoAConstView<TrackSoAConstView<pixelTopology::Phase1Strip>> : std::true_type {};
+  template <>
+  struct IsTrackSoAConstView<TrackSoAView<pixelTopology::Phase1Strip>> : std::true_type {};
 
   template <typename T>
   constexpr bool isTrackSoAConstView = IsTrackSoAConstView<T>::value;
 
-  template <typename ConstView, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
+  // enable_if should be used when there is another implementation, 
+  // please use static_assert to report invalid template arguments
+  template <typename ConstView> //, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr float charge(ConstView const& tracks, int32_t i) {
     //was: std::copysign(1.f, tracks[i].state()(2)). Will be constexpr with C++23
     float v = tracks[i].state()(2);
     return float((0.0f < v) - (v < 0.0f));
   }
 
-  template <typename ConstView, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
+  template <typename ConstView> //, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr float phi(ConstView const& tracks, int32_t i) {
     return tracks[i].state()(0);
   }
 
-  template <typename ConstView, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
+  template <typename ConstView> //, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr float tip(ConstView const& tracks, int32_t i) {
     return tracks[i].state()(1);
   }
 
-  template <typename ConstView, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
+  template <typename ConstView> //, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr float zip(ConstView const& tracks, int32_t i) {
     return tracks[i].state()(4);
   }
 
-  template <typename ConstView, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
+  template <typename ConstView> //, typename = std::enable_if_t<isTrackSoAConstView<ConstView>>>
   ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr bool isTriplet(ConstView const& tracks, int32_t i) {
     return tracks[i].nLayers() == 3;
   }

--- a/DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h
+++ b/DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h
@@ -140,6 +140,7 @@ namespace pixelTrack {
 
       float pt = std::min<float>(tracks.pt(it), chi2MaxPt);
       float chi2Cut = chi2Scale * (chi2Coeff[0] + roughLog(pt) * chi2Coeff[1]);
+      //chi2Cut = chi2Scale;
       if (tracks.chi2(it) >= chi2Cut) {
 #ifdef NTUPLE_FIT_DEBUG
         printf("Bad chi2 %d pt %f eta %f chi2 %f\n", it, tracks.pt(it), tracks.eta(it), tracks.chi2(it));
@@ -173,6 +174,7 @@ namespace pixelTrack {
 
 // TODO: Should those be placed in the ALPAKA_ACCELERATOR_NAMESPACE
 template struct TracksUtilities<pixelTopology::Phase1>;
+template struct TracksUtilities<pixelTopology::Phase1Strip>;
 template struct TracksUtilities<pixelTopology::Phase2>;
 
 #endif  // DataFormats_TrackSoA_interface_alpaka_TrackUtilities_h

--- a/DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h
+++ b/DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h
@@ -8,7 +8,7 @@
 #include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
 #include "DataFormats/TrackSoA/interface/TracksDevice.h"
 #include "DataFormats/TrackSoA/interface/TracksHost.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/AssertDeviceMatchesHostCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -29,6 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using TracksSoACollectionPhase1 = TracksSoACollection<pixelTopology::Phase1>;
     using TracksSoACollectionPhase2 = TracksSoACollection<pixelTopology::Phase2>;
     using TracksSoACollectionHIonPhase1 = TracksSoACollection<pixelTopology::HIonPhase1>;
+    using TracksSoACollectionPhase1Strip = TracksSoACollection<pixelTopology::Phase1Strip>;
   }  // namespace pixelTrack
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
@@ -50,5 +51,6 @@ namespace cms::alpakatools {
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(pixelTrack::TracksSoACollectionPhase1, pixelTrack::TracksHostPhase1);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(pixelTrack::TracksSoACollectionPhase2, pixelTrack::TracksHostPhase2);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(pixelTrack::TracksSoACollectionHIonPhase1, pixelTrack::TracksHostHIonPhase1);
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(pixelTrack::TracksSoACollectionPhase1Strip, pixelTrack::TracksHostPhase1Strip);
 
 #endif  // DataFormats_TrackSoA_interface_alpaka_TracksSoACollection_h

--- a/DataFormats/TrackSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/TrackSoA/src/alpaka/classes_cuda_def.xml
@@ -13,4 +13,9 @@
   <class name="alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase2" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase2>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase2>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::PortableCollection<reco::TrackLayout<pixelTopology::Phase1Strip>>" persistent="false"/>
+  <class name="alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase1Strip" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase1Strip>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase1Strip>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/TrackSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/TrackSoA/src/alpaka/classes_rocm_def.xml
@@ -13,4 +13,9 @@
   <class name="alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase2" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase2>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase2>>" persistent="false"/>
+
+    <class name="alpaka_rocm_async::PortableCollection<reco::TrackLayout<pixelTopology::Phase1Strip>>" persistent="false"/>
+  <class name="alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase1Strip" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase1Strip>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::pixelTrack::TracksSoACollectionPhase1Strip>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/TrackSoA/src/classes.cc
+++ b/DataFormats/TrackSoA/src/classes.cc
@@ -1,9 +1,10 @@
 #include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
 #include "DataFormats/TrackSoA/interface/TracksSoA.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 using namespace reco;
 
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackLayout<pixelTopology::Phase1>>);
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackLayout<pixelTopology::Phase2>>);
 // SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackLayout<pixelTopology::HIonPhase1>>); //TODO: For the moment we live without HIons
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackLayout<pixelTopology::Phase1Strip>>);

--- a/DataFormats/TrackSoA/src/classes_def.xml
+++ b/DataFormats/TrackSoA/src/classes_def.xml
@@ -25,4 +25,14 @@
   <class name="PortableHostCollection<reco::TrackLayout<pixelTopology::HIonPhase1>>"/>
   <class name="pixelTrack::TracksHostHIonPhase1"/>
   <class name="edm::Wrapper<pixelTrack::TracksHostHIonPhase1>" splitLevel="0"/>
+
+  <class name="reco::TrackSoA<pixelTopology::Phase1Strip>"/>
+  <class name="reco::TrackSoA<pixelTopology::Phase1Strip>::Layout<>"/>
+  <class name="reco::TrackLayout<pixelTopology::Phase1Strip>"/>
+  <class name="reco::TrackSoAView<pixelTopology::Phase1Strip>"/>
+
+  <class name="PortableHostCollection<reco::TrackLayout<pixelTopology::Phase1Strip>>"/>
+  <class name="pixelTrack::TracksHostPhase1Strip">
+  </class>
+  <class name="edm::Wrapper<pixelTrack::TracksHostPhase1Strip>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h
@@ -8,6 +8,7 @@
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 template <typename TrackerTraits, typename TDev>
 class TrackingRecHitDevice : public PortableDeviceCollection<TrackingRecHitLayout<TrackerTraits>, TDev> {

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h
@@ -8,6 +8,7 @@
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 template <typename TrackerTraits>
 class TrackingRecHitHost : public PortableHostCollection<TrackingRecHitLayout<TrackerTraits>> {
@@ -48,5 +49,6 @@ public:
 using TrackingRecHitHostPhase1 = TrackingRecHitHost<pixelTopology::Phase1>;
 using TrackingRecHitHostPhase2 = TrackingRecHitHost<pixelTopology::Phase2>;
 using TrackingRecHitHostHIonPhase1 = TrackingRecHitHost<pixelTopology::HIonPhase1>;
+using TrackingRecHitHostPhase1Strip = TrackingRecHitHost<pixelTopology::Phase1Strip>;
 
 #endif  // DataFormats_TrackingRecHitSoA_interface_TrackingRecHitsHost_h

--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h
@@ -10,7 +10,7 @@
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
@@ -25,6 +25,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using TrackingRecHitSoAPhase1 = TrackingRecHitsSoACollection<pixelTopology::Phase1>;
   using TrackingRecHitSoAPhase2 = TrackingRecHitsSoACollection<pixelTopology::Phase2>;
   using TrackingRecHitSoAHIonPhase1 = TrackingRecHitsSoACollection<pixelTopology::HIonPhase1>;
+  using TrackingRecHitSoAPhase1Strip = TrackingRecHitsSoACollection<pixelTopology::Phase1Strip>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
@@ -69,5 +70,5 @@ namespace cms::alpakatools {
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(TrackingRecHitSoAPhase1, TrackingRecHitHostPhase1);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(TrackingRecHitSoAPhase2, TrackingRecHitHostPhase2);
 ASSERT_DEVICE_MATCHES_HOST_COLLECTION(TrackingRecHitSoAHIonPhase1, TrackingRecHitHostHIonPhase1);
-
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(TrackingRecHitSoAPhase1Strip, TrackingRecHitHostPhase1Strip );
 #endif  // DataFormats_TrackingRecHitSoA_interface_alpaka_TrackingRecHitsSoACollection_h

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda_def.xml
@@ -13,4 +13,9 @@
   <class name="alpaka_cuda_async::TrackingRecHitSoAHIonPhase1" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAHIonPhase1>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAHIonPhase1>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::PortableCollection<TrackingRecHitLayout<pixelTopology::Phase1Strip>>" persistent="false"/>
+  <class name="alpaka_cuda_async::TrackingRecHitSoAPhase1Strip" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAPhase1Strip>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAPhase1Strip>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm_def.xml
@@ -13,5 +13,10 @@
   <class name="alpaka_rocm_async::TrackingRecHitSoAHIonPhase1" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::TrackingRecHitSoAHIonPhase1>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::TrackingRecHitSoAHIonPhase1>>" persistent="false"/>
+
+  <class name="alpaka_rocm_async::PortableCollection<TrackingRecHitLayout<pixelTopology::Phase1Strip>>" persistent="false"/>
+  <class name="alpaka_rocm_async::TrackingRecHitSoAPhase1Strip" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::TrackingRecHitSoAPhase1Strip>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::TrackingRecHitSoAPhase1Strip>>" persistent="false"/>
 </lcgdict>
 

--- a/DataFormats/TrackingRecHitSoA/src/classes.cc
+++ b/DataFormats/TrackingRecHitSoA/src/classes.cc
@@ -1,7 +1,8 @@
 #include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase1>>);
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase2>>);
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackingRecHitLayout<pixelTopology::HIonPhase1>>);
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase1Strip>>);

--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -25,4 +25,13 @@
   <class name="PortableHostCollection<TrackingRecHitLayout<pixelTopology::HIonPhase1>>"/>
   <class name="TrackingRecHitHostHIonPhase1"/>
   <class name="edm::Wrapper<TrackingRecHitHostHIonPhase1>" splitLevel="0"/>
+
+  <class name="TrackingRecHitSoA<pixelTopology::Phase1Strip>"/>
+  <class name="TrackingRecHitSoA<pixelTopology::Phase1Strip>::Layout<>"/>
+  <class name="TrackingRecHitLayout<pixelTopology::Phase1Strip>"/>
+  <class name="TrackingRecHitSoAView<pixelTopology::Phase1Strip>"/>
+
+  <class name="PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase1Strip>>"/>
+  <class name="TrackingRecHitHostPhase1Strip" />
+  <class name="edm::Wrapper<TrackingRecHitHostPhase1Strip>" splitLevel="0"/>
 </lcgdict>

--- a/Geometry/CommonTopologies/interface/SimplePixelStripTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelStripTopology.h
@@ -1,0 +1,305 @@
+#ifndef Geometry_CommonTopologies_SimplePixelStripTopology_h
+#define Geometry_CommonTopologies_SimplePixelStripTopology_h
+#include <iostream>
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+namespace phase1PixelStripTopology {
+  
+  struct LayerData {
+    uint32_t start;
+    uint32_t end;
+    bool isStrip2D = false; // if true then map every two module indices to the same sequential ID
+  };
+
+  enum Layer : uint8_t;
+
+  struct LayerPairData {
+    Layer inner;
+    Layer outer;
+    int16_t phicut;
+    float minz;
+    float maxz;
+    float maxr;
+  };
+
+  enum Layer : uint8_t {
+    BPIX1 = 0,
+    BPIX2,
+    BPIX3,
+    BPIX4,
+    FPIX1Pos,
+    FPIX2Pos,
+    FPIX3Pos,
+    FPIX1Neg,
+    FPIX2Neg,
+    FPIX3Neg,
+    TIB1,
+    TIB2,
+    TID1Pos2D,
+    TID2Pos2D,
+    TID3Pos2D,
+    TID1Neg2D,
+    TID2Neg2D,
+    TID3Neg2D,
+    nLayers
+  };
+
+  constexpr LayerData layerData[nLayers] = {
+    {0,     96    },      // BPIX1 
+    {96,    320   },      // BPIX2 
+    {320,   672   },      // BPIX3 
+    {672,   1184  },      // BPIX4 
+    {1184,  1296  },      // FPIX1Pos 
+    {1296,  1408  },      // FPIX2Pos 
+    {1408,  1520  },      // FPIX3Pos 
+    {1520,  1632  },      // FPIX1Neg 
+    {1632,  1744  },      // FPIX2Neg 
+    {1744,  1856  },      // FPIX3Neg 
+    {1856,  2528, true},  // TIB1 
+    {2528,  3392, true},  // TIB2 
+    {4580,  4676, true},  // TID1Pos2D
+    {4716,  4812, true},  // TID2Pos2D
+    {4852,  4948, true},  // TID3Pos2D
+    {4988,  5084, true},  // TID1Neg2D
+    {5124,  5220, true},  // TID2Neg2D
+    {5260,  5356, true},  // TID3Neg2D
+  };
+
+  using pixelTopology::phi5deg;
+  using pixelTopology::phi0p05;
+  using pixelTopology::phi0p06;
+  using pixelTopology::phi0p07;
+  using pixelTopology::phi0p09;
+  //constexpr int16_t phi0p05 = 522;  // round(521.52189...) = phi2short(0.05);
+  //constexpr int16_t phi0p06 = 626;  // round(625.82270...) = phi2short(0.06);
+  //constexpr int16_t phi0p07 = 730;  // round(730.12648...) = phi2short(0.07);
+  //constexpr int16_t phi0p09 = 900;
+  //constexpr int16_t phi5deg = 1820; 
+  constexpr LayerPairData layerPairData[] = {
+  { BPIX1,    BPIX2,      phi0p05,  -20.,   20.,  20.           }, // 0  (No inner layer) OK
+  { BPIX1,    FPIX1Pos,   phi0p07,  0.,     30.,  9.            }, // 1  (No inner layer) OK
+  { BPIX1,    FPIX1Neg,   phi0p07,  -30.,   0.,   9.            }, // 2  (No inner layer) OK
+  { BPIX2,    BPIX3,      phi0p05,  -22.,   22.,  20.           }, // 3  OK
+  { BPIX2,    FPIX1Pos,   phi0p07,  10.,    30.,  7.            }, // 4  OK
+  { BPIX2,    FPIX1Neg,   phi0p06,  -30.,   -10., 7.            }, // 5  OK
+  { FPIX1Pos, FPIX2Pos,   phi0p06,  -70.,   70.,  5.            }, // 6  OK
+  { FPIX1Neg, FPIX2Neg,   phi0p05,  -70.,   70.,  5.            }, // 7  OK
+  { BPIX1,    BPIX3,      phi0p05,  -20.,   20.,  20.           }, // 8 (No inner layer) OK
+  { BPIX2,    BPIX4,      phi0p05,  -22.,   22.,  20.           }, // 9  OK
+  { BPIX1,    FPIX2Pos,   phi0p06,    0.,   30.,  9.            }, // 10 (No inner layer) OK
+  { BPIX1,    FPIX2Neg,   phi0p05,  -30.,   0.,   9.            }, // 11 (No inner layer) Until here Starting Pairs OK
+  { FPIX1Pos, TIB1,       1200,  -70.,   70.,  1000.            }, // 12 
+  { FPIX1Neg, TIB1,       1200,  -70.,   70.,  1000.            }, // 13 
+  { BPIX3,    BPIX4,      phi0p06,  -22.,   22.,  20.           }, // 14    
+  { BPIX3,    FPIX1Pos,   phi0p07,  15.,    30.,  6.            }, // 15 
+  { BPIX3,    FPIX1Neg,   phi0p06,  -30,   -15.,  6.            }, // 16 
+  { FPIX2Pos, FPIX3Pos,   phi0p06,  -70.,   70.,  5.            }, // 17 
+  { FPIX2Neg, FPIX3Neg,   phi0p05,  -70.,   70.,  5.            }, // 18 
+  { BPIX3,    TIB1,       phi5deg,  -22.,   22.,   1000.        }, // 19 
+  { BPIX4,    TIB1,       phi5deg,  -22.,   22.,   1000.        }, // 20 
+  { BPIX4,    TIB2,       phi5deg,  -22.,   22.,   1000.        }, // 21 
+  { TIB1,     TIB2,       phi5deg,  -55.,   55.,   1000.        }, // 22
+  { FPIX2Neg, TIB1,       phi5deg,  -70.,   70.,   1000.        }, // 23 
+  { FPIX3Neg, TIB1,       phi5deg,  -70.,   70.,   1000.        }, // 24
+  { FPIX3Neg, TID1Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 25
+  { FPIX3Neg, TID2Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 26
+  { FPIX3Neg, TID3Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 27
+  { TID1Neg2D,TID2Neg2D,  phi5deg,  -1000., 1000., 1000.        }, // 28
+  { TID2Neg2D,TID3Neg2D,  phi5deg,  -1000., 1000., 1000.        }, // 29
+  { TIB1,     TID1Neg2D,  phi5deg,  -55.,   0.,    1000.        }, // 30
+  { TIB2,     TID1Neg2D,  phi5deg,  -55.,   0.,    1000.        }, // 31
+  { BPIX2,    TIB1,       phi5deg,  -22.,   0.,    1000.        }, // 32 
+  { BPIX2,    TIB2,       phi5deg,  -22.,   0.,    1000.        }, // 33
+  { BPIX1,    TIB1,       phi5deg,  -22.,   0.,    1000.        }, // 34
+  { BPIX3,    TIB2,       phi5deg,  -22.,   22.,   1000.        }, // 35
+  { BPIX4,    TID1Neg2D,  phi5deg,  -55.,  0.,    1000.         }, // 36
+  { FPIX1Pos, FPIX3Pos,   phi0p06,  -70.,   70.,      9.        }, // 37
+  { FPIX1Neg, FPIX3Neg,   phi0p05,  -70.,   70.,      9.        }, // 38
+  { FPIX1Neg, TIB2,       phi5deg,  -70.,   70.,   1000.        }, // 39
+  { FPIX1Neg, TID1Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 40
+  { FPIX1Neg, TID2Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 41
+  { FPIX2Pos, TID3Pos2D,  phi5deg,  -70.,   70.,   1000.        }, // 42
+  { FPIX2Neg, TIB2,       phi5deg,  -70.,   70.,   1000.        }, // 43
+  { FPIX2Neg, TID1Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 44
+  { FPIX2Neg, TID2Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 45
+  { FPIX2Neg, TID3Neg2D,  phi5deg,  -70.,   70.,   1000.        }, // 46
+  { FPIX3Neg, TIB2,       phi5deg,  -70.,   70.,   1000.        }, // 47
+  { BPIX2,    FPIX2Neg,   phi5deg,  -30.,   0.,   1000.         } //  48
+  };
+  
+  constexpr uint32_t maxNumClustersPerModules = 1024;
+  constexpr auto numberOfLayers = nLayers;
+  constexpr auto nPairs = std::size(layerPairData);
+
+  constexpr auto makeLayerStart() {
+    std::array<uint32_t, numberOfLayers + 1> layerStart = {{0}};
+    for (auto i = 0u; i < numberOfLayers; ++i)
+      if (layerData[i].isStrip2D)
+        layerStart[i + 1] = layerStart[i] + (layerData[i].end - layerData[i].start) / 2;
+      else
+        layerStart[i + 1] = layerStart[i] + layerData[i].end - layerData[i].start;
+    return layerStart;
+  }
+
+  HOST_DEVICE_CONSTANT std::array<uint32_t, numberOfLayers + 1> layerStart = makeLayerStart();
+  
+  constexpr uint16_t numberOfModules = layerStart[numberOfLayers];
+
+  constexpr auto makeLayerPairs() {
+    std::array<uint8_t, 2 * nPairs> layerPairs = {{0}};
+    for (auto i = 0u; i < nPairs; ++i) {
+      layerPairs[2 * i] = layerPairData[i].inner;
+      layerPairs[2 * i + 1] = layerPairData[i].outer;
+    }
+    return layerPairs;
+  }
+
+  HOST_DEVICE_CONSTANT std::array<uint8_t, 2 * nPairs> layerPairs = makeLayerPairs();
+
+  template <class T, class F>
+  constexpr auto makePairCutsArray(F&& f) {
+    std::array<T, nPairs> result{};
+    for (auto i = 0u; i < nPairs; ++i)
+      result[i] = f(layerPairData[i]);
+    return result;
+  }
+
+  HOST_DEVICE_CONSTANT std::array<int16_t, nPairs> phicuts = makePairCutsArray<int16_t>([] (const auto& x) { return x.phicut; });
+  HOST_DEVICE_CONSTANT std::array<float, nPairs> minz = makePairCutsArray<float>([] (const auto& x) { return x.minz; });
+  HOST_DEVICE_CONSTANT std::array<float, nPairs> maxz = makePairCutsArray<float>([] (const auto& x) { return x.maxz; });
+  HOST_DEVICE_CONSTANT std::array<float, nPairs> maxr = makePairCutsArray<float>([] (const auto& x) { return x.maxr; });
+
+  using IndexMap = std::array<int, layerData[numberOfLayers - 1].end>;
+
+  constexpr IndexMap makeIndexMap() {
+    IndexMap indexMap = {{0}};
+    for (auto& i : indexMap)
+      i = numberOfModules;
+    int newIndex = 0;
+    for (const auto& layer : layerData) {
+      for (auto i = layer.start; i < layer.end; ++i) {
+        indexMap[i] = newIndex;
+        if (!layer.isStrip2D || i % 2 == 1)
+          ++newIndex;
+      }
+    }
+    return indexMap;
+  }
+
+  constexpr IndexMap indexMap = makeIndexMap();
+
+  // constexpr uint32_t numberOfLayers = 12;
+  // constexpr int nPairs = 21 + 4 + 10 + 1; // without jump + jumping barrel + jumping forward
+  // constexpr uint16_t numberOfModules = 3392;
+
+
+  // HOST_DEVICE_CONSTANT uint8_t layerPairs[2 * nPairs] = {
+  //     0, 1, 0, 4, 0, 7,              // BPIX1 (3)
+  //     1, 2, 1, 4, 1, 7,              // BPIX2 (6)
+  //     4, 5, 7, 8,                    // FPIX1 (8)
+  //     2, 3, 2, 4, 2, 7, 5, 6, 8, 9,  // BPIX3 & FPIX2 (13)
+  //     0, 2, 1, 3,                    // Jumping Barrel (15)
+  //     0, 5, 0, 8,                    // Jumping Forward (BPIX1,FPIX2)
+  //     4, 6, 7, 9,                     // Jumping Forward (19)
+  //     3, 10,                          // BPIX4 (20)
+  //     4, 10, 5, 10, 6, 10,            // Pixel Positive Endcap (23)
+  //     7, 10, 8, 10, 9, 10,            // Pixel Negative Endcap (26)
+  //     10, 11,                         // TIB1 (27) 
+  //     1, 10, 2, 10, 3, 11,            // Jumping from Pixel Barrel (30)
+  //     4, 11, 5, 11, 6, 11,            // Jumping from Pixel Positive Endcap (33)
+  //     7, 11, 8, 11, 9, 11             // Jumping from Pixel Negative Endcap (36)
+  // };
+
+  // HOST_DEVICE_CONSTANT int16_t phicuts[nPairs]{phi0p05, phi0p07, phi0p07, phi0p05, phi0p06,
+  //                                              phi0p06, phi0p05, phi0p05, phi0p06, phi0p06,
+  //                                              phi0p06, phi0p05, phi0p05, phi0p05, phi0p05,
+                                               
+  //                                              phi0p05, phi0p05, phi0p05, phi0p05, phi5deg,
+  //                                              phi5deg, phi5deg, phi5deg, phi0p09, phi0p09,
+  //                                              phi0p09, phi0p09, phi0p09, phi0p09, phi0p09,
+                                               
+  //                                              phi0p09, phi0p09, phi0p09, phi0p09, phi0p09,
+  //                                              phi0p09
+  //                                              };
+
+  // HOST_DEVICE_CONSTANT float minz[nPairs] = {
+  //     -20., 0., -30., -22., 10., -30., -70., -70., -22., 15., -30, -70., -70., -20., -22., 0, -30., -70., -70.,
+  //     -22.,-70.,-70.,-70.,-70.,-70.,-70.,-80.,-22.,-22.,-70.,-70.,-70.,-70.,-70.,-70.,-70.};
+  // HOST_DEVICE_CONSTANT float maxz[nPairs] = {
+  //     20., 30., 0., 22., 30., -10., 70., 70., 22., 30., -15., 70., 70., 20., 22., 30., 0., 70., 70.,
+  //     22.,70.,70.,70.,70.,70.,70.,80.,22.,22.,70.,70., 70.,70.,70.,70.,70.};
+  // HOST_DEVICE_CONSTANT float maxr[nPairs] = {
+  //     20., 9., 9., 20., 7., 7., 5., 5., 20., 6., 6., 5., 5., 20., 20., 9., 9., 9., 9.,
+  //     10000.,10000.,10000.,10000.,10000.,10000.,10000.,10000.,10000.,10000.,10000.,10000., 10000.,10000.,10000.,10000.,10000.};
+
+  // static constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
+  //                                                             96,
+  //                                                             320,
+  //                                                             672,  // barrel
+  //                                                             1184,
+  //                                                             1296,
+  //                                                             1408,  // positive endcap
+  //                                                             1520,
+  //                                                             1632,
+  //                                                             1744,  // negative endcap
+  //                                                             1856,
+  //                                                             2528, 
+  //                                                             numberOfModules};
+
+} // namespace phase1PixelStripTopology
+namespace pixelTopology {
+
+  struct Phase1Strip : public Phase1 {
+
+    typedef Phase1 PixelBase; //Could be removed using based class
+    static constexpr uint32_t maxNumClustersPerModules = phase1PixelStripTopology::maxNumClustersPerModules;
+    static constexpr uint32_t maxHitsInModule = phase1PixelStripTopology::maxNumClustersPerModules;
+    static constexpr uint32_t maxCellNeighbors = 64;//64
+    static constexpr uint32_t maxCellTracks = 90; //302
+    static constexpr uint32_t maxHitsOnTrack = 15; //15
+    static constexpr uint32_t maxHitsOnTrackForFullFit = 6;
+    static constexpr uint32_t avgHitsPerTrack = 7;//7
+    static constexpr uint32_t maxCellsPerHit = 256;
+    static constexpr uint32_t avgTracksPerHit = 10;//10
+    static constexpr uint32_t maxNumberOfTuples = 256*1024*2;// 256 * 2048*10; //256*2048
+    //this is well above thanks to maxNumberOfTuples
+    static constexpr uint32_t maxHitsForContainers = avgHitsPerTrack * maxNumberOfTuples;
+    static constexpr uint32_t maxNumberOfDoublets = 10 * 256 * 1024;
+    static constexpr uint32_t maxNumOfActiveDoublets = maxNumberOfDoublets / 8;
+    static constexpr uint32_t maxNumberOfQuadruplets = maxNumberOfTuples;//*4
+    static constexpr uint32_t maxDepth = 12;//12
+    static constexpr int minYsizeB1 = 1;
+    static constexpr int minYsizeB2 = 1;
+    static constexpr uint32_t const *layerStart = phase1PixelStripTopology::layerStart.data();
+    
+    static constexpr float const *minz = phase1PixelStripTopology::minz.data();
+    static constexpr float const *maxz = phase1PixelStripTopology::maxz.data();
+    static constexpr float const *maxr = phase1PixelStripTopology::maxr.data();
+
+    static constexpr uint8_t const *layerPairs = phase1PixelStripTopology::layerPairs.data();
+    static constexpr int16_t const *phicuts = phase1PixelStripTopology::phicuts.data();
+
+    static constexpr uint32_t numberOfLayers = phase1PixelStripTopology::numberOfLayers;
+    static constexpr uint32_t numberOfStripLayers = numberOfLayers - numberOfPixelLayers;
+
+    static constexpr uint16_t numberOfModules = phase1PixelStripTopology::numberOfModules;
+    static constexpr uint16_t numberOfPixelModules = phase1PixelStripTopology::layerStart[numberOfPixelLayers];
+    static constexpr uint16_t numberOfStripModules = numberOfModules - numberOfPixelModules;
+
+    static constexpr int nPairsForQuadruplets = phase1PixelStripTopology::nPairs;                     // quadruplets require hits in all layers
+    static constexpr int nPairsForTriplets = nPairsForQuadruplets ;  // include barrel "jumping" layer pairs
+    static constexpr int nPairs = nPairsForTriplets;                // include forward "jumping" layer pairs
+
+
+    static constexpr char const *nameModifier = "Phase1Strip";
+    
+    static constexpr int mapIndex(int i) {
+      if (i > 0 && i < (int)phase1PixelStripTopology::indexMap.size())
+        return phase1PixelStripTopology::indexMap[i];
+      else
+        return i;
+    }
+  };
+  
+}  // namespace pixelTopology
+
+#endif  // Geometry_CommonTopologies_SimplePixelStripTopology_h

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -1,8 +1,10 @@
 #ifndef Geometry_CommonTopologies_SimplePixelTopology_h
 #define Geometry_CommonTopologies_SimplePixelTopology_h
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
+#include <tuple>
 #include <type_traits>
 #include "FWCore/Utilities/interface/HostDeviceConstant.h"
 
@@ -27,6 +29,7 @@ namespace pixelTopology {
   constexpr int16_t phi0p06 = 626;  // round(625.82270...) = phi2short(0.06);
   constexpr int16_t phi0p07 = 730;  // round(730.12648...) = phi2short(0.07);
   constexpr int16_t phi0p09 = 900;
+  constexpr int16_t phi5deg = 1820;
 
   constexpr uint16_t last_barrel_layer = 3;  // this is common between all the topologies
 
@@ -131,8 +134,8 @@ namespace phase1PixelTopology {
   using pixelTopology::phi0p06;
   using pixelTopology::phi0p07;
 
-  constexpr uint32_t numberOfLayers = 28;
-  constexpr int nPairs = 13 + 2 + 4;
+  constexpr uint32_t numberOfLayers = 10;
+  constexpr int nPairs = 13 + 2 + 4;; // without jump + jumping barrel + jumping forward 
   constexpr uint16_t numberOfModules = 1856;
 
   constexpr uint32_t maxNumClustersPerModules = 1024;
@@ -196,7 +199,8 @@ namespace phase1PixelTopology {
                                                               1520,
                                                               1632,
                                                               1744,  // negative endcap
-                                                              numberOfModules};
+                                                              numberOfModules
+                                                              };
 }  // namespace phase1PixelTopology
 
 namespace phase2PixelTopology {
@@ -230,7 +234,8 @@ namespace phase2PixelTopology {
       4,  6,  5,  7,  6,  8,  7,  9,  8,  10, 9,  11, 10, 12,  // POS Jump (48)
       16, 18, 17, 19, 18, 20, 19, 21, 20, 22, 21, 23, 22, 24,  // NEG Jump (55)
   };
-  HOST_DEVICE_CONSTANT uint32_t layerStart[numberOfLayers + 1] = {0,
+
+  static constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
                                                                   108,
                                                                   324,
                                                                   504,  // Barrel
@@ -337,7 +342,10 @@ namespace pixelTopology {
     static constexpr uint32_t maxNumOfActiveDoublets = maxNumberOfDoublets / 8;
     static constexpr uint32_t maxNumberOfQuadruplets = maxNumberOfTuples;
     static constexpr uint32_t maxDepth = 12;
-    static constexpr uint32_t numberOfLayers = 28;
+
+    static constexpr uint32_t numberOfPixelLayers = 28;
+    static constexpr uint32_t numberOfStripLayers = 0;
+    static constexpr uint32_t numberOfLayers = numberOfStripLayers + numberOfPixelLayers;
 
     static constexpr uint32_t maxSizeCluster = 2047;
 
@@ -378,7 +386,9 @@ namespace pixelTopology {
     static constexpr int maxDYsize = 10;
     static constexpr int maxDYPred = 20;
 
-    static constexpr uint16_t numberOfModules = phase2PixelTopology::numberOfModules;
+    static constexpr uint16_t numberOfModules = 3892;
+    static constexpr uint16_t numberOfPixelModules = 3892;
+    static constexpr uint16_t numberOfStripModules = 0;
 
     // 1000 bins < 1024 bins (10 bits) must be:
     // - < 32*32 (warpSize*warpSize for block prefix scan for CUDA)
@@ -413,12 +423,14 @@ namespace pixelTopology {
 
     static constexpr inline uint16_t localX(uint16_t px) { return px; }
     static constexpr inline uint16_t localY(uint16_t py) { return py; }
+
+    static constexpr int mapIndex(int i) { return i; }
   };
 
   struct Phase1 {
     // types
     using hindex_type = uint32_t;  // FIXME from siPixelRecHitsHeterogeneousProduct
-    using tindex_type = uint16_t;  // for tuples
+    using tindex_type = uint32_t;  // for tuples
     using cindex_type = uint32_t;  // for cells
 
     static constexpr uint32_t maxCellNeighbors = 36;
@@ -434,7 +446,10 @@ namespace pixelTopology {
     static constexpr uint32_t maxNumOfActiveDoublets = maxNumberOfDoublets / 8;
     static constexpr uint32_t maxNumberOfQuadruplets = maxNumberOfTuples;
     static constexpr uint32_t maxDepth = 6;
-    static constexpr uint32_t numberOfLayers = 10;
+
+    static constexpr uint32_t numberOfPixelLayers = 10;
+    static constexpr uint32_t numberOfStripLayers = 0;
+    static constexpr uint32_t numberOfLayers = numberOfPixelLayers + numberOfStripLayers;
 
     static constexpr uint32_t maxSizeCluster = 1023;
 
@@ -464,18 +479,20 @@ namespace pixelTopology {
 
     static constexpr float dzdrFact = 8 * 0.0285 / 0.015;  // from dz/dr to "DY"
 
-    static constexpr int minYsizeB1 = 36;
-    static constexpr int minYsizeB2 = 28;
+    static constexpr int minYsizeB1 = 1;
+    static constexpr int minYsizeB2 = 1;
 
     static constexpr int nPairsForQuadruplets = 13;                     // quadruplets require hits in all layers
     static constexpr int nPairsForTriplets = nPairsForQuadruplets + 2;  // include barrel "jumping" layer pairs
-    static constexpr int nPairs = nPairsForTriplets + 4;                // include forward "jumping" layer pairs
+    static constexpr int nPairs = nPairsForTriplets +4;                // include forward "jumping" layer pairs
 
     static constexpr int maxDYsize12 = 28;
     static constexpr int maxDYsize = 20;
     static constexpr int maxDYPred = 20;
-
-    static constexpr uint16_t numberOfModules = phase1PixelTopology::numberOfModules;
+    
+    static constexpr uint16_t numberOfModules = 1856;
+    static constexpr uint16_t numberOfPixelModules = phase1PixelTopology::layerStart[numberOfPixelLayers];
+    static constexpr uint16_t numberOfStripModules = numberOfModules - numberOfPixelModules;
 
     static constexpr uint16_t numRowsInRoc = 80;
     static constexpr uint16_t numColsInRoc = 52;
@@ -544,8 +561,10 @@ namespace pixelTopology {
         shift += 1;
       return py + shift;
     }
-  };
 
+    static constexpr int mapIndex(int i) { return i; }
+  };
+  
   struct HIonPhase1 : public Phase1 {
     // Storing here the needed constants different w.r.t. pp Phase1 topology.
     // All the other defined by inheritance in the HIon topology struct.
@@ -577,6 +596,9 @@ namespace pixelTopology {
   template <typename T>
   using isPhase2Topology = typename std::enable_if<std::is_base_of<Phase2, T>::value>::type;
 
+  template <typename T>
+  using base_traits_t = std::conditional_t<std::is_base_of_v<Phase1, T>, Phase1, Phase2>;
+  
 }  // namespace pixelTopology
 
 #endif  // Geometry_CommonTopologies_SimplePixelTopology_h

--- a/HLTrigger/Configuration/python/customizeHLTforAlpakaStripNoDoubletRecovery.py
+++ b/HLTrigger/Configuration/python/customizeHLTforAlpakaStripNoDoubletRecovery.py
@@ -1,0 +1,795 @@
+import FWCore.ParameterSet.Config as cms
+import re
+import itertools
+
+from FWCore.ParameterSet.MassReplace import massReplaceInputTag
+from HeterogeneousCore.AlpakaCore.functions import *
+from HLTrigger.Configuration.common import *
+
+## Pixel HLT in Alpaka
+def customizeHLTforDQMGPUvsCPUPixel(process):
+    '''Ad-hoc changes to test HLT config containing only DQM_PixelReconstruction_v and DQMGPUvsCPU stream
+       only up to the Pixel Local Reconstruction
+    '''
+    dqmPixelRecoPathName = None
+    for pathName in process.paths_():
+        if pathName.startswith('DQM_PixelReconstruction_v'):
+            dqmPixelRecoPathName = pathName
+            break
+
+    if dqmPixelRecoPathName == None:
+        return process
+
+    for prod in producers_by_type(process, 'SiPixelPhase1MonitorRecHitsSoAAlpaka'):
+        return process
+
+    # modify EventContent of DQMGPUvsCPU stream
+    try:
+        outCmds_new = [foo for foo in process.hltOutputDQMGPUvsCPU.outputCommands if 'Pixel' not in foo]
+        outCmds_new += [
+            'keep *Cluster*_hltSiPixelClusters_*_*',
+            'keep *Cluster*_hltSiPixelClustersSerialSync_*_*',
+            'keep *_hltSiPixelDigiErrors_*_*',
+            'keep *_hltSiPixelDigiErrorsSerialSync_*_*',
+            'keep *RecHit*_hltSiPixelRecHits_*_*',
+            'keep *RecHit*_hltSiPixelRecHitsSerialSync_*_*',
+            'keep *_hltPixelTracks_*_*',
+            'keep *_hltPixelTracksSerialSync_*_*',
+            'keep *_hltPixelVertices_*_*',
+            'keep *_hltPixelVerticesSerialSync_*_*',
+        ]
+        process.hltOutputDQMGPUvsCPU.outputCommands = outCmds_new[:]
+    except:
+        pass
+
+    # PixelRecHits: monitor of SerialSync product (Alpaka backend: 'serial_sync')
+    process.hltPixelRecHitsSoAMonitorCPU = cms.EDProducer('SiPixelPhase1MonitorRecHitsSoAAlpaka',
+        pixelHitsSrc = cms.InputTag('hltSiPixelRecHitsSoASerialSync'),
+        TopFolderName = cms.string('SiPixelHeterogeneous/PixelRecHitsCPU')
+    )
+
+    # PixelRecHits: monitor of GPU product (Alpaka backend: '')
+    process.hltPixelRecHitsSoAMonitorGPU = cms.EDProducer('SiPixelPhase1MonitorRecHitsSoAAlpaka',
+        pixelHitsSrc = cms.InputTag('hltSiPixelRecHitsSoA'),
+        TopFolderName = cms.string('SiPixelHeterogeneous/PixelRecHitsGPU')
+    )
+
+    # PixelRecHits: 'GPUvsCPU' comparisons
+    process.hltPixelRecHitsSoACompareGPUvsCPU = cms.EDProducer('SiPixelPhase1CompareRecHitsSoAAlpaka',
+        pixelHitsSrcHost = cms.InputTag('hltSiPixelRecHitsSoASerialSync'),
+        pixelHitsSrcDevice = cms.InputTag('hltSiPixelRecHitsSoA'),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU'),
+        minD2cut = cms.double(1.0e-4)
+    )
+
+    process.hltPixelTracksSoAMonitorCPU = cms.EDProducer("SiPixelPhase1MonitorTrackSoAAlpaka",
+        minQuality = cms.string('loose'),
+        pixelTrackSrc = cms.InputTag('hltPixelTracksSoASerialSync'),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCPU'),
+        useQualityCut = cms.bool(True)
+    )
+
+    process.hltPixelTracksSoAMonitorGPU = cms.EDProducer("SiPixelPhase1MonitorTrackSoAAlpaka",
+        minQuality = cms.string('loose'),
+        pixelTrackSrc = cms.InputTag('hltPixelTracksSoA'),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackGPU'),
+        useQualityCut = cms.bool(True)
+    )
+
+    process.hltPixelTracksSoACompareGPUvsCPU = cms.EDProducer("SiPixelPhase1StripCompareTrackSoAAlpaka",
+        deltaR2cut = cms.double(0.04),
+        minQuality = cms.string('loose'),
+        pixelTrackSrcHost = cms.InputTag("hltPixelTracksSoASerialSync"),
+        pixelTrackSrcDevice = cms.InputTag("hltPixelTracksSoA"),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelTrackCompareGPUvsCPU'),
+        useQualityCut = cms.bool(True)
+    )
+
+    process.hltPixelVertexSoAMonitorCPU = cms.EDProducer("SiPixelMonitorVertexSoAAlpaka",
+        beamSpotSrc = cms.InputTag("hltOnlineBeamSpot"),
+        pixelVertexSrc = cms.InputTag("hltPixelVerticesSoASerialSync"),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexCPU')
+    )
+
+    process.hltPixelVertexSoAMonitorGPU = cms.EDProducer("SiPixelMonitorVertexSoAAlpaka",
+        beamSpotSrc = cms.InputTag("hltOnlineBeamSpot"),
+        pixelVertexSrc = cms.InputTag("hltPixelVerticesSoA"),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexGPU')
+    )
+
+    process.hltPixelVertexSoACompareGPUvsCPU = cms.EDProducer("SiPixelCompareVertexSoAAlpaka",
+        beamSpotSrc = cms.InputTag("hltOnlineBeamSpot"),
+        dzCut = cms.double(1),
+        pixelVertexSrcHost = cms.InputTag("hltPixelVerticesSoASerialSync"),
+        pixelVertexSrcDevice = cms.InputTag("hltPixelVerticesSoA"),
+        topFolderName = cms.string('SiPixelHeterogeneous/PixelVertexCompareGPUvsCPU')
+    )
+
+    process.HLTDQMPixelReconstruction = cms.Sequence(
+        process.hltPixelRecHitsSoAMonitorCPU
+      + process.hltPixelRecHitsSoAMonitorGPU
+      + process.hltPixelRecHitsSoACompareGPUvsCPU
+      + process.hltPixelTracksSoAMonitorCPU
+      + process.hltPixelTracksSoAMonitorGPU
+      + process.hltPixelTracksSoACompareGPUvsCPU
+      + process.hltPixelVertexSoAMonitorCPU
+      + process.hltPixelVertexSoAMonitorGPU
+      + process.hltPixelVertexSoACompareGPUvsCPU
+    )
+
+    for delMod in ['hltPixelConsumerCPU', 'hltPixelConsumerGPU']:
+        if hasattr(process, delMod):
+            process.__delattr__(delMod)
+
+    return process
+
+
+def customizeHLTforAlpakaPixelRecoLocal(process):
+    '''Customisation to introduce the Local Pixel Reconstruction in Alpaka
+    '''
+
+    if not hasattr(process, 'HLTDoLocalPixelSequence'):
+        return process
+
+    process.hltESPSiPixelCablingSoA = cms.ESProducer('SiPixelCablingSoAESProducer@alpaka',
+        CablingMapLabel = cms.string(''),
+        UseQualityInfo = cms.bool(False),
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    process.hltESPSiPixelGainCalibrationForHLTSoA = cms.ESProducer('SiPixelGainCalibrationForHLTSoAESProducer@alpaka',
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    process.hltESPPixelCPEFastParamsPhase1 = cms.ESProducer('PixelCPEFastParamsESProducerAlpakaPhase1@alpaka',
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    if hasattr(process, 'hltESPPixelCPEFast'):
+        del process.hltESPPixelCPEFast
+
+    # alpaka EDProducer
+    # consumes
+    #  - reco::BeamSpot
+    # produces
+    #  - BeamSpotDevice
+    process.hltOnlineBeamSpotDevice = cms.EDProducer('BeamSpotDeviceProducer@alpaka',
+        src = cms.InputTag('hltOnlineBeamSpot'),
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    if hasattr(process, 'hltOnlineBeamSpotToGPU'):
+        # hltOnlineBeamSpotToGPU is currently still used in HIon menu,
+        # remove it only if the relevant ConditionalTask of the HIon menu is not present
+        # (this check mainly applies to the HLT combined table)
+        if not (hasattr(process, 'HLTDoLocalPixelPPOnAATask') and process.HLTDoLocalPixelPPOnAATask.contains(process.hltOnlineBeamSpotToGPU)):
+            del process.hltOnlineBeamSpotToGPU
+
+    # alpaka EDProducer
+    # consumes
+    #  - FEDRawDataCollection
+    # produces (* optional)
+    #  - SiPixelClustersSoA
+    #  - SiPixelDigisSoACollection
+    #  - SiPixelDigiErrorsSoACollection *
+    #  - SiPixelFormatterErrors *
+    process.hltSiPixelClustersSoA = cms.EDProducer('SiPixelRawToClusterPhase1@alpaka',
+        IncludeErrors = cms.bool(True),
+        UseQualityInfo = cms.bool(False),
+        clusterThreshold_layer1 = cms.int32(4000),
+        clusterThreshold_otherLayers = cms.int32(4000),
+        VCaltoElectronGain      = cms.double(1),  # all gains=1, pedestals=0
+        VCaltoElectronGain_L1   = cms.double(1),
+        VCaltoElectronOffset    = cms.double(0),
+        VCaltoElectronOffset_L1 = cms.double(0),
+        InputLabel = cms.InputTag('rawDataCollector'),
+        Regions = cms.PSet(),
+        CablingMapLabel = cms.string(''),
+        # autoselect the alpaka backend
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    if hasattr(process, 'hltSiPixelClustersGPU'):
+        del process.hltSiPixelClustersGPU
+
+    process.hltSiPixelClusters = cms.EDProducer('SiPixelDigisClustersFromSoAAlpakaPhase1',
+        src = cms.InputTag('hltSiPixelClustersSoA'),
+        clusterThreshold_layer1 = cms.int32(4000),
+        clusterThreshold_otherLayers = cms.int32(4000),
+        produceDigis = cms.bool(False),
+        storeDigis = cms.bool(False)
+    )
+
+    # used only in the PPRef menu for the legacy pixel track reconstruction
+    process.hltSiPixelClustersCache = cms.EDProducer('SiPixelClusterShapeCacheProducer',
+        src = cms.InputTag('hltSiPixelClusters'),
+        onDemand = cms.bool(False)
+    )
+
+    # legacy EDProducer
+    # consumes
+    #  - SiPixelDigiErrorsHost
+    #  - SiPixelFormatterErrors
+    # produces
+    #  - edm::DetSetVector<SiPixelRawDataError>
+    #  - DetIdCollection
+    #  - DetIdCollection, 'UserErrorModules'
+    #  - edmNew::DetSetVector<PixelFEDChannel>
+    process.hltSiPixelDigiErrors = cms.EDProducer('SiPixelDigiErrorsFromSoAAlpaka',
+        digiErrorSoASrc = cms.InputTag('hltSiPixelClustersSoA'),
+        fmtErrorsSoASrc = cms.InputTag('hltSiPixelClustersSoA'),
+        CablingMapLabel = cms.string(''),
+        UsePhase1 = cms.bool(True),
+        ErrorList = cms.vint32(29),
+        UserErrorList = cms.vint32(40)
+    )
+    # alpaka EDProducer
+    # consumes
+    #  - BeamSpotDevice
+    #  - SiPixelClustersSoA
+    #  - SiPixelDigisSoACollection
+    # produces
+    #  - TrackingRecHitsSoACollection<TrackerTraits>
+    process.hltSiStripRawToClustersFacility = cms.EDProducer("SiStripClusterizerFromRaw",
+    Algorithms = cms.PSet(
+        CommonModeNoiseSubtractionMode = cms.string('Median'),
+        PedestalSubtractionFedMode = cms.bool(True),
+        SiStripFedZeroSuppressionMode = cms.uint32(4),
+        TruncateInSuppressor = cms.bool(True),
+        Use10bitsTruncation = cms.bool(False),
+        doAPVRestore = cms.bool(False),
+        useCMMeanMap = cms.bool(False)
+    ),
+    Clusterizer = cms.PSet(
+        Algorithm = cms.string('ThreeThresholdAlgorithm'),
+        ChannelThreshold = cms.double(2.0),
+        ClusterThreshold = cms.double(5.0),
+        ConditionsLabel = cms.string(''),
+        MaxAdjacentBad = cms.uint32(0),
+        MaxClusterSize = cms.uint32(8),
+        MaxSequentialBad = cms.uint32(1),
+        MaxSequentialHoles = cms.uint32(0),
+        RemoveApvShots = cms.bool(True),
+        SeedThreshold = cms.double(3.0),
+        clusterChargeCut = cms.PSet(
+            refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone')
+        ),
+        setDetId = cms.bool(True)
+    ),
+    ConditionsLabel = cms.string(''),
+    DoAPVEmulatorCheck = cms.bool(False),
+    HybridZeroSuppressed = cms.bool(False),
+    LegacyUnpacker = cms.bool(False),
+    ProductLabel = cms.InputTag("rawDataCollector"),
+    onDemand = cms.bool(False)
+    )
+    process.hltSiStripMatchedRecHitsFull = cms.EDProducer( "SiStripRecHitConverter",
+    ClusterProducer = cms.InputTag( "hltSiStripRawToClustersFacility" ),
+    rphiRecHits = cms.string( "rphiRecHit" ),
+    stereoRecHits = cms.string( "stereoRecHit" ),
+    matchedRecHits = cms.string( "matchedRecHit" ),
+    useSiStripQuality = cms.bool( False ),
+    MaskBadAPVFibers = cms.bool( False ),
+    doMatching = cms.bool( True ),
+    StripCPE = cms.ESInputTag( "hltESPStripCPEfromTrackAngle","hltESPStripCPEfromTrackAngle" ),
+    Matcher = cms.ESInputTag( "SiStripRecHitMatcherESProducer","StandardMatcher" ),
+    siStripQualityLabel = cms.ESInputTag( "","" )
+    )
+    
+    process.hltSiPixelOnlyRecHitsSoA = cms.EDProducer('SiPixelRecHitAlpakaPhase1@alpaka',
+        beamSpot = cms.InputTag('hltOnlineBeamSpotDevice'),
+        src = cms.InputTag('hltSiPixelClustersSoA'),
+        CPE = cms.string('PixelCPEFastParams'),
+        mightGet = cms.optional.untracked.vstring,
+        # autoselect the alpaka backend
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+    
+    process.hltSiPixelRecHitsSoA = cms.EDProducer('SiStripRecHitSoAPhase1@alpaka',
+      stripRecHitSource = cms.InputTag('hltSiStripMatchedRecHitsFull', 'matchedRecHit'),
+      beamSpot =  cms.InputTag('hltOnlineBeamSpot'),
+      pixelRecHitSoASource = cms.InputTag('hltSiPixelOnlyRecHitsSoA'),
+      mightGet = cms.optional.untracked.vstring,
+      
+      alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string('')
+      )
+    )
+    process.hltSiPixelRecHits = cms.EDProducer('SiPixelRecHitFromSoAAlpakaPhase1',
+        pixelRecHitSrc = cms.InputTag('hltSiPixelOnlyRecHitsSoA'),
+        src = cms.InputTag('hltSiPixelClusters'),
+    )
+
+    ###
+    ### Task: Pixel Local Reconstruction
+    ###
+    process.HLTDoLocalPixelTask = cms.ConditionalTask(
+        process.hltOnlineBeamSpotDevice,
+        process.hltSiPixelClustersSoA,
+        process.hltSiPixelClusters,   
+        process.hltSiPixelClustersCache,          
+        process.hltSiPixelDigiErrors, 
+        process.hltSiStripRawToClustersFacility,
+        process.hltSiStripMatchedRecHitsFull,
+        process.hltSiPixelOnlyRecHitsSoA,
+        process.hltSiPixelRecHitsSoA,
+        process.hltSiPixelRecHits, 
+    )
+    process.HLTDoLocalPixelSequence = cms.Sequence(
+        process.hltOnlineBeamSpotDevice+
+        process.hltSiPixelClustersSoA+
+        process.hltSiPixelClusters+                                                                                                                               
+        process.hltSiPixelClustersCache+                                                                                                                                       
+        process.hltSiPixelDigiErrors+                                                                                                                                        
+        process.hltSiStripRawToClustersFacility+
+        process.hltSiStripMatchedRecHitsFull+
+        process.hltSiPixelOnlyRecHitsSoA+
+        process.hltSiPixelRecHitsSoA+
+        process.hltSiPixelRecHits                                                                                                                                      
+    )
+            
+    ###
+    ### SerialSync version of Pixel Local Reconstruction
+    ###
+    process.hltOnlineBeamSpotDeviceSerialSync = makeSerialClone(process.hltOnlineBeamSpotDevice)
+
+    process.hltSiPixelClustersSoASerialSync = makeSerialClone(process.hltSiPixelClustersSoA)
+
+    process.hltSiPixelClustersSerialSync = process.hltSiPixelClusters.clone(
+        src = 'hltSiPixelClustersSoASerialSync'
+    )
+
+    process.hltSiPixelDigiErrorsSerialSync = process.hltSiPixelDigiErrors.clone(
+        digiErrorSoASrc = 'hltSiPixelClustersSoASerialSync',
+        fmtErrorsSoASrc = 'hltSiPixelClustersSoASerialSync',
+    )
+    
+    process.hltSiPixelOnlyRecHitsSoACPUSerial = makeSerialClone(process.hltSiPixelOnlyRecHitsSoA,
+        beamSpot = 'hltOnlineBeamSpotDeviceSerialSync',
+        src = 'hltSiPixelClustersSoASerialSync'
+    )
+    process.hltSiPixelRecHitsSoASerialSync = makeSerialClone(process.hltSiPixelRecHitsSoA,
+      pixelRecHitSoASource = cms.InputTag('hltSiPixelOnlyRecHitsSoACPUSerial'),
+      )
+    
+    process.hltSiPixelRecHitsSerialSync = process.hltSiPixelRecHits.clone(
+         pixelRecHitSrc = 'hltSiPixelOnlyRecHitsSoACPUSerial',
+         src = 'hltSiPixelClustersSerialSync',
+    )
+
+    if(not hasattr(process,'hltSiPixelOnlyRecHitsSoA')):
+        return process
+    
+    process.HLTDoLocalPixelCPUSerialTask = cms.ConditionalTask(
+        process.hltOnlineBeamSpotDeviceSerialSync,
+        process.hltSiPixelClustersSoASerialSync,
+        process.hltSiPixelClustersSerialSync,
+        process.hltSiPixelDigiErrorsSerialSync,
+        process.hltSiStripRawToClustersFacility,
+        process.hltSiStripMatchedRecHitsFull,
+        process.hltSiPixelOnlyRecHitsSoACPUSerial,
+        process.hltSiPixelRecHitsSoASerialSync,
+        process.hltSiPixelRecHitsSerialSync
+    )
+    if not hasattr(process, 'HLTDoLocalPixelSequenceSerialSync'):
+        return process
+    process.HLTDoLocalPixelSequenceSerialSync = cms.Sequence( process.HLTDoLocalPixelCPUSerialTask)
+    process.HLTDoLocalPixelSequenceSerialSync = cms.Sequence(
+        process.hltOnlineBeamSpotDeviceSerialSync+
+        process.hltSiPixelClustersSoASerialSync+
+        process.hltSiPixelClustersSerialSync+
+        process.hltSiPixelDigiErrorsSerialSync+
+        process.hltSiStripRawToClustersFacility+
+        process.hltSiStripMatchedRecHitsFull+
+        process.hltSiPixelOnlyRecHitsSoACPUSerial+
+        process.hltSiPixelRecHitsSoASerialSync+
+        process.hltSiPixelRecHitsSerialSync
+        )
+    return process
+
+
+def customizeHLTforAlpakaPixelRecoTracking(process):
+    '''Customisation to introduce the Pixel-Track Reconstruction in Alpaka
+    '''
+
+    if not hasattr(process, 'HLTRecoPixelTracksSequence'):
+        return process
+                
+    for producer in producers_by_type(process, "TrackListMerger"):
+        current_producers = producer.TrackProducers
+        if (
+            'hltIter0PFlowTrackSelectionHighPurity' in current_producers and 
+            'hltDoubletRecoveryPFlowTrackSelectionHighPurity' in current_producers
+        ):
+            setattr(producer, "TrackProducers",cms.VInputTag('hltIter0PFlowTrackSelectionHighPurity'))
+            setattr(producer,"hasSelector",cms.vint32( 0))
+            setattr(producer,"indivShareFrac",cms.vdouble( 1.0))
+            setattr(producer, "selectedTrackQuals", cms.VInputTag( 'hltIter0PFlowTrackSelectionHighPurity'))
+            setattr(producer,"setsToMerge",cms.VPSet( cms.PSet(  pQual = cms.bool( False ), tLists = cms.vint32( 0))))
+                    
+    if hasattr(process, "hltDoubletRecoveryPFlowTrackSelectionHighPurity"):
+        del process.hltDoubletRecoveryPFlowTrackSelectionHighPurity
+
+    for producer in producers_by_type(process, "TrackListMerger"):
+        current_producers = producer.TrackProducers
+        if (
+            'hltIter0PFlowTrackSelectionHighPuritySerialSync' in current_producers and
+            'hltDoubletRecoveryPFlowTrackSelectionHighPuritySerialSync' in current_producers
+        ):
+            setattr(producer, "TrackProducers",cms.VInputTag('hltIter0PFlowTrackSelectionHighPuritySerialSync'))
+            setattr(producer,"hasSelector",cms.vint32( 0))
+            setattr(producer,"indivShareFrac",cms.vdouble( 1.0))
+            setattr(producer, "selectedTrackQuals", cms.VInputTag( 'hltIter0PFlowTrackSelectionHighPuritySerialSync'))
+            setattr(producer,"setsToMerge",cms.VPSet( cms.PSet(  pQual = cms.bool( False ), tLists = cms.vint32( 0))))
+    if hasattr(process, "HLTIterativeTrackingDoubletRecovery"):
+        del process.HLTIterativeTrackingDoubletRecovery
+    if hasattr(process, "HLTIterativeTrackingDoubletRecoverySerialSync"):
+        del process.HLTIterativeTrackingDoubletRecoverySerialSync
+    if hasattr(process, "hltDoubletRecoveryPFlowTrackSelectionHighPuritySerialSync"):
+        del process.hltDoubletRecoveryPFlowTrackSelectionHighPuritySerialSync
+                    
+    # alpaka EDProducer
+    # consumes
+    #  - TrackingRecHitsSoACollection<TrackerTraits>
+    # produces
+    #  - TkSoADevice
+    
+    process.frameSoAESProducerPhase1Strip = cms.ESProducer('FrameSoAESProducerPhase1Strip@alpaka',
+      ComponentName = cms.string('FrameSoAPhase1Strip'),
+      appendToDataLabel = cms.string(''),
+      alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string('')
+      )
+    )
+    
+    process.hltPixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase1Strip@alpaka',
+        pixelRecHitSrc = cms.InputTag('hltSiPixelRecHitsSoA'),
+        frameSoA = cms.string('FrameSoAPhase1Strip'),
+        ptmin = cms.double(0.9),
+        maxNumberOfDoublets = cms.uint32(10*256*1024),
+        CAThetaCutBarrel = cms.double(0.002),
+        CAThetaCutForward = cms.double(0.003),
+        hardCurvCut = cms.double(0.0328407225),
+        dcaCutInnerTriplet = cms.double(0.15),
+        dcaCutOuterTriplet = cms.double(0.25),
+        CAThetaCutBarrelPixelBarrelStrip = cms.double(0.002),
+        CAThetaCutBarrelPixelForwardStrip = cms.double(0.003),
+        CAThetaCutBarrelStripForwardStrip = cms.double(0.003),
+        CAThetaCutBarrelStrip = cms.double(0.002),
+        CAThetaCutDefault = cms.double(0.003),
+        dcaCutInnerTripletPixelStrip = cms.double(0.15),
+        dcaCutOuterTripletPixelStrip = cms.double(0.25),
+        dcaCutTripletStrip = cms.double(0.25),
+        dcaCutTripletDefault = cms.double(0.25),
+        earlyFishbone = cms.bool(True),
+        lateFishbone = cms.bool(False),
+        fillStatistics = cms.bool(False),
+        minHitsPerNtuplet = cms.uint32(3),
+        minHitsForSharingCut = cms.uint32(10),
+        fitNas4 = cms.bool(False),
+        doClusterCut = cms.bool(True),
+        doZ0Cut = cms.bool(True),
+	cellZ0Cut = cms.double(10.0),
+        cellPtCut = cms.double(0.5),
+        doPtCut = cms.bool(True),
+        useRemovers = cms.bool(False),
+        useRiemannFit = cms.bool(False),
+        doSharedHitCut = cms.bool(False), #originall True                                                                                              
+        dupPassThrough = cms.bool(False), #originall False                                                                                             
+        useSimpleTripletCleaner = cms.bool(True),#originally True,                                                                                     
+        idealConditions = cms.bool(False),
+        includeJumpingForwardDoublets = cms.bool(True),
+        trackQualityCuts = cms.PSet(
+          chi2MaxPt = cms.double(10),
+          chi2Coeff = cms.vdouble(
+            0.9,
+            1.8
+          ),
+	chi2Scale = cms.double(8),
+          tripletMinPt = cms.double(0.5),
+          tripletMaxTip = cms.double(0.3),
+          tripletMaxZip = cms.double(12),
+          quadrupletMinPt = cms.double(0.3),
+          quadrupletMaxTip = cms.double(0.5),
+          quadrupletMaxZip = cms.double(12)
+        ),
+    #minz = cms.vdouble(
+    # -20.0, 0.0, -30.0, -22.0, 10.0, -30.0, -70.0, -70.0, -20.0, -22.0, 0.0, -30.0, -70.0, -70.0, -22.0, 15.0, -30.0, -70.0, -70.0, -22.0, -22.0, -22.0, -55.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -1000.0, -1000.0, -1000.0, -1000.0, 0.0, -55.0, 0.0, -55.0, -22.0, -22.0, -22.0, -22.0, 0.0, -55.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -30.0, 0.0 ,#),
+# phicuts Good Cuts for Trk DPGv7 TTbar PU
+#phiCuts = cms.vint32(
+#     522, 730, 730, 522, 730, 626, 626, 522, 522, 522, 626, 522, 1200, 1200, 626, 730, 626, 626, 522, 5000, 5000, 5000, 5000, 0, 5000, 0, 0, 0, 0, 5000, 5000, 5000, 5000, 0, 0, 5000, 5000, 0, 5000, 0, 5000, 5000, 5000, 5000, 5000, 0, 5000, 626, 0, 0, 0, 0, 522, 5000, 5000, 5000, 5000, 0, 0, 0, 0, 5000, 5000, 5000, 5000, 0, 5000, 5000, 0 ,
+                                               #),
+phiCuts = cms.vint32(
+     522, 730, 730, 522, 730, 626, 626, 522, 522, 522, 626, 522, 1200, 1200, 626, 730, 626, 626, 522, 2000, 2000, 2000, 2000,  2000, 2000, 2000, 2000, 2000, 2000, 2000,  2000,  2000, 2000, 2000, 2000, 2000, 2000, 626,  522, 2000, 2000, 2000, 2000,  2000, 2000, 2000, 2000, 2000, 2000),
+
+
+## Good Cuts for TTbar PU and No PU                                               
+#        phiCuts = cms.vint32( 522, 730, 730, 522, 730, 626, 626, 522, 522, 522, 626, 522, 1200, 1200, 626, 730, 626, 626, 522, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 626, 5000, 5000, 5000, 5000, 522, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000,
+#        ),
+#minz = cms.vdouble(
+#     -20.0, 0.0, -30.0, -22.0, 10.0, -30.0, -70.0, -70.0, -20.0, -22.0, 0.0, -30.0, -70.0, -70.0, -22.0, 15.0, -30.0, -70.0, -70.0, -22.0, -22.0, -22.0, -55.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -1000.0, -1000.0, -1000.0, -1000.0, 0.0, -55.0, 0.0, -55.0, -22.0, -22.0, -22.0, -22.0, 0.0, -55.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -70.0, -30.0, 0.0 ,
+                                               #),
+        # autoselect the alpaka backend
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    if hasattr(process, 'hltL2TauTagNNProducer'):
+        process.hltL2TauTagNNProducer = cms.EDProducer("L2TauNNProducerAlpakaStrip", **process.hltL2TauTagNNProducer.parameters_())
+    process.hltPixelTracksSoASerialSync = makeSerialClone(process.hltPixelTracksSoA,
+        pixelRecHitSrc = 'hltSiPixelRecHitsSoASerialSync'
+    )
+    
+    process.hltPixelTracks = cms.EDProducer("PixelTrackProducerFromSoAAlpakaPhase1Strip",
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        minNumberOfHits = cms.int32(0),
+        minQuality = cms.string('loose'),
+        pixelRecHitLegacySrc = cms.InputTag("hltSiPixelRecHits"),
+        trackSrc = cms.InputTag("hltPixelTracksSoA"),
+        useStripHits = cms.bool(True), 
+        hitModuleStartSrc = cms.InputTag("hltSiPixelRecHitsSoA"),     
+        stripRecHitLegacySrc = cms.InputTag('hltSiStripMatchedRecHitsFull', 'matchedRecHit'),
+        mightGet = cms.optional.untracked.vstring
+    )
+    process.hltESPTTRHBuilderPixelOnly = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
+        ComponentName = cms.string('hltESPTTRHBuilderPixelOnly'),
+        ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+        Matcher = cms.string('StandardMatcher'),
+        Phase2StripCPE = cms.string(''),
+        PixelCPE = cms.string('hltESPPixelCPEGeneric'),
+        StripCPE = cms.string('hltESPStripCPEfromTrackAngle'),
+        appendToDataLabel = cms.string('')
+    )
+                
+    process.HLTRecoPixelTracksTask = cms.ConditionalTask(
+        process.hltPixelTracksSoA,
+        process.hltPixelTracks,
+    )
+
+    process.hltPixelTracksSerialSync = process.hltPixelTracks.clone(
+        pixelRecHitLegacySrc = cms.InputTag("hltSiPixelRecHitsSerialSync"),
+        hitModuleStartSrc = cms.InputTag("hltSiPixelRecHitsSoASerialSync"),     
+        trackSrc = cms.InputTag("hltPixelTracksSoASerialSync")
+    )
+
+    process.HLTRecoPixelTracksCPUSerialTask = cms.ConditionalTask(
+        process.hltPixelTracksSoASerialSync,
+        process.hltPixelTracksSerialSync,
+    )
+    process.HLTRecoPixelTracksSequence = cms.Sequence( process.HLTRecoPixelTracksTask )
+    process.HLTRecoPixelTracksCPUSerialSequence = cms.Sequence( process.HLTRecoPixelTracksCPUSerialTask )
+
+    process.HLTRecoPixelTracksSequence = cms.Sequence(process.hltPixelTracksSoA+process.hltPixelTracks)
+    if hasattr(process, 'hltPixelTracksSerialSync'):
+        process.HLTRecoPixelTracksCPUSerialSequence = cms.Sequence(process.hltPixelTracksSoASerialSync+process.hltPixelTracksSerialSync)
+
+    return process
+
+def customizeHLTforAlpakaPixelRecoVertexing(process):
+    '''Customisation to introduce the Pixel-Vertex Reconstruction in Alpaka
+    '''
+
+    #if not hasattr(process, 'HLTRecopixelvertexingSequence'):
+    #    return process
+#
+    ## do not apply the customisation if the menu is already using the alpaka pixel reconstruction
+    #for prod in producers_by_type(process, 'PixelVertexProducerAlpakaPhase1Strip@alpaka'):
+    #    return process
+
+    # alpaka EDProducer
+    # consumes
+    #  - TkSoADevice
+    # produces
+    #  - ZVertexDevice
+
+
+    
+    process.hltPixelVerticesSoA = cms.EDProducer('PixelVertexProducerAlpakaPhase1Strip@alpaka',
+        oneKernel = cms.bool(True),
+        useDensity = cms.bool(True),
+        useDBSCAN = cms.bool(False),
+        useIterative = cms.bool(False),
+        minT = cms.int32(2),
+        eps = cms.double(0.07),
+        errmax = cms.double(0.01),
+        chi2max = cms.double(9),
+        PtMin = cms.double(0.5),
+        PtMax = cms.double(75),
+        pixelTrackSrc = cms.InputTag('hltPixelTracksSoA'),
+        # autoselect the alpaka backend
+        alpaka = cms.untracked.PSet(
+            backend = cms.untracked.string('')
+        )
+    )
+
+    process.hltPixelVerticesSoASerialSync = makeSerialClone(process.hltPixelVerticesSoA,
+        pixelTrackSrc = 'hltPixelTracksSoASerialSync'
+    )
+
+    process.hltPixelVertices = cms.EDProducer("PixelVertexProducerFromSoAAlpaka",
+        TrackCollection = cms.InputTag("hltPixelTracks"),
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        src = cms.InputTag("hltPixelVerticesSoA")
+    )
+
+    process.hltPixelVerticesSerialSync = process.hltPixelVertices.clone(
+        TrackCollection = cms.InputTag("hltPixelTracksSerialSync"),
+        src = cms.InputTag("hltPixelVerticesSoASerialSync")
+    )
+
+    if hasattr(process, 'hltPixelVerticesCPU'):
+        del process.hltPixelVerticesCPU
+    if hasattr(process, 'hltPixelVerticesCPUOnly'):
+        del process.hltPixelVerticesCPUOnly
+    if hasattr(process, 'hltPixelVerticesFromGPU'):
+        del process.hltPixelVerticesFromGPU
+    if hasattr(process, 'hltPixelVerticesGPU'):
+        del process.hltPixelVerticesGPU
+
+    ## failsafe for fake menus
+    if hasattr(process, 'hltTrimmedPixelVertices'):
+        process.HLTRecopixelvertexingTask = cms.ConditionalTask(
+            process.HLTRecoPixelTracksTask,
+            process.hltPixelVerticesSoA,
+            process.hltPixelVertices,
+            process.hltTrimmedPixelVertices
+        )
+        process.HLTRecopixelvertexingSequence = cms.Sequence( process.HLTRecopixelvertexingTask )
+    if hasattr(process, 'hltTrimmedPixelVerticesSerialSync'):
+        process.HLTRecopixelvertexingCPUSerialTask = cms.ConditionalTask(
+            process.HLTRecoPixelTracksCPUSerialTask,
+            process.hltPixelVerticesSoASerialSync,
+            process.hltPixelVerticesSerialSync,
+            process.hltTrimmedPixelVerticesSerialSync
+        )
+        process.HLTRecopixelvertexingSequenceSerialSync = cms.Sequence( process.HLTRecopixelvertexingCPUSerialTask )
+
+    return process
+
+def customizeHLTforAlpakaPixelReco(process):
+    '''Customisation to introduce the Pixel Local+Track+Vertex Reconstruction in Alpaka
+    '''
+    process = customizeHLTforAlpakaPixelRecoLocal(process)
+    process = customizeHLTforAlpakaPixelRecoTracking(process)
+    process = customizeHLTforAlpakaPixelRecoVertexing(process)
+    process = customizeHLTforDQMGPUvsCPUPixel(process)
+
+    return process
+
+
+def customizeHLTforAlpakaStatus(process):
+
+    if not hasattr(process, 'statusOnGPU'):
+        return process
+
+    process.hltBackend = cms.EDProducer('AlpakaBackendProducer@alpaka')
+
+    insert_modules_before(process, process.statusOnGPU, process.hltBackend)
+
+    del process.statusOnGPU
+
+    process.hltStatusOnGPUFilter = cms.EDFilter('AlpakaBackendFilter',
+        producer = cms.InputTag('hltBackend', 'backend'),
+        backends = cms.vstring('CudaAsync', 'ROCmAsync')
+    )
+
+    insert_modules_before(process, process.statusOnGPUFilter, process.hltStatusOnGPUFilter)
+    insert_modules_before(process, ~process.statusOnGPUFilter, ~process.hltStatusOnGPUFilter)
+
+    del process.statusOnGPUFilter
+
+    return process
+
+
+def _replace_object(process, target, obj):
+    for container in itertools.chain(
+        process.sequences_().values(),
+        process.paths_().values(),
+        process.endpaths_().values()
+    ):
+        if target.label() in [bar for foo,bar in container.directDependencies()]:
+            try:
+                position = container.index(target)
+                container.insert(position, obj)
+                container.remove(target)
+            except ValueError:
+                container.associate(obj)
+                container.remove(target)
+
+    for container in itertools.chain(
+        process.tasks_().values(),
+        process.conditionaltasks_().values(),
+    ):
+        if target.label() in [bar for foo,bar in container.directDependencies()]:
+            container.add(obj)
+            container.remove(target)
+
+    return process
+
+def _rename_edmodule(process, oldModuleLabel, newModuleLabel, typeBlackList):
+    if not hasattr(process, oldModuleLabel) or hasattr(process, newModuleLabel) or oldModuleLabel == newModuleLabel:
+        return process
+    oldObj = getattr(process, oldModuleLabel)
+    if oldObj.type_() in typeBlackList:
+        return process
+    setattr(process, newModuleLabel, oldObj.clone())
+    newObj = getattr(process, newModuleLabel)
+    process = _replace_object(process, oldObj, newObj)
+    process.__delattr__(oldModuleLabel)
+    process = massReplaceInputTag(process, oldModuleLabel, newModuleLabel, False, True, False)
+    for outputModuleLabel in process.outputModules_():
+        outputModule = getattr(process, outputModuleLabel)
+        if not hasattr(outputModule, 'outputCommands'):
+            continue
+        for outputCmdIdx, outputCmd in enumerate(outputModule.outputCommands):
+            outputModule.outputCommands[outputCmdIdx] = outputCmd.replace(f'_{oldModuleLabel}_', f'_{newModuleLabel}_')
+    return process
+
+def _rename_edmodules(process, matchExpr, oldStr, newStr, typeBlackList):
+    for moduleDict in [process.producers_(), process.filters_(), process.analyzers_()]:
+        moduleLabels = list(moduleDict.keys())
+        for moduleLabel in moduleLabels:
+            if bool(re.match(matchExpr, moduleLabel)):
+                moduleLabelNew = moduleLabel.replace(oldStr, '') + newStr
+                process = _rename_edmodule(process, moduleLabel, moduleLabelNew, typeBlackList)
+    return process
+
+def _rename_container(process, oldContainerLabel, newContainerLabel):
+    if not hasattr(process, oldContainerLabel) or hasattr(process, newContainerLabel) or oldContainerLabel == newContainerLabel:
+        return process
+    oldObj = getattr(process, oldContainerLabel)
+    setattr(process, newContainerLabel, oldObj.copy())
+    newObj = getattr(process, newContainerLabel)
+    process = _replace_object(process, oldObj, newObj)
+    process.__delattr__(oldContainerLabel)
+    return process
+
+def _rename_containers(process, matchExpr, oldStr, newStr):
+    for containerName in itertools.chain(
+        process.sequences_().keys(),
+        process.tasks_().keys(),
+        process.conditionaltasks_().keys()
+    ):
+        if bool(re.match(matchExpr, containerName)):
+            containerNameNew = containerName.replace(oldStr, '') + newStr
+            process = _rename_container(process, containerName, containerNameNew)
+    return process
+
+def customizeHLTforAlpakaRename(process):
+    # mass renaming of EDModules and Sequences:
+    # if the label matches matchRegex, remove oldStr and append newStr
+    for matchRegex, oldStr, newStr in [
+        [".*Portable.*", "Portable", ""],
+        [".*SerialSync.*", "SerialSync", "SerialSync"],
+        [".*CPUSerial.*", "CPUSerial", "SerialSync"],
+        [".*CPUOnly.*", "CPUOnly", "SerialSync"],
+    ]:
+        process = _rename_edmodules(process, matchRegex, oldStr, newStr, ['HLTPrescaler'])
+        process = _rename_containers(process, matchRegex, oldStr, newStr)
+
+    return process
+
+
+def customizeHLTforAlpakaStripNoDoubletRecovery(process):
+    print("applying AlpakaCustomizer")
+    process = customizeHLTforAlpakaStatus(process)
+    process = customizeHLTforAlpakaPixelReco(process)
+    process = customizeHLTforAlpakaRename(process)
+
+    return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -63,12 +63,47 @@ def customiseHLTFor46647(process):
             delattr(prod, "TripletCollection")
 
     return process
+def configureFrameSoAESProducers(process):
+    """
+    Configures the appropriate FrameSoAESProducer based on the pixel topology (Phase1, Phase2, etc.).
+    If the corresponding producer is not found, it will add it to the process.
+    """
+    
+    # Define a mapping of pixel topology to corresponding ESProducer and component name
+    topology_to_es_producer = {
+        'Phase1': ('frameSoAESProducerPhase1', 'FrameSoAPhase1', 'FrameSoAESProducerPhase1@alpaka'),
+        'HIonPhase1': ('frameSoAESProducerHIonPhase1', 'FrameSoAPhase1HIonPhase1', 'FrameSoAESProducerHIonPhase1@alpaka'),
+        'Phase2': ('frameSoAESProducerPhase2', 'FrameSoAPhase2', 'FrameSoAESProducerPhase2@alpaka'),
+        'Phase1Strip': ('frameSoAESProducerPhase1Strip', 'FrameSoAPhase1Strip', 'FrameSoAESProducerPhase1Strip@alpaka'),
+    }
+
+    
+    for pixel_topology, (es_name, component_name, producer_type) in topology_to_es_producer.items():
+        if not hasattr(process, es_name):
+            # If the producer does not exist, create and add it
+            #print(f"Adding {es_name} with component name {component_name}")
+            setattr(process, es_name, cms.ESProducer(producer_type,
+                                                     ComponentName=cms.string(component_name),
+                                                     appendToDataLabel=cms.string('')))
+        else:
+            print(f"{es_name} already configured.")
+
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customiseForOffline(process)
-
+    # Pixel+Strip HLT
+    #from Configuration.ProcessModifiers.stripNtupletFit_cff import stripNtupletFit 
+    #from HLTrigger.Configuration.customizeHLTforAlpakaStripNoDoubletRecovery import customizeHLTforAlpakaStripNoDoubletRecovery
+    #(stripNtupletFit).makeProcessModifier(customizeHLTforAlpakaStripNoDoubletRecovery).apply(process)
+     
+    #from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
+    #from HLTrigger.Configuration.customizeHLTforAlpakaStrip import customizeHLTforAlpakaStrip
+    #(stripNtupletFit).makeProcessModifier(customizeHLTforAlpakaStrip).apply(process)
+    process = configureFrameSoAESProducers(process)
+     
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -77,7 +77,11 @@ def configureFrameSoAESProducers(process):
         'Phase1Strip': ('frameSoAESProducerPhase1Strip', 'FrameSoAPhase1Strip', 'FrameSoAESProducerPhase1Strip@alpaka'),
     }
 
-    
+    has_alpaka_named_module = any("Alpaka" in name for name in process.__dict__.keys())
+
+    if not has_alpaka_named_module:
+        print("No modules with 'Alpaka' in their names found in the process. Skipping configuration of FrameSoAESProducers.")
+        return process
     for pixel_topology, (es_name, component_name, producer_type) in topology_to_es_producer.items():
         if not hasattr(process, es_name):
             # If the producer does not exist, create and add it

--- a/RecoLocalTracker/ClusterParameterEstimator/BuildFile.xml
+++ b/RecoLocalTracker/ClusterParameterEstimator/BuildFile.xml
@@ -1,6 +1,13 @@
 <use name="FWCore/Utilities"/>
 <use name="TrackingTools/TrajectoryState"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="clhep"/>
+<use name="alpaka"/>
+<flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoADevice.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoADevice.h
@@ -1,0 +1,10 @@
+#ifndef RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoADevice_h
+#define RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoADevice_h
+
+#include "DataFormats/Portable/interface/PortableDeviceCollection.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoALayout.h"
+
+template <typename TDev>
+using FrameSoADevice = PortableDeviceCollection<FrameSoALayout,TDev>;
+
+#endif  // RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoADevice_h

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoAHost.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoAHost.h
@@ -1,0 +1,10 @@
+#ifndef RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoAHost_h
+#define RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoAHost_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoALayout.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+
+using FrameSoAHost = PortableHostCollection<FrameSoALayout>;
+
+#endif  // RecoLocalTracker_ClusterParameterEstimator_interface_FrameSoAHost_h

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoALayout.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoALayout.h
@@ -1,0 +1,19 @@
+#ifndef RecoLocalTracker_ClusterParameterEstimator_interface_FrameLayout_h
+#define RecoLocalTracker_ClusterParameterEstimator_interface_FrameLayout_h
+
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "DataFormats/GeometrySurface/interface/SOARotation.h"
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(FrameLayout,
+                    SOA_COLUMN(SOAFrame<float>, detFrame))
+
+using FrameSoALayout = FrameLayout<>;
+using FrameSoAView = FrameSoALayout::View;
+using FrameSoAConstView = FrameSoALayout::ConstView;
+
+#endif //RecoLocalTracker_ClusterParameterEstimator_interface_FrameLayout_h

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/alpaka/FrameSoACollection.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/alpaka/FrameSoACollection.h
@@ -1,0 +1,36 @@
+#ifndef RecoLocalTracker_ClusterParameterEstimator_interface_alpaka_FrameSoACollection_h
+#define RecoLocalTracker_ClusterParameterEstimator_interface_alpaka_FrameSoACollection_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoAHost.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoADevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+  using FrameSoACollection = FrameSoAHost;
+#else
+  using FrameSoACollection = FrameSoADevice<Device>;
+#endif
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToDevice<FrameSoAHost> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue, FrameSoAHost const& srcData) {
+      using TDevice = typename alpaka::trait::DevType<TQueue>::type;
+      FrameSoADevice<TDevice> dstData (srcData->metadata().size(), queue);
+      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      return dstData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif  // RecoLocalTracker_ClusterParameterEstimator_interface_alpaka_FrameSoACollection_h

--- a/RecoLocalTracker/ClusterParameterEstimator/plugins/BuildFile.xml
+++ b/RecoLocalTracker/ClusterParameterEstimator/plugins/BuildFile.xml
@@ -1,0 +1,12 @@
+<library file="alpaka/*.cc" name="RecoLocalTrackerClusterParameterEstimatorPluginsPortable">
+  <use name="alpaka"/>
+  <use name="DataFormats/Portable"/>
+  <use name="FWCore/Framework"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="RecoLocalTracker/Records"/>
+  <use name="DataFormats/TrackerCommon"/>
+  <use name="RecoLocalTracker/ClusterParameterEstimator"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoLocalTracker/ClusterParameterEstimator/plugins/alpaka/FrameSoAESProducer.cc
+++ b/RecoLocalTracker/ClusterParameterEstimator/plugins/alpaka/FrameSoAESProducer.cc
@@ -1,0 +1,124 @@
+#include <memory>
+#include <string>
+#include <alpaka/alpaka.hpp>
+#include <type_traits>
+
+#include "DataFormats/GeometrySurface/interface/SOARotation.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "Geometry/CommonTopologies/interface/TrackerGeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/CommonTopologies/interface/Topology.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "RecoLocalTracker/Records/interface/FrameSoARecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/alpaka/FrameSoACollection.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoAHost.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  template <typename TrackerTraits>
+  class FrameSoAESProducer : public ESProducer {
+
+    using Rotation = SOARotation<float>;
+    using Frame = SOAFrame<float>;
+
+  public:
+    FrameSoAESProducer(edm::ParameterSet const& iConfig);
+    std::unique_ptr<FrameSoAHost> produce(const FrameSoARecord& iRecord);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geometry_;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topology_;
+  };
+
+  using namespace edm;
+
+  template <typename TrackerTraits>
+  FrameSoAESProducer<TrackerTraits>::FrameSoAESProducer(const edm::ParameterSet& p)
+      : ESProducer(p) {
+    auto const& myname = p.getParameter<std::string>("ComponentName");
+
+    auto cc = setWhatProduced(this, myname);
+    geometry_ = cc.consumes();
+    topology_ = cc.consumes();
+  }
+
+  template <typename TrackerTraits>
+  std::unique_ptr<FrameSoAHost> FrameSoAESProducer<TrackerTraits>::produce(
+      const FrameSoARecord& iRecord) {
+
+    const TrackerGeometry* geometry = &iRecord.get(geometry_); 
+    const TrackerTopology* topology = &iRecord.get(topology_); 
+
+    auto const& detUnits = geometry->detUnits();
+
+    auto product = std::make_unique<FrameSoAHost>(TrackerTraits::numberOfModules, cms::alpakatools::host());
+    
+    if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1Strip>) {
+      int i = 0;
+      for (auto layer : phase1PixelStripTopology::layerData) {
+        auto step = layer.isStrip2D ? 2 : 1;
+        for (auto j = layer.start; j != layer.end; j += step) {
+          auto& s = layer.isStrip2D ? 
+            geometry->idToDet(topology->glued(detUnits[i]->geographicalId()))->surface() :
+            detUnits[j]->surface();
+          product->view()[i].detFrame() = Frame(s.position().x(), s.position().y(), s.position().z(), s.rotation()); 
+          ++i;
+        }
+      }
+    }
+    else {
+      constexpr auto n_detectors = TrackerTraits::numberOfModules; // converting only up to the modules used in the CA topology
+
+      assert(n_detectors < detUnits.size()); //still there shouldn't be more modules than what we have from the TrackerGeometry
+
+      for (unsigned i = 0; i != n_detectors; ++i) {
+        auto det = detUnits[i];
+        auto vv = det->surface().position();
+        auto rr = Rotation(det->surface().rotation());
+        product->view()[i].detFrame() =  Frame(vv.x(), vv.y(), vv.z(), rr); 
+      }
+    }
+
+
+    return product;
+  }
+
+  template <typename TrackerTraits>
+  void FrameSoAESProducer<TrackerTraits>::fillDescriptions(
+      edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    std::string name = "FrameSoAPhase1";
+    name += TrackerTraits::nameModifier;
+    desc.add<std::string>("ComponentName", name);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  using FrameSoAESProducerPhase1 = FrameSoAESProducer<pixelTopology::Phase1>;
+  using FrameSoAESProducerPhase2 = FrameSoAESProducer<pixelTopology::Phase2>;
+  using FrameSoAESProducerHIonPhase1 = FrameSoAESProducer<pixelTopology::HIonPhase1>;
+  using FrameSoAESProducerPhase1Strip = FrameSoAESProducer<pixelTopology::Phase1Strip>; 
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(FrameSoAESProducerPhase1);
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(FrameSoAESProducerPhase1Strip);
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(FrameSoAESProducerPhase2);
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(FrameSoAESProducerHIonPhase1);

--- a/RecoLocalTracker/ClusterParameterEstimator/src/ES_FrameSoA.cc
+++ b/RecoLocalTracker/ClusterParameterEstimator/src/ES_FrameSoA.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoAHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(FrameSoAHost);

--- a/RecoLocalTracker/ClusterParameterEstimator/src/alpaka/ES_FrameSoA.cc
+++ b/RecoLocalTracker/ClusterParameterEstimator/src/alpaka/ES_FrameSoA.cc
@@ -1,0 +1,4 @@
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/alpaka/FrameSoACollection.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+TYPELOOKUP_ALPAKA_DATA_REG(FrameSoACollection);

--- a/RecoLocalTracker/Records/BuildFile.xml
+++ b/RecoLocalTracker/Records/BuildFile.xml
@@ -8,3 +8,4 @@
 <use name="boost"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CalibTracker/Records"/>
+<flags ALPAKA_BACKENDS="1"/>

--- a/RecoLocalTracker/Records/interface/FrameSoARecord.h
+++ b/RecoLocalTracker/Records/interface/FrameSoARecord.h
@@ -1,0 +1,11 @@
+#ifndef RecoLocalTracker_Records_FrameSoARecord_h
+#define RecoLocalTracker_Records_FrameSoARecord_h
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "FWCore/Utilities/interface/mplVector.h"
+
+class FrameSoARecord :public edm::eventsetup::DependentRecordImplementation<FrameSoARecord, edm::mpl::Vector<TrackerDigiGeometryRecord, TrackerTopologyRcd> > {};
+#endif

--- a/RecoLocalTracker/Records/src/FrameSoARecord.cc
+++ b/RecoLocalTracker/Records/src/FrameSoARecord.cc
@@ -1,0 +1,5 @@
+#include "RecoLocalTracker/Records/interface/FrameSoARecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+EVENTSETUP_RECORD_REG(FrameSoARecord);

--- a/RecoLocalTracker/SiPixelRecHits/interface/alpaka/PixelCPEFastParamsCollection.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/alpaka/PixelCPEFastParamsCollection.h
@@ -8,6 +8,7 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsDevice.h"
 #include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 // TODO: The class is created via inheritance of the PortableCollection.
 // This is generally discouraged, and should be done via composition.

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEESProducers_cff.py
@@ -20,10 +20,14 @@ from RecoLocalTracker.SiPixelRecHits.pixelCPEFastESProducerHIonPhase1_cfi import
 from CalibTracker.SiPixelESProducers.SiPixelTemplateDBObjectESProducer_cfi import *
 from CalibTracker.SiPixelESProducers.SiPixel2DTemplateDBObjectESProducer_cfi import *
 
+# Alpaka specic
 def _addProcessCPEsAlpaka(process):
     process.load("RecoLocalTracker.SiPixelRecHits.pixelCPEFastParamsESProducerAlpakaPhase1_cfi")
     process.load("RecoLocalTracker.SiPixelRecHits.pixelCPEFastParamsESProducerAlpakaPhase2_cfi")
     process.load("RecoLocalTracker.SiPixelRecHits.pixelCPEFastParamsESProducerAlpakaHIonPhase1_cfi")
+    process.load("RecoLocalTracker.ClusterParameterEstimator.frameSoAESProducerPhase1Strip_cfi")
+    process.load("RecoLocalTracker.ClusterParameterEstimator.frameSoAESProducerPhase1_cfi")
+    process.load("RecoLocalTracker.ClusterParameterEstimator.frameSoAESProducerPhase2_cfi")
 
 modifyConfigurationForAlpakaCPEs_ = alpaka.makeProcessModifier(_addProcessCPEsAlpaka)
 

--- a/RecoLocalTracker/SiPixelRecHits/src/ES_PixelCPEFastParams.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/ES_PixelCPEFastParams.cc
@@ -1,6 +1,6 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h"
 #include "FWCore/Utilities/interface/typelookup.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 using PixelCPEFastParamsHostPhase1 = PixelCPEFastParamsHost<pixelTopology::Phase1>;
 using PixelCPEFastParamsHostHIonPhase1 = PixelCPEFastParamsHost<pixelTopology::HIonPhase1>;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -4,7 +4,8 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFast.h"
@@ -529,3 +530,4 @@ void PixelCPEFast<TrackerTraits>::fillPSetDescription(edm::ParameterSetDescripti
 template class PixelCPEFast<pixelTopology::Phase1>;
 template class PixelCPEFast<pixelTopology::Phase2>;
 template class PixelCPEFast<pixelTopology::HIonPhase1>;
+template class PixelCPEFast<pixelTopology::Phase1Strip>;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
@@ -1,6 +1,6 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsDevice.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 
 using PixelCPEFastParamsPhase1 = PixelCPEFastParamsDevice<alpaka_common::DevHost, pixelTopology::Phase1>;
 using PixelCPEFastParamsHIonPhase1 = PixelCPEFastParamsDevice<alpaka_common::DevHost, pixelTopology::HIonPhase1>;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -4,10 +4,11 @@
 #include "DataFormats/GeometrySurface/interface/SOARotation.h"
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+// #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h"
 
 //-----------------------------------------------------------------------------

--- a/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/GeometryCommonDetAlgo"/>
 <use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackingRecHitSoA"/>
 <use name="DataFormats/SiStripCluster"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="RecoLocalTracker/Records"/>
@@ -14,6 +15,7 @@
 <use name="CalibTracker/Records"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="vdt_headers"/>
+<flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -2,7 +2,8 @@
 #define RecoLocalTracker_SiStripRecHitConverter_StripCPEfromTrackAngle_H
 
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
-
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
 class StripCPEfromTrackAngle : public StripCPE {
 private:
   using StripCPE::localParameters;

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/BuildFile.xml
@@ -1,5 +1,14 @@
 <use name="RecoLocalTracker/SiStripRecHitConverter"/>
 <use name="CalibTracker/Records"/>
+<use name="DataFormats/TrackingRecHitSoA"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
 <library file="*.cc" name="RecoLocalTrackerSiStripRecHitConverterPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>
+<library file="alpaka/*.cc" name="RecoLocalTrackerRecHitConverterPluginsPortable">
+  <use name="alpaka"/>
+  <use name="DataFormats/Portable"/>
+  <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/SiStripRecHitConverter.cc
@@ -17,6 +17,7 @@ SiStripRecHitConverter::SiStripRecHitConverter(edm::ParameterSet const& conf)
   produces<SiStripRecHit2DCollection>(rphiRecHitsTag);
   produces<SiStripRecHit2DCollection>(stereoRecHitsTag);
   if (doMatching) {
+    //std::cout << "Running the module that produces strip hits" << std::endl;
     produces<SiStripMatchedRecHit2DCollection>(matchedRecHitsTag);
     produces<SiStripRecHit2DCollection>(rphiRecHitsTag + "Unmatched");
     produces<SiStripRecHit2DCollection>(stereoRecHitsTag + "Unmatched");
@@ -49,10 +50,12 @@ void SiStripRecHitConverter::produce(edm::Event& e, const edm::EventSetup& es) {
   LogDebug("SiStripRecHitConverter") << "found\n"
                                      << output.rphi->dataSize() << "  clusters in mono detectors\n"
                                      << output.stereo->dataSize() << "  clusters in partners stereo detectors\n";
-
+  
   e.put(std::move(output.rphi), rphiRecHitsTag);
   e.put(std::move(output.stereo), stereoRecHitsTag);
   if (doMatching) {
+    //std::cout << "found\n"
+    //        << output.matched->dataSize() << "  clusters in matched detectors\n";
     e.put(std::move(output.matched), matchedRecHitsTag);
     e.put(std::move(output.rphiUnmatched), rphiRecHitsTag + "Unmatched");
     e.put(std::move(output.stereoUnmatched), stereoRecHitsTag + "Unmatched");

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoA.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoA.cc
@@ -1,0 +1,256 @@
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpot/interface/alpaka/BeamSpotDevice.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "RecoLocalTracker/Records/interface/PixelCPEFastParamsRecord.h"
+
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/alpaka/PixelCPEFastParamsCollection.h"
+
+// #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/GluedGeomDet.h"
+
+#include "SiStripRecHitSoAKernel.h"
+#include "alpaka/mem/view/Traits.hpp"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+template <typename TrackerTraits>
+class SiStripRecHitSoA : public stream::SynchronizingEDProducer<> {
+
+  using PixelBase = typename TrackerTraits::PixelBase;
+
+  using StripHits = TrackingRecHitsSoACollection<TrackerTraits>;
+  using PixelHits = TrackingRecHitsSoACollection<PixelBase>;
+
+  using StripHitsHost = TrackingRecHitHost<TrackerTraits>;
+  using PixelHitsHost = TrackingRecHitHost<PixelBase>;
+
+  using Algo = hitkernels::SiStripRecHitSoAKernel<TrackerTraits>;
+
+public:
+  explicit SiStripRecHitSoA(const edm::ParameterSet& iConfig);
+  ~SiStripRecHitSoA() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override {};
+  void produce(device::Event& iEvent, device::EventSetup const& iSetup) override;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> recHitToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  const edm::EDGetTokenT<PixelHitsHost> pixelRecHitSoAToken_;
+
+  const device::EDPutToken<StripHits> stripSoA_;
+  const edm::EDPutTokenT<std::vector<uint32_t>> hmsToken_;
+
+  const Algo Algo_;
+};
+
+template <typename TrackerTraits>
+SiStripRecHitSoA<TrackerTraits>::SiStripRecHitSoA(const edm::ParameterSet& iConfig)
+    : geomToken_(esConsumes()),
+      recHitToken_{consumes(iConfig.getParameter<edm::InputTag>("stripRecHitSource"))},
+      //beamSpotToken(consumes(edm::InputTag("offlineBeamSpot"))),
+      beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      pixelRecHitSoAToken_{consumes(iConfig.getParameter<edm::InputTag>("pixelRecHitSoASource"))},
+      stripSoA_{produces()},
+      hmsToken_{produces()}
+{
+  
+}
+
+template <typename TrackerTraits>
+void SiStripRecHitSoA<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("stripRecHitSource", edm::InputTag("siStripMatchedRecHits", "matchedRecHit"));
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<edm::InputTag>("pixelRecHitSoASource", edm::InputTag("siPixelRecHitsPreSplittingAlpaka"));
+  descriptions.addWithDefaultLabel(desc);
+
+  // desc.setUnknown();
+  // descriptions.addDefault(desc);
+}
+
+template <typename TrackerTraits>
+void SiStripRecHitSoA<TrackerTraits>::produce(device::Event& iEvent, device::EventSetup const& iSetup) {
+
+  // Get the objects that we need
+  const TrackerGeometry* trackerGeometry = &iSetup.getData(geomToken_);
+  auto const& stripHits = iEvent.get(recHitToken_);
+  auto const& pixelHitsHost = iEvent.get(pixelRecHitSoAToken_);
+  auto& bs = iEvent.get(beamSpotToken_);
+
+  // Count strip hits
+  size_t nStripHits = 0;
+  //std::cout << "number of modules: " << TrackerTraits::numberOfModules << std::endl;
+  //std::cout << "stripHits size: " << stripHits.size() << std::endl;
+  for (const auto& detSet : stripHits) {
+    const GluedGeomDet* det = static_cast<const GluedGeomDet*>(trackerGeometry->idToDet(detSet.detId()));
+    //std::cout << "detSet.detId()" << detSet.detId() << std::endl;
+    //std::cout << "det->stereoDet()->index()" << det->stereoDet()->index() << std::endl;
+    if (TrackerTraits::mapIndex(det->stereoDet()->index()) < TrackerTraits::numberOfModules)
+        nStripHits += detSet.size();
+  } 
+
+  size_t nPixelHits = pixelHitsHost.view().metadata().size();
+
+  //std::cout << "nStripHits = " << nStripHits << std::endl;
+  //std::cout << "nPixelHits = " << nPixelHits << std::endl;
+
+  // HostView<const PixelHits, PixelHitsHost> pixelHitsHostView(pixelHits, iEvent.queue());
+  // PixelHitsHost& pixelHitsHost = pixelHitsHostView.get();
+  // PixelHitsHost pixelHitsHost(nPixelHits, iEvent.queue());
+
+  // alpaka::memcpy(iEvent.queue(), pixelHitsHost.buffer(), pixelHits.buffer());
+
+  StripHitsHost allHitsHost(
+    iEvent.queue(),
+    nPixelHits + nStripHits
+  );
+  
+  // Copy pixel data
+  std::copy(pixelHitsHost.view().xLocal(), pixelHitsHost.view().xLocal() + nPixelHits, allHitsHost.view().xLocal());
+  std::copy(pixelHitsHost.view().yLocal(), pixelHitsHost.view().yLocal() + nPixelHits, allHitsHost.view().yLocal());
+  std::copy(pixelHitsHost.view().xerrLocal(), pixelHitsHost.view().xerrLocal() + nPixelHits, allHitsHost.view().xerrLocal());
+  std::copy(pixelHitsHost.view().yerrLocal(), pixelHitsHost.view().yerrLocal() + nPixelHits, allHitsHost.view().yerrLocal());
+  std::copy(pixelHitsHost.view().xGlobal(), pixelHitsHost.view().xGlobal() + nPixelHits, allHitsHost.view().xGlobal());
+  std::copy(pixelHitsHost.view().yGlobal(), pixelHitsHost.view().yGlobal() + nPixelHits, allHitsHost.view().yGlobal());
+  std::copy(pixelHitsHost.view().zGlobal(), pixelHitsHost.view().zGlobal() + nPixelHits, allHitsHost.view().zGlobal());
+  std::copy(pixelHitsHost.view().rGlobal(), pixelHitsHost.view().rGlobal() + nPixelHits, allHitsHost.view().rGlobal());
+  std::copy(pixelHitsHost.view().iphi(), pixelHitsHost.view().iphi() + nPixelHits, allHitsHost.view().iphi());
+  std::copy(pixelHitsHost.view().chargeAndStatus(), pixelHitsHost.view().chargeAndStatus() + nPixelHits, allHitsHost.view().chargeAndStatus());
+  std::copy(pixelHitsHost.view().clusterSizeX(), pixelHitsHost.view().clusterSizeX() + nPixelHits, allHitsHost.view().clusterSizeX());
+  std::copy(pixelHitsHost.view().clusterSizeY(), pixelHitsHost.view().clusterSizeY() + nPixelHits, allHitsHost.view().clusterSizeY());
+  std::copy(pixelHitsHost.view().detectorIndex(), pixelHitsHost.view().detectorIndex() + nPixelHits, allHitsHost.view().detectorIndex());
+
+  std::copy(pixelHitsHost.view().phiBinnerStorage(), pixelHitsHost.view().phiBinnerStorage() + nPixelHits, allHitsHost.view().phiBinnerStorage());
+
+  allHitsHost.view().offsetBPIX2() = pixelHitsHost.view().offsetBPIX2();
+
+  auto& hitsModuleStart = allHitsHost.view().hitsModuleStart();
+
+  std::copy(
+    pixelHitsHost.view().hitsModuleStart().begin(),
+    pixelHitsHost.view().hitsModuleStart().end(),
+    hitsModuleStart.begin()
+  );  
+
+  std::map<size_t, edmNew::DetSet<SiStripMatchedRecHit2D>> mappedModuleHits;
+
+  // Loop over strip RecHits
+  for (auto detSet : stripHits) {
+
+    const GluedGeomDet* det = static_cast<const GluedGeomDet*>(trackerGeometry->idToDet(detSet.detId()));
+    size_t index = TrackerTraits::mapIndex(det->stereoDet()->index());
+    
+    if (index >= TrackerTraits::numberOfModules)
+      continue;
+
+    mappedModuleHits[index] = detSet;
+  }
+
+  size_t i = 0;
+  size_t lastIndex = TrackerTraits::numberOfPixelModules;
+
+  for (auto& [index, detSet] : mappedModuleHits) {
+
+    const GluedGeomDet* det = static_cast<const GluedGeomDet*>(trackerGeometry->idToDet(detSet.detId()));
+
+    // no hits since lastIndex: hitsModuleStart[lastIndex:index] = hitsModuleStart[lastIndex]
+    for (auto j = lastIndex + 1; j < index + 1; ++j)
+      hitsModuleStart[j] = hitsModuleStart[lastIndex];
+
+    hitsModuleStart[index + 1] = hitsModuleStart[index] + detSet.size();
+    lastIndex = index + 1;
+
+    for (const auto& recHit : detSet) {
+      allHitsHost.view()[nPixelHits + i].xLocal() = recHit.localPosition().x();
+      allHitsHost.view()[nPixelHits + i].yLocal() = recHit.localPosition().y();
+      allHitsHost.view()[nPixelHits + i].xerrLocal() = recHit.localPositionError().xx();
+      allHitsHost.view()[nPixelHits + i].yerrLocal() = recHit.localPositionError().yy();
+      auto globalPosition = det->toGlobal(recHit.localPosition());
+      double gx = globalPosition.x() - bs.x0();
+      double gy = globalPosition.y() - bs.y0();
+      double gz = globalPosition.z() - bs.z0();
+      allHitsHost.view()[nPixelHits + i].xGlobal() = gx;
+      allHitsHost.view()[nPixelHits + i].yGlobal() = gy;
+      allHitsHost.view()[nPixelHits + i].zGlobal() = gz;
+      allHitsHost.view()[nPixelHits + i].rGlobal() = sqrt(gx * gx + gy * gy);
+      allHitsHost.view()[nPixelHits + i].iphi() = unsafe_atan2s<7>(gy, gx);
+      // allHitsHost.view()[nPixelHits + i].chargeAndStatus().charge = ?
+      // allHitsHost.view()[nPixelHits + i].chargeAndStatus().status = ?
+      // allHitsHost.view()[nPixelHits + i].clusterSizeX() = ?
+      // allHitsHost.view()[nPixelHits + i].clusterSizeY() = ?
+      allHitsHost.view()[nPixelHits + i].detectorIndex() = index;
+      // ???
+      ++i;
+    }
+    
+  }
+
+  for (auto j = lastIndex + 1; j < TrackerTraits::numberOfModules + 1; ++j)
+    hitsModuleStart[j] = hitsModuleStart[lastIndex];
+
+
+  for (auto layer = 0U; layer < TrackerTraits::numberOfLayers + 1; ++layer) {
+    allHitsHost.view().hitsLayerStart()[layer] = 
+      hitsModuleStart[TrackerTraits::layerStart[layer]];
+  }
+
+  iEvent.emplace(hmsToken_, std::vector<uint32_t>(hitsModuleStart.begin(), hitsModuleStart.end()));
+
+  iEvent.emplace(stripSoA_, Algo_.fillHitsAsync(allHitsHost, iEvent.queue()));
+
+  //std::cout << "produce done" << std::endl;
+  
+}
+  using SiStripRecHitSoAPhase1 = SiStripRecHitSoA<pixelTopology::Phase1Strip>;
+}
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(SiStripRecHitSoAPhase1);
+
+// using SiPixelRecHitSoAFromLegacyPhase2 = SiStripRecHitSoA<pixelTopology::Phase2>;
+// DEFINE_FWK_MODULE(SiPixelRecHitSoAFromLegacyPhase2);

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoAKernel.dev.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoAKernel.dev.cc
@@ -1,0 +1,73 @@
+// C++ headers
+#include <algorithm>
+#include <numeric>
+
+// Alpaka headers
+#include <alpaka/alpaka.hpp>
+
+// CMSSW headers
+#include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "SiStripRecHitSoAKernel.h"
+
+//#define GPU_DEBUG
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  using namespace cms::alpakatools;
+
+  namespace hitkernels {
+
+    template <typename TrackerTraits>
+    TrackingRecHitsSoACollection<TrackerTraits> SiStripRecHitSoAKernel<TrackerTraits>::fillHitsAsync(
+        StripHitsHost const& hits_h,
+        Queue queue) const {
+          
+      TrackingRecHitsSoACollection<TrackerTraits> hits_d(queue, hits_h.nHits(), hits_h.offsetBPIX2(), hits_h.hitsModuleStart());
+      alpaka::memcpy(queue, hits_d.buffer(), hits_h.buffer());
+
+      // assuming full warp of threads is better than a smaller number...
+      if (hits_h.nHits()) {
+        
+        constexpr auto nLayers = TrackerTraits::numberOfLayers;
+
+        typename TrackingRecHitSoA<TrackerTraits>::PhiBinnerView hrv_d;
+        hrv_d.assoc = &(hits_d.view().phiBinner());
+        hrv_d.offSize = -1;
+        hrv_d.offStorage = nullptr;
+        hrv_d.contentSize = hits_h.nHits();
+        hrv_d.contentStorage = hits_d.view().phiBinnerStorage();
+
+        // cms::alpakatools::fillManyFromVector<Acc1D>(&(hits_d.view().phiBinner()),
+        //                                             nLayers,
+        //                                             hits_d.view().iphi(),
+        //                                             hits_d.view().hitsLayerStart().data(),
+        //                                             hits_h.nHits(),
+        //                                             (uint32_t)256,
+        //                                             queue);
+        cms::alpakatools::fillManyFromVector<Acc1D>(&(hits_d.view().phiBinner()),
+                                                      hrv_d,
+                                                      nLayers,
+                                                      hits_d.view().iphi(),
+                                                      hits_d.view().hitsLayerStart().data(),
+                                                      hits_h.nHits(),
+                                                      (uint32_t)256,
+                                                      queue);
+
+#ifdef GPU_DEBUG
+          alpaka::wait(queue);
+#endif
+        }
+
+#ifdef GPU_DEBUG
+      alpaka::wait(queue);
+      std::cout << "SiStripRecHitSoAKernel -> DONE!" << std::endl;
+#endif
+
+      return hits_d;
+    }
+
+    template class SiStripRecHitSoAKernel<pixelTopology::Phase1Strip>;
+
+  }  // namespace hitkernels
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoAKernel.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/alpaka/SiStripRecHitSoAKernel.h
@@ -1,0 +1,46 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_SiStripRecHitSoAKernel_h
+#define RecoLocalTracker_SiPixelRecHits_SiStripRecHitSoAKernel_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersSoACollection.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace hitkernels {
+    using namespace cms::alpakatools;
+
+    template <typename TrackerTraits>
+    class SiStripRecHitSoAKernel {
+
+      using StripHits = TrackingRecHitsSoACollection<TrackerTraits>;
+      using StripHitsHost = TrackingRecHitHost<TrackerTraits>;
+
+    public:
+      SiStripRecHitSoAKernel() = default;
+      ~SiStripRecHitSoAKernel() = default;
+
+      SiStripRecHitSoAKernel(const SiStripRecHitSoAKernel&) = delete;
+      SiStripRecHitSoAKernel(SiStripRecHitSoAKernel&&) = delete;
+      SiStripRecHitSoAKernel& operator=(const SiStripRecHitSoAKernel&) = delete;
+      SiStripRecHitSoAKernel& operator=(SiStripRecHitSoAKernel&&) = delete;
+
+      StripHits fillHitsAsync(
+        StripHitsHost const& hits_h,
+        Queue queue) const;
+
+    };
+  }  // namespace pixelgpudetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelRecHits_SiStripRecHitSoAKernel_h

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpakaStrip.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpakaStrip.cc
@@ -1,0 +1,824 @@
+/*
+ * \class L2TauTagProducer
+ *
+ * L2Tau identification using Convolutional NN.
+ *
+ * \author Valeria D'Amante, Università di Siena and INFN Pisa
+ *         Konstantin Androsov, EPFL and ETHZ
+*/
+#include <memory>
+#include <boost/property_tree/json_parser.hpp>
+#include <cmath>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/isFinite.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalDetId/interface/EcalDetIdCollections.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
+#include "DataFormats/HcalRecHit/interface/HFRecHit.h"
+#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
+#include "RecoTracker/PixelTrackFitting/interface/FitUtils.h"
+#include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCurvilinear.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+
+#include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
+#include "DataFormats/TrackSoA/interface/TracksHost.h"
+#include "DataFormats/VertexSoA/interface/ZVertexHost.h"
+
+namespace L2TauTagNNv1 {
+  constexpr int nCellEta = 5;
+  constexpr int nCellPhi = 5;
+  constexpr int nVars = 31;
+  constexpr float dR_max = 0.5;
+  enum class NNInputs {
+    nVertices = 0,
+    l1Tau_pt,
+    l1Tau_eta,
+    l1Tau_hwIso,
+    EcalEnergySum,
+    EcalSize,
+    EcalEnergyStdDev,
+    EcalDeltaEta,
+    EcalDeltaPhi,
+    EcalChi2,
+    EcalEnergySumForPositiveChi2,
+    EcalSizeForPositiveChi2,
+    HcalEnergySum,
+    HcalSize,
+    HcalEnergyStdDev,
+    HcalDeltaEta,
+    HcalDeltaPhi,
+    HcalChi2,
+    HcalEnergySumForPositiveChi2,
+    HcalSizeForPositiveChi2,
+    PatatrackPtSum,
+    PatatrackSize,
+    PatatrackSizeWithVertex,
+    PatatrackPtSumWithVertex,
+    PatatrackChargeSum,
+    PatatrackDeltaEta,
+    PatatrackDeltaPhi,
+    PatatrackChi2OverNdof,
+    PatatrackNdof,
+    PatatrackDxy,
+    PatatrackDz
+  };
+
+  const std::map<NNInputs, std::string> varNameMap = {
+      {NNInputs::nVertices, "nVertices"},
+      {NNInputs::l1Tau_pt, "l1Tau_pt"},
+      {NNInputs::l1Tau_eta, "l1Tau_eta"},
+      {NNInputs::l1Tau_hwIso, "l1Tau_hwIso"},
+      {NNInputs::EcalEnergySum, "EcalEnergySum"},
+      {NNInputs::EcalSize, "EcalSize"},
+      {NNInputs::EcalEnergyStdDev, "EcalEnergyStdDev"},
+      {NNInputs::EcalDeltaEta, "EcalDeltaEta"},
+      {NNInputs::EcalDeltaPhi, "EcalDeltaPhi"},
+      {NNInputs::EcalChi2, "EcalChi2"},
+      {NNInputs::EcalEnergySumForPositiveChi2, "EcalEnergySumForPositiveChi2"},
+      {NNInputs::EcalSizeForPositiveChi2, "EcalSizeForPositiveChi2"},
+      {NNInputs::HcalEnergySum, "HcalEnergySum"},
+      {NNInputs::HcalSize, "HcalSize"},
+      {NNInputs::HcalEnergyStdDev, "HcalEnergyStdDev"},
+      {NNInputs::HcalDeltaEta, "HcalDeltaEta"},
+      {NNInputs::HcalDeltaPhi, "HcalDeltaPhi"},
+      {NNInputs::HcalChi2, "HcalChi2"},
+      {NNInputs::HcalEnergySumForPositiveChi2, "HcalEnergySumForPositiveChi2"},
+      {NNInputs::HcalSizeForPositiveChi2, "HcalSizeForPositiveChi2"},
+      {NNInputs::PatatrackPtSum, "PatatrackPtSum"},
+      {NNInputs::PatatrackSize, "PatatrackSize"},
+      {NNInputs::PatatrackSizeWithVertex, "PatatrackSizeWithVertex"},
+      {NNInputs::PatatrackPtSumWithVertex, "PatatrackPtSumWithVertex"},
+      {NNInputs::PatatrackChargeSum, "PatatrackChargeSum"},
+      {NNInputs::PatatrackDeltaEta, "PatatrackDeltaEta"},
+      {NNInputs::PatatrackDeltaPhi, "PatatrackDeltaPhi"},
+      {NNInputs::PatatrackChi2OverNdof, "PatatrackChi2OverNdof"},
+      {NNInputs::PatatrackNdof, "PatatrackNdof"},
+      {NNInputs::PatatrackDxy, "PatatrackDxy"},
+      {NNInputs::PatatrackDz, "PatatrackDz"}};
+}  // namespace L2TauTagNNv1
+namespace {
+  inline float& getCellImpl(
+      tensorflow::Tensor& cellGridMatrix, int tau_idx, int phi_idx, int eta_idx, L2TauTagNNv1::NNInputs NNInput_idx) {
+    return cellGridMatrix.tensor<float, 4>()(tau_idx, phi_idx, eta_idx, static_cast<int>(NNInput_idx));
+  }
+}  // namespace
+struct normDictElement {
+  float mean;
+  float std;
+  float min;
+  float max;
+};
+
+struct L2TauNNProducerAlpakaStripCacheData {
+  L2TauNNProducerAlpakaStripCacheData() : graphDef(nullptr), session(nullptr) {}
+  tensorflow::GraphDef* graphDef;
+  tensorflow::Session* session;
+  std::vector<normDictElement> normVec;
+};
+
+class L2TauNNProducerAlpakaStrip : public edm::stream::EDProducer<edm::GlobalCache<L2TauNNProducerAlpakaStripCacheData>> {
+public:
+  using TracksHost = pixelTrack::TracksHostPhase1Strip;
+
+  struct caloRecHitCollections {
+    const HBHERecHitCollection* hbhe;
+    const HORecHitCollection* ho;
+    const EcalRecHitCollection* eb;
+    const EcalRecHitCollection* ee;
+    const CaloGeometry* geometry;
+  };
+
+  struct InputDescTau {
+    std::string CollectionName;
+    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
+  };
+
+  static constexpr float dR2_max = L2TauTagNNv1::dR_max * L2TauTagNNv1::dR_max;
+  static constexpr float dEta_width = 2 * L2TauTagNNv1::dR_max / static_cast<float>(L2TauTagNNv1::nCellEta);
+  static constexpr float dPhi_width = 2 * L2TauTagNNv1::dR_max / static_cast<float>(L2TauTagNNv1::nCellPhi);
+
+  explicit L2TauNNProducerAlpakaStrip(const edm::ParameterSet&, const L2TauNNProducerAlpakaStripCacheData*);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  static std::unique_ptr<L2TauNNProducerAlpakaStripCacheData> initializeGlobalCache(const edm::ParameterSet&);
+  static void globalEndJob(L2TauNNProducerAlpakaStripCacheData*);
+
+private:
+  void checknan(tensorflow::Tensor& tensor, int debugLevel);
+  void standardizeTensor(tensorflow::Tensor& tensor);
+  std::vector<float> getTauScore(const tensorflow::Tensor& cellGridMatrix);
+  void produce(edm::Event& event, const edm::EventSetup& eventsetup) override;
+  void fillL1TauVars(tensorflow::Tensor& cellGridMatrix, const std::vector<l1t::TauRef>& allTaus);
+  void fillCaloRecHits(tensorflow::Tensor& cellGridMatrix,
+                       const std::vector<l1t::TauRef>& allTaus,
+                       const caloRecHitCollections& caloRecHits);
+  void fillPatatracks(tensorflow::Tensor& cellGridMatrix,
+                      const std::vector<l1t::TauRef>& allTaus,
+                      const TracksHost& patatracks_tsoa,
+                      const ZVertexHost& patavtx_soa,
+                      const reco::BeamSpot& beamspot,
+                      const MagneticField* magfi);
+  void selectGoodTracksAndVertices(const ZVertexHost& patavtx_soa,
+                                   const TracksHost& patatracks_tsoa,
+                                   std::vector<int>& trkGood,
+                                   std::vector<int>& vtxGood);
+  std::pair<float, float> impactParameter(int it,
+                                          const TracksHost& patatracks_tsoa,
+                                          float patatrackPhi,
+                                          const reco::BeamSpot& beamspot,
+                                          const MagneticField* magfi);
+  template <typename VPos, typename LVec>
+  std::tuple<float, float, int, int> getEtaPhiIndices(const VPos& position, const LVec& tau_p4);
+  template <typename LVec>
+  std::tuple<float, float, int, int> getEtaPhiIndices(float eta, float phi, const LVec& tau_p4);
+
+private:
+  const int debugLevel_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauTriggerToken_;
+  std::vector<InputDescTau> L1TauDesc_;
+  const edm::EDGetTokenT<HBHERecHitCollection> hbheToken_;
+  const edm::EDGetTokenT<HORecHitCollection> hoToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> ebToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> eeToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken_;
+  const edm::EDGetTokenT<ZVertexHost> pataVerticesToken_;
+  const edm::EDGetTokenT<TracksHost> pataTracksToken_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  const unsigned int maxVtx_;
+  const float fractionSumPt2_;
+  const float minSumPt2_;
+  const float trackPtMin_;
+  const float trackPtMax_;
+  const float trackChi2Max_;
+  std::string inputTensorName_;
+  std::string outputTensorName_;
+  const L2TauNNProducerAlpakaStripCacheData* L2cacheData_;
+};
+
+std::unique_ptr<L2TauNNProducerAlpakaStripCacheData> L2TauNNProducerAlpakaStrip::initializeGlobalCache(
+    const edm::ParameterSet& cfg) {
+  std::unique_ptr<L2TauNNProducerAlpakaStripCacheData> cacheData = std::make_unique<L2TauNNProducerAlpakaStripCacheData>();
+  cacheData->normVec.reserve(L2TauTagNNv1::nVars);
+
+  auto const graphPath = edm::FileInPath(cfg.getParameter<std::string>("graphPath")).fullPath();
+
+  cacheData->graphDef = tensorflow::loadGraphDef(graphPath);
+  cacheData->session = tensorflow::createSession(cacheData->graphDef);
+
+  boost::property_tree::ptree loadPtreeRoot;
+  auto const normalizationDict = edm::FileInPath(cfg.getParameter<std::string>("normalizationDict")).fullPath();
+  boost::property_tree::read_json(normalizationDict, loadPtreeRoot);
+  for (const auto& [key, val] : L2TauTagNNv1::varNameMap) {
+    boost::property_tree::ptree var = loadPtreeRoot.get_child(val);
+    normDictElement current_element;
+    current_element.mean = var.get_child("mean").get_value<float>();
+    current_element.std = var.get_child("std").get_value<float>();
+    current_element.min = var.get_child("min").get_value<float>();
+    current_element.max = var.get_child("max").get_value<float>();
+    cacheData->normVec.push_back(current_element);
+  }
+  return cacheData;
+}
+void L2TauNNProducerAlpakaStrip::globalEndJob(L2TauNNProducerAlpakaStripCacheData* cacheData) {
+  if (cacheData->graphDef != nullptr) {
+    delete cacheData->graphDef;
+  }
+  tensorflow::closeSession(cacheData->session);
+}
+void L2TauNNProducerAlpakaStrip::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("debugLevel", 0)->setComment("set debug level for printing out info");
+  edm::ParameterSetDescription l1TausPset;
+  l1TausPset.add<std::string>("L1CollectionName", "DoubleTau")->setComment("Name of collections");
+  l1TausPset.add<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"))
+      ->setComment("Which trigger should the L1 Taus collection pass");
+  edm::ParameterSet l1TausPSetDefault;
+  l1TausPSetDefault.addParameter<std::string>("L1CollectionName", "DoubleTau");
+  l1TausPSetDefault.addParameter<edm::InputTag>("L1TauTrigger", edm::InputTag("hltL1sDoubleTauBigOR"));
+  desc.addVPSet("L1Taus", l1TausPset, {l1TausPSetDefault});
+  desc.add<edm::InputTag>("hbheInput", edm::InputTag("hltHbhereco"))->setComment("HBHE recHit collection");
+  desc.add<edm::InputTag>("hoInput", edm::InputTag("hltHoreco"))->setComment("HO recHit Collection");
+  desc.add<edm::InputTag>("ebInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEB"))->setComment("EB recHit Collection");
+  desc.add<edm::InputTag>("eeInput", edm::InputTag("hltEcalRecHit:EcalRecHitsEE"))->setComment("EE recHit Collection");
+  desc.add<edm::InputTag>("pataVertices", edm::InputTag("hltPixelVerticesSoA"))
+      ->setComment("patatrack vertices collection");
+  desc.add<edm::InputTag>("pataTracks", edm::InputTag("hltPixelTracksSoA"))->setComment("patatrack collection");
+  desc.add<edm::InputTag>("BeamSpot", edm::InputTag("hltOnlineBeamSpot"))->setComment("BeamSpot Collection");
+  desc.add<uint>("maxVtx", 100)->setComment("max output collection size (number of accepted vertices)");
+  desc.add<double>("fractionSumPt2", 0.3)->setComment("threshold on sumPt2 fraction of the leading vertex");
+  desc.add<double>("minSumPt2", 0.)->setComment("min sumPt2");
+  desc.add<double>("track_pt_min", 1.0)->setComment("min track p_T");
+  desc.add<double>("track_pt_max", 10.0)->setComment("max track p_T");
+  desc.add<double>("track_chi2_max", 99999.)->setComment("max track chi2");
+  desc.add<std::string>("graphPath", "RecoTauTag/TrainingFiles/data/L2TauNNTag/L2TauTag_Run3v1.pb")
+      ->setComment("path to the saved CNN");
+  desc.add<std::string>("normalizationDict", "RecoTauTag/TrainingFiles/data/L2TauNNTag/NormalizationDict.json")
+      ->setComment("path to the dictionary for variable standardization");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+L2TauNNProducerAlpakaStrip::L2TauNNProducerAlpakaStrip(const edm::ParameterSet& cfg,
+                                             const L2TauNNProducerAlpakaStripCacheData* cacheData)
+    : debugLevel_(cfg.getParameter<int>("debugLevel")),
+      hbheToken_(consumes<HBHERecHitCollection>(cfg.getParameter<edm::InputTag>("hbheInput"))),
+      hoToken_(consumes<HORecHitCollection>(cfg.getParameter<edm::InputTag>("hoInput"))),
+      ebToken_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("ebInput"))),
+      eeToken_(consumes<EcalRecHitCollection>(cfg.getParameter<edm::InputTag>("eeInput"))),
+      geometryToken_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
+      bFieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>()),
+      pataVerticesToken_(consumes(cfg.getParameter<edm::InputTag>("pataVertices"))),
+      pataTracksToken_(consumes(cfg.getParameter<edm::InputTag>("pataTracks"))),
+      beamSpotToken_(consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("BeamSpot"))),
+      maxVtx_(cfg.getParameter<uint>("maxVtx")),
+      fractionSumPt2_(cfg.getParameter<double>("fractionSumPt2")),
+      minSumPt2_(cfg.getParameter<double>("minSumPt2")),
+      trackPtMin_(cfg.getParameter<double>("track_pt_min")),
+      trackPtMax_(cfg.getParameter<double>("track_pt_max")),
+      trackChi2Max_(cfg.getParameter<double>("track_chi2_max")) {
+  if (cacheData->graphDef == nullptr) {
+    throw cms::Exception("InvalidCacheData") << "Invalid Cache Data.";
+  }
+  inputTensorName_ = cacheData->graphDef->node(0).name();
+  outputTensorName_ = cacheData->graphDef->node(cacheData->graphDef->node_size() - 1).name();
+  L2cacheData_ = cacheData;
+  std::vector<edm::ParameterSet> L1TauCollections = cfg.getParameter<std::vector<edm::ParameterSet>>("L1Taus");
+  L1TauDesc_.reserve(L1TauCollections.size());
+  for (const auto& l1TauInput : L1TauCollections) {
+    InputDescTau toInsert;
+    toInsert.CollectionName = l1TauInput.getParameter<std::string>("L1CollectionName");
+    toInsert.inputToken_ =
+        consumes<trigger::TriggerFilterObjectWithRefs>(l1TauInput.getParameter<edm::InputTag>("L1TauTrigger"));
+    L1TauDesc_.push_back(toInsert);
+  }
+  for (const auto& desc : L1TauDesc_)
+    produces<std::vector<float>>(desc.CollectionName);
+}
+
+void L2TauNNProducerAlpakaStrip::checknan(tensorflow::Tensor& tensor, int debugLevel) {
+  using NNInputs = L2TauTagNNv1::NNInputs;
+  std::vector<int> tensor_shape(tensor.shape().dims());
+  for (int d = 0; d < tensor.shape().dims(); d++) {
+    tensor_shape.at(d) = tensor.shape().dim_size(d);
+  }
+  if (tensor_shape.size() != 4) {
+    throw cms::Exception("InvalidTensor") << "Tensor shape does not have 4 dimensions!";
+  }
+  for (int tau_idx = 0; tau_idx < tensor_shape.at(0); tau_idx++) {
+    for (int phi_idx = 0; phi_idx < tensor_shape.at(1); phi_idx++) {
+      for (int eta_idx = 0; eta_idx < tensor_shape.at(2); eta_idx++) {
+        for (int var_idx = 0; var_idx < tensor_shape.at(3); var_idx++) {
+          auto getCell = [&](NNInputs input) -> float& {
+            return getCellImpl(tensor, tau_idx, phi_idx, eta_idx, input);
+          };
+          auto nonstd_var = getCell(static_cast<NNInputs>(var_idx));
+          if (edm::isNotFinite(nonstd_var)) {
+            edm::LogWarning("InputVar") << "var is nan \nvar name= "
+                                        << L2TauTagNNv1::varNameMap.at(static_cast<L2TauTagNNv1::NNInputs>(var_idx))
+                                        << "\t var_idx = " << var_idx << "\t eta_idx = " << eta_idx
+                                        << "\t phi_idx = " << phi_idx << "\t tau_idx = " << tau_idx;
+            if (debugLevel > 2) {
+              edm::LogWarning("InputVar") << "other vars in same cell \n";
+              if (var_idx + 1 < tensor_shape.at(3))
+                edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 1))
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 1));
+              if (var_idx + 2 < tensor_shape.at(3))
+                edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 2))
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 2));
+              if (var_idx + 3 < tensor_shape.at(3))
+                edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 3))
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 3));
+              if (var_idx + 4 < tensor_shape.at(3))
+                edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 4))
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 4));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void L2TauNNProducerAlpakaStrip::standardizeTensor(tensorflow::Tensor& tensor) {
+  using NNInputs = L2TauTagNNv1::NNInputs;
+  std::vector<int> tensor_shape(tensor.shape().dims());
+  for (int d = 0; d < tensor.shape().dims(); d++) {
+    tensor_shape.at(d) = tensor.shape().dim_size(d);
+  }
+  if (tensor_shape.size() != 4) {
+    throw cms::Exception("InvalidTensor") << "Tensor shape does not have 4 dimensions!";
+  }
+  for (int tau_idx = 0; tau_idx < tensor_shape.at(0); tau_idx++) {
+    for (int phi_idx = 0; phi_idx < tensor_shape.at(1); phi_idx++) {
+      for (int eta_idx = 0; eta_idx < tensor_shape.at(2); eta_idx++) {
+        for (int var_idx = 0; var_idx < tensor_shape.at(3); var_idx++) {
+          auto getCell = [&](NNInputs input) -> float& {
+            return getCellImpl(tensor, tau_idx, phi_idx, eta_idx, input);
+          };
+          float mean = L2cacheData_->normVec.at(var_idx).mean;
+          float std = L2cacheData_->normVec.at(var_idx).std;
+          float min = L2cacheData_->normVec.at(var_idx).min;
+          float max = L2cacheData_->normVec.at(var_idx).max;
+          float nonstd_var = getCell(static_cast<NNInputs>(var_idx));
+          float std_var = static_cast<float>((nonstd_var - mean) / std);
+          if (std_var > max) {
+            std_var = static_cast<float>(max);
+          } else if (std_var < min) {
+            std_var = static_cast<float>(min);
+          }
+          getCell(static_cast<NNInputs>(var_idx)) = std_var;
+        }
+      }
+    }
+  }
+}
+
+void L2TauNNProducerAlpakaStrip::fillL1TauVars(tensorflow::Tensor& cellGridMatrix, const std::vector<l1t::TauRef>& allTaus) {
+  using NNInputs = L2TauTagNNv1::NNInputs;
+
+  const int nTaus = allTaus.size();
+  for (int tau_idx = 0; tau_idx < nTaus; tau_idx++) {
+    for (int eta_idx = 0; eta_idx < L2TauTagNNv1::nCellEta; eta_idx++) {
+      for (int phi_idx = 0; phi_idx < L2TauTagNNv1::nCellPhi; phi_idx++) {
+        auto getCell = [&](NNInputs input) -> float& {
+          return getCellImpl(cellGridMatrix, tau_idx, phi_idx, eta_idx, input);
+        };
+        getCell(NNInputs::l1Tau_pt) = allTaus[tau_idx]->pt();
+        getCell(NNInputs::l1Tau_eta) = allTaus[tau_idx]->eta();
+        getCell(NNInputs::l1Tau_hwIso) = allTaus[tau_idx]->hwIso();
+      }
+    }
+  }
+}
+
+template <typename LVec>
+std::tuple<float, float, int, int> L2TauNNProducerAlpakaStrip::getEtaPhiIndices(float eta, float phi, const LVec& tau_p4) {
+  const float deta = eta - tau_p4.eta();
+  const float dphi = reco::deltaPhi(phi, tau_p4.phi());
+  const int eta_idx = static_cast<int>(floor((deta + L2TauTagNNv1::dR_max) / dEta_width));
+  const int phi_idx = static_cast<int>(floor((dphi + L2TauTagNNv1::dR_max) / dPhi_width));
+  return std::make_tuple(deta, dphi, eta_idx, phi_idx);
+}
+
+template <typename VPos, typename LVec>
+std::tuple<float, float, int, int> L2TauNNProducerAlpakaStrip::getEtaPhiIndices(const VPos& position, const LVec& tau_p4) {
+  return getEtaPhiIndices(position.eta(), position.phi(), tau_p4);
+}
+
+void L2TauNNProducerAlpakaStrip::fillCaloRecHits(tensorflow::Tensor& cellGridMatrix,
+                                            const std::vector<l1t::TauRef>& allTaus,
+                                            const caloRecHitCollections& caloRecHits) {
+  using NNInputs = L2TauTagNNv1::NNInputs;
+
+  const int nTaus = allTaus.size();
+  float deta, dphi;
+  int eta_idx = 0;
+  int phi_idx = 0;
+  int tau_idx = 0;
+
+  auto getCell = [&](NNInputs input) -> float& {
+    return getCellImpl(cellGridMatrix, tau_idx, phi_idx, eta_idx, input);
+  };
+  for (tau_idx = 0; tau_idx < nTaus; tau_idx++) {
+    // calorechit_EE
+    for (const auto& caloRecHit_ee : *caloRecHits.ee) {
+      if (caloRecHit_ee.energy() <= 0)
+        continue;
+      const auto& position = caloRecHits.geometry->getGeometry(caloRecHit_ee.id())->getPosition();
+      const float eeCalEn = caloRecHit_ee.energy();
+      const float eeCalChi2 = caloRecHit_ee.chi2();
+      if (reco::deltaR2(position, allTaus[tau_idx]->polarP4()) < dR2_max) {
+        std::tie(deta, dphi, eta_idx, phi_idx) = getEtaPhiIndices(position, allTaus[tau_idx]->polarP4());
+        getCell(NNInputs::EcalEnergySum) += eeCalEn;
+        getCell(NNInputs::EcalSize) += 1.;
+        getCell(NNInputs::EcalEnergyStdDev) += eeCalEn * eeCalEn;
+        getCell(NNInputs::EcalDeltaEta) += deta * eeCalEn;
+        getCell(NNInputs::EcalDeltaPhi) += dphi * eeCalEn;
+        if (eeCalChi2 >= 0) {
+          getCell(NNInputs::EcalChi2) += eeCalChi2 * eeCalEn;
+          getCell(NNInputs::EcalEnergySumForPositiveChi2) += eeCalEn;
+          getCell(NNInputs::EcalSizeForPositiveChi2) += 1.;
+        }
+      }
+    }
+
+    // calorechit_EB
+    for (const auto& caloRecHit_eb : *caloRecHits.eb) {
+      if (caloRecHit_eb.energy() <= 0)
+        continue;
+      const auto& position = caloRecHits.geometry->getGeometry(caloRecHit_eb.id())->getPosition();
+      const float ebCalEn = caloRecHit_eb.energy();
+      const float ebCalChi2 = caloRecHit_eb.chi2();
+      if (reco::deltaR2(position, allTaus[tau_idx]->polarP4()) < dR2_max) {
+        std::tie(deta, dphi, eta_idx, phi_idx) = getEtaPhiIndices(position, allTaus[tau_idx]->polarP4());
+        getCell(NNInputs::EcalEnergySum) += ebCalEn;
+        getCell(NNInputs::EcalSize) += 1.;
+        getCell(NNInputs::EcalEnergyStdDev) += ebCalEn * ebCalEn;
+        getCell(NNInputs::EcalDeltaEta) += deta * ebCalEn;
+        getCell(NNInputs::EcalDeltaPhi) += dphi * ebCalEn;
+        if (ebCalChi2 >= 0) {
+          getCell(NNInputs::EcalChi2) += ebCalChi2 * ebCalEn;
+          getCell(NNInputs::EcalEnergySumForPositiveChi2) += ebCalEn;
+          getCell(NNInputs::EcalSizeForPositiveChi2) += 1.;
+        }
+      }
+    }
+
+    // calorechit_HBHE
+    for (const auto& caloRecHit_hbhe : *caloRecHits.hbhe) {
+      if (caloRecHit_hbhe.energy() <= 0)
+        continue;
+      const auto& position = caloRecHits.geometry->getGeometry(caloRecHit_hbhe.id())->getPosition();
+      const float hbheCalEn = caloRecHit_hbhe.energy();
+      const float hbheCalChi2 = caloRecHit_hbhe.chi2();
+      if (reco::deltaR2(position, allTaus[tau_idx]->polarP4()) < dR2_max) {
+        std::tie(deta, dphi, eta_idx, phi_idx) = getEtaPhiIndices(position, allTaus[tau_idx]->polarP4());
+        getCell(NNInputs::HcalEnergySum) += hbheCalEn;
+        getCell(NNInputs::HcalEnergyStdDev) += hbheCalEn * hbheCalEn;
+        getCell(NNInputs::HcalSize) += 1.;
+        getCell(NNInputs::HcalDeltaEta) += deta * hbheCalEn;
+        getCell(NNInputs::HcalDeltaPhi) += dphi * hbheCalEn;
+        if (hbheCalChi2 >= 0) {
+          getCell(NNInputs::HcalChi2) += hbheCalChi2 * hbheCalEn;
+          getCell(NNInputs::HcalEnergySumForPositiveChi2) += hbheCalEn;
+          getCell(NNInputs::HcalSizeForPositiveChi2) += 1.;
+        }
+      }
+    }
+
+    // calorechit_HO
+    for (const auto& caloRecHit_ho : *caloRecHits.ho) {
+      if (caloRecHit_ho.energy() <= 0)
+        continue;
+      const auto& position = caloRecHits.geometry->getGeometry(caloRecHit_ho.id())->getPosition();
+      const float hoCalEn = caloRecHit_ho.energy();
+      if (reco::deltaR2(position, allTaus[tau_idx]->polarP4()) < dR2_max) {
+        std::tie(deta, dphi, eta_idx, phi_idx) = getEtaPhiIndices(position, allTaus[tau_idx]->polarP4());
+        getCell(NNInputs::HcalEnergySum) += hoCalEn;
+        getCell(NNInputs::HcalEnergyStdDev) += hoCalEn * hoCalEn;
+        getCell(NNInputs::HcalSize) += 1.;
+        getCell(NNInputs::HcalDeltaEta) += deta * hoCalEn;
+        getCell(NNInputs::HcalDeltaPhi) += dphi * hoCalEn;
+      }
+    }
+
+    // normalize to sum and define stdDev
+    for (eta_idx = 0; eta_idx < L2TauTagNNv1::nCellEta; eta_idx++) {
+      for (phi_idx = 0; phi_idx < L2TauTagNNv1::nCellPhi; phi_idx++) {
+        /* normalize eCal vars*/
+        if (getCell(NNInputs::EcalEnergySum) > 0.) {
+          getCell(NNInputs::EcalDeltaEta) /= getCell(NNInputs::EcalEnergySum);
+          getCell(NNInputs::EcalDeltaPhi) /= getCell(NNInputs::EcalEnergySum);
+        }
+        if (getCell(NNInputs::EcalEnergySumForPositiveChi2) > 0.) {
+          getCell(NNInputs::EcalChi2) /= getCell(NNInputs::EcalEnergySumForPositiveChi2);
+        }
+        if (getCell(NNInputs::EcalSize) > 1.) {
+          // (stdDev - (enSum*enSum)/size) / (size-1)
+          getCell(NNInputs::EcalEnergyStdDev) =
+              (getCell(NNInputs::EcalEnergyStdDev) -
+               (getCell(NNInputs::EcalEnergySum) * getCell(NNInputs::EcalEnergySum)) / getCell(NNInputs::EcalSize)) /
+              (getCell(NNInputs::EcalSize) - 1);
+        } else {
+          getCell(NNInputs::EcalEnergyStdDev) = 0.;
+        }
+        /* normalize hCal Vars */
+        if (getCell(NNInputs::HcalEnergySum) > 0.) {
+          getCell(NNInputs::HcalDeltaEta) /= getCell(NNInputs::HcalEnergySum);
+          getCell(NNInputs::HcalDeltaPhi) /= getCell(NNInputs::HcalEnergySum);
+        }
+        if (getCell(NNInputs::HcalEnergySumForPositiveChi2) > 0.) {
+          getCell(NNInputs::HcalChi2) /= getCell(NNInputs::HcalEnergySumForPositiveChi2);
+        }
+        if (getCell(NNInputs::HcalSize) > 1.) {
+          // (stdDev - (enSum*enSum)/size) / (size-1)
+          getCell(NNInputs::HcalEnergyStdDev) =
+              (getCell(NNInputs::HcalEnergyStdDev) -
+               (getCell(NNInputs::HcalEnergySum) * getCell(NNInputs::HcalEnergySum)) / getCell(NNInputs::HcalSize)) /
+              (getCell(NNInputs::HcalSize) - 1);
+        } else {
+          getCell(NNInputs::HcalEnergyStdDev) = 0.;
+        }
+      }
+    }
+  }
+}
+
+void L2TauNNProducerAlpakaStrip::selectGoodTracksAndVertices(const ZVertexHost& patavtx_soa,
+                                                        const TracksHost& patatracks_tsoa,
+                                                        std::vector<int>& trkGood,
+                                                        std::vector<int>& vtxGood) {
+  using patatrackHelpers = TracksUtilities<pixelTopology::Phase1Strip>;
+  const auto maxTracks = patatracks_tsoa.view().metadata().size();
+  const int nv = patavtx_soa.view().nvFinal();
+  trkGood.clear();
+  trkGood.reserve(maxTracks);
+  vtxGood.clear();
+  vtxGood.reserve(nv);
+  auto const* quality = patatracks_tsoa.view().quality();
+
+  // No need to sort either as the algorithms is just using the max (not even the location, just the max value of pt2sum).
+  std::vector<float> pTSquaredSum(nv, 0);
+  std::vector<int> nTrkAssociated(nv, 0);
+
+  for (int32_t trk_idx = 0; trk_idx < maxTracks; ++trk_idx) {
+    auto nHits = patatrackHelpers::nHits(patatracks_tsoa.view(), trk_idx);
+    if (nHits == 0) {
+      break;
+    }
+    int vtx_ass_to_track = patavtx_soa.view()[trk_idx].idv();
+    if (vtx_ass_to_track >= 0 && vtx_ass_to_track < nv) {
+      auto patatrackPt = patatracks_tsoa.view()[trk_idx].pt();
+      ++nTrkAssociated[vtx_ass_to_track];
+      if (patatrackPt >= trackPtMin_ && patatracks_tsoa.const_view()[trk_idx].chi2() <= trackChi2Max_) {
+        patatrackPt = std::min(patatrackPt, trackPtMax_);
+        pTSquaredSum[vtx_ass_to_track] += patatrackPt * patatrackPt;
+      }
+    }
+    if (nHits > 0 and quality[trk_idx] >= pixelTrack::Quality::loose) {
+      trkGood.push_back(trk_idx);
+    }
+  }
+  if (nv > 0) {
+    const auto minFOM_fromFrac = (*std::max_element(pTSquaredSum.begin(), pTSquaredSum.end())) * fractionSumPt2_;
+    for (int j = nv - 1; j >= 0 && vtxGood.size() < maxVtx_; --j) {
+      auto vtx_idx = patavtx_soa.view()[j].sortInd();
+      assert(vtx_idx < nv);
+      if (nTrkAssociated[vtx_idx] >= 2 && pTSquaredSum[vtx_idx] >= minFOM_fromFrac &&
+          pTSquaredSum[vtx_idx] > minSumPt2_) {
+        vtxGood.push_back(vtx_idx);
+      }
+    }
+  }
+}
+
+std::pair<float, float> L2TauNNProducerAlpakaStrip::impactParameter(int it,
+                                                               const TracksHost& patatracks_tsoa,
+                                                               float patatrackPhi,
+                                                               const reco::BeamSpot& beamspot,
+                                                               const MagneticField* magfi) {
+  /* dxy and dz */
+  riemannFit::Vector5d ipar, opar;
+  riemannFit::Matrix5d icov, ocov;
+  TracksUtilities<pixelTopology::Phase1Strip>::copyToDense(patatracks_tsoa.view(), ipar, icov, it);
+  riemannFit::transformToPerigeePlane(ipar, icov, opar, ocov);
+  LocalTrajectoryParameters lpar(opar(0), opar(1), opar(2), opar(3), opar(4), 1.);
+  float sp = std::sin(patatrackPhi);
+  float cp = std::cos(patatrackPhi);
+  Surface::RotationType Rotation(sp, -cp, 0, 0, 0, -1.f, cp, sp, 0);
+  GlobalPoint BeamSpotPoint(beamspot.x0(), beamspot.y0(), beamspot.z0());
+  Plane impPointPlane(BeamSpotPoint, Rotation);
+  GlobalTrajectoryParameters gp(
+      impPointPlane.toGlobal(lpar.position()), impPointPlane.toGlobal(lpar.momentum()), lpar.charge(), magfi);
+  GlobalPoint vv = gp.position();
+  math::XYZPoint pos(vv.x(), vv.y(), vv.z());
+  GlobalVector pp = gp.momentum();
+  math::XYZVector mom(pp.x(), pp.y(), pp.z());
+  auto lambda = M_PI_2 - pp.theta();
+  auto phi = pp.phi();
+  float patatrackDxy = -vv.x() * std::sin(phi) + vv.y() * std::cos(phi);
+  float patatrackDz =
+      (vv.z() * std::cos(lambda) - (vv.x() * std::cos(phi) + vv.y() * std::sin(phi)) * std::sin(lambda)) /
+      std::cos(lambda);
+  return std::make_pair(patatrackDxy, patatrackDz);
+}
+
+void L2TauNNProducerAlpakaStrip::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
+                                           const std::vector<l1t::TauRef>& allTaus,
+                                           const TracksHost& patatracks_tsoa,
+                                           const ZVertexHost& patavtx_soa,
+                                           const reco::BeamSpot& beamspot,
+                                           const MagneticField* magfi) {
+  using NNInputs = L2TauTagNNv1::NNInputs;
+  using patatrackHelpers = TracksUtilities<pixelTopology::Phase1Strip>;
+  float deta, dphi;
+  int eta_idx = 0;
+  int phi_idx = 0;
+  int tau_idx = 0;
+
+  auto getCell = [&](NNInputs input) -> float& {
+    return getCellImpl(cellGridMatrix, tau_idx, phi_idx, eta_idx, input);
+  };
+
+  std::vector<int> trkGood;
+  std::vector<int> vtxGood;
+
+  selectGoodTracksAndVertices(patavtx_soa, patatracks_tsoa, trkGood, vtxGood);
+
+  const int nTaus = allTaus.size();
+  for (tau_idx = 0; tau_idx < nTaus; tau_idx++) {
+    const float tauEta = allTaus[tau_idx]->eta();
+    const float tauPhi = allTaus[tau_idx]->phi();
+
+    for (const auto it : trkGood) {
+      const float patatrackPt = patatracks_tsoa.const_view()[it].pt();
+      if (patatrackPt <= 0)
+        continue;
+      const float patatrackPhi = reco::phi(patatracks_tsoa.const_view(), it);
+      const float patatrackEta = patatracks_tsoa.const_view()[it].eta();
+      const float patatrackCharge = reco::charge(patatracks_tsoa.const_view(), it);
+      const float patatrackChi2OverNdof = patatracks_tsoa.view()[it].chi2();
+      const auto nHits = patatrackHelpers::nHits(patatracks_tsoa.const_view(), it);
+      if (nHits <= 0)
+        continue;
+      const int patatrackNdof = 2 * std::min(6, nHits) - 5;
+
+      const int vtx_idx_assTrk = patavtx_soa.view()[it].idv();
+      if (reco::deltaR2(patatrackEta, patatrackPhi, tauEta, tauPhi) < dR2_max) {
+        std::tie(deta, dphi, eta_idx, phi_idx) =
+            getEtaPhiIndices(patatrackEta, patatrackPhi, allTaus[tau_idx]->polarP4());
+        getCell(NNInputs::PatatrackPtSum) += patatrackPt;
+        getCell(NNInputs::PatatrackSize) += 1.;
+        getCell(NNInputs::PatatrackChargeSum) += patatrackCharge;
+        getCell(NNInputs::PatatrackDeltaEta) += deta * patatrackPt;
+        getCell(NNInputs::PatatrackDeltaPhi) += dphi * patatrackPt;
+        getCell(NNInputs::PatatrackChi2OverNdof) += patatrackChi2OverNdof * patatrackPt;
+        getCell(NNInputs::PatatrackNdof) += patatrackNdof * patatrackPt;
+        std::pair<float, float> impactParameters = impactParameter(it, patatracks_tsoa, patatrackPhi, beamspot, magfi);
+        getCell(NNInputs::PatatrackDxy) += impactParameters.first * patatrackPt;
+        getCell(NNInputs::PatatrackDz) += impactParameters.second * patatrackPt;
+        if ((std::find(vtxGood.begin(), vtxGood.end(), vtx_idx_assTrk) != vtxGood.end())) {
+          getCell(NNInputs::PatatrackPtSumWithVertex) += patatrackPt;
+          getCell(NNInputs::PatatrackSizeWithVertex) += 1.;
+        }
+      }
+    }
+
+    // normalize to sum and define stdDev
+    for (eta_idx = 0; eta_idx < L2TauTagNNv1::nCellEta; eta_idx++) {
+      for (phi_idx = 0; phi_idx < L2TauTagNNv1::nCellPhi; phi_idx++) {
+        getCell(NNInputs::nVertices) = vtxGood.size();
+        if (getCell(NNInputs::PatatrackPtSum) > 0.) {
+          getCell(NNInputs::PatatrackDeltaEta) /= getCell(NNInputs::PatatrackPtSum);
+          getCell(NNInputs::PatatrackDeltaPhi) /= getCell(NNInputs::PatatrackPtSum);
+          getCell(NNInputs::PatatrackChi2OverNdof) /= getCell(NNInputs::PatatrackPtSum);
+          getCell(NNInputs::PatatrackNdof) /= getCell(NNInputs::PatatrackPtSum);
+          getCell(NNInputs::PatatrackDxy) /= getCell(NNInputs::PatatrackPtSum);
+          getCell(NNInputs::PatatrackDz) /= getCell(NNInputs::PatatrackPtSum);
+        }
+      }
+    }
+  }
+}
+
+std::vector<float> L2TauNNProducerAlpakaStrip::getTauScore(const tensorflow::Tensor& cellGridMatrix) {
+  const int nTau = cellGridMatrix.shape().dim_size(0);
+  if (nTau == 0) {
+    return std::vector<float>();
+  } else {
+    std::vector<tensorflow::Tensor> pred_tensor;
+    tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
+    std::vector<float> pred_vector(nTau);
+    for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {
+      pred_vector[tau_idx] = pred_tensor[0].matrix<float>()(tau_idx, 0);
+    }
+
+    return pred_vector;
+  }
+}
+
+void L2TauNNProducerAlpakaStrip::produce(edm::Event& event, const edm::EventSetup& eventsetup) {
+  std::vector<std::vector<size_t>> TauCollectionMap(L1TauDesc_.size());
+  l1t::TauVectorRef allTaus;
+
+  for (size_t inp_idx = 0; inp_idx < L1TauDesc_.size(); inp_idx++) {
+    l1t::TauVectorRef l1Taus;
+    auto const& l1TriggeredTaus = event.get(L1TauDesc_[inp_idx].inputToken_);
+    l1TriggeredTaus.getObjects(trigger::TriggerL1Tau, l1Taus);
+    TauCollectionMap.at(inp_idx).resize(l1Taus.size());
+
+    for (size_t l1_idx = 0; l1_idx < l1Taus.size(); l1_idx++) {
+      size_t tau_idx;
+      const auto iter = std::find(allTaus.begin(), allTaus.end(), l1Taus[l1_idx]);
+      if (iter != allTaus.end()) {
+        tau_idx = std::distance(allTaus.begin(), iter);
+      } else {
+        allTaus.push_back(l1Taus[l1_idx]);
+        tau_idx = allTaus.size() - 1;
+      }
+      TauCollectionMap.at(inp_idx).at(l1_idx) = tau_idx;
+    }
+  }
+  const auto ebCal = event.getHandle(ebToken_);
+  const auto eeCal = event.getHandle(eeToken_);
+  const auto hbhe = event.getHandle(hbheToken_);
+  const auto ho = event.getHandle(hoToken_);
+  auto const& patatracks_SoA = event.get(pataTracksToken_);
+  auto const& vertices_SoA = event.get(pataVerticesToken_);
+  const auto bsHandle = event.getHandle(beamSpotToken_);
+
+  auto const fieldESH = eventsetup.getHandle(bFieldToken_);
+  auto const geometry = eventsetup.getHandle(geometryToken_);
+
+  caloRecHitCollections caloRecHits;
+  caloRecHits.hbhe = &*hbhe;
+  caloRecHits.ho = &*ho;
+  caloRecHits.eb = &*ebCal;
+  caloRecHits.ee = &*eeCal;
+  caloRecHits.geometry = &*geometry;
+
+  const int nTaus = allTaus.size();
+  tensorflow::Tensor cellGridMatrix(tensorflow::DT_FLOAT,
+                                    {nTaus, L2TauTagNNv1::nCellEta, L2TauTagNNv1::nCellPhi, L2TauTagNNv1::nVars});
+  const int n_inputs = nTaus * L2TauTagNNv1::nCellEta * L2TauTagNNv1::nCellPhi * L2TauTagNNv1::nVars;
+  for (int input_idx = 0; input_idx < n_inputs; ++input_idx) {
+    cellGridMatrix.flat<float>()(input_idx) = 0;
+  }
+  fillL1TauVars(cellGridMatrix, allTaus);
+
+  fillCaloRecHits(cellGridMatrix, allTaus, caloRecHits);
+
+  fillPatatracks(cellGridMatrix, allTaus, patatracks_SoA, vertices_SoA, *bsHandle, fieldESH.product());
+
+  standardizeTensor(cellGridMatrix);
+
+  if (debugLevel_ > 0) {
+    checknan(cellGridMatrix, debugLevel_);
+  }
+
+  std::vector<float> tau_score = getTauScore(cellGridMatrix);
+
+  for (size_t inp_idx = 0; inp_idx < L1TauDesc_.size(); inp_idx++) {
+    const size_t nTau = TauCollectionMap[inp_idx].size();
+    auto tau_tags = std::make_unique<std::vector<float>>(nTau);
+    for (size_t tau_pos = 0; tau_pos < nTau; ++tau_pos) {
+      const auto tau_idx = TauCollectionMap[inp_idx][tau_pos];
+      if (debugLevel_ > 0) {
+        edm::LogInfo("DebugInfo") << event.id().event() << " \t " << (allTaus[tau_idx])->pt() << " \t "
+                                  << tau_score.at(tau_idx) << std::endl;
+      }
+      (*tau_tags)[tau_pos] = tau_score.at(tau_idx);
+    }
+    event.put(std::move(tau_tags), L1TauDesc_[inp_idx].CollectionName);
+  }
+}
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L2TauNNProducerAlpakaStrip);

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpakaStrip.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpakaStrip.cc
@@ -593,7 +593,7 @@ void L2TauNNProducerAlpakaStrip::selectGoodTracksAndVertices(const ZVertexHost& 
     if (nHits == 0) {
       break;
     }
-    int vtx_ass_to_track = patavtx_soa.view()[trk_idx].idv();
+    int vtx_ass_to_track = patavtx_soa.view<reco::ZVertexTracksSoA>()[trk_idx].idv();
     if (vtx_ass_to_track >= 0 && vtx_ass_to_track < nv) {
       auto patatrackPt = patatracks_tsoa.view()[trk_idx].pt();
       ++nTrkAssociated[vtx_ass_to_track];
@@ -690,7 +690,7 @@ void L2TauNNProducerAlpakaStrip::fillPatatracks(tensorflow::Tensor& cellGridMatr
         continue;
       const int patatrackNdof = 2 * std::min(6, nHits) - 5;
 
-      const int vtx_idx_assTrk = patavtx_soa.view()[it].idv();
+      const int vtx_idx_assTrk = patavtx_soa.view<reco::ZVertexTracksSoA>()[it].idv();
       if (reco::deltaR2(patatrackEta, patatrackPhi, tauEta, tauPhi) < dR2_max) {
         std::tie(deta, dphi, eta_idx, phi_idx) =
             getEtaPhiIndices(patatrackEta, patatrackPhi, allTaus[tau_idx]->polarP4());

--- a/RecoTracker/PixelSeeding/BuildFile.xml
+++ b/RecoTracker/PixelSeeding/BuildFile.xml
@@ -16,6 +16,7 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackSoA"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="RecoTracker/PixelTrackFitting"/>

--- a/RecoTracker/PixelSeeding/plugins/BuildFile.xml
+++ b/RecoTracker/PixelSeeding/plugins/BuildFile.xml
@@ -11,6 +11,9 @@
 <iftool name="cuda-gcc-support">
   <use name="cuda"/>
   <set name="cuda_src" value="*.cu"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="CUDADataFormats/Track"/>
+  <use name="CUDADataFormats/TrackingRecHit"/>
 <else/>
   <set name="cuda_src" value=""/>
 </iftool>

--- a/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/CAHitNtupletGeneratorKernels.h
@@ -40,6 +40,15 @@ namespace caHitNtupletGenerator {
     const float hardCurvCut_;
     const float dcaCutInnerTriplet_;
     const float dcaCutOuterTriplet_;
+    const float CAThetaCutBarrelPixelBarrelStrip_;
+    const float CAThetaCutBarrelPixelForwardStrip_;
+    const float CAThetaCutBarrelStripForwardStrip_;
+    const float CAThetaCutBarrelStrip_;
+    const float CAThetaCutDefault_;
+    const float dcaCutInnerTripletPixelStrip_;
+    const float dcaCutOuterTripletPixelStrip_;
+    const float dcaCutTripletStrip_;
+    const float dcaCutTripletDefault_;
   };
 
   template <typename TrackerTraits, typename Enable = void>

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CACell.h
@@ -2,16 +2,14 @@
 #define RecoTracker_PixelSeeding_plugins_alpaka_CACell_h
 
 // #define ONLY_TRIPLETS_IN_HOLE
-
 #include <cmath>
 #include <limits>
-
 #include <alpaka/alpaka.hpp>
 
 #include "DataFormats/TrackSoA/interface/TrackDefinitions.h"
 #include "DataFormats/TrackSoA/interface/TracksSoA.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -43,7 +41,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using HitContainer = typename reco::TrackSoA<TrackerTraits>::HitContainer;
     using Quality = ::pixelTrack::Quality;
     static constexpr auto bad = ::pixelTrack::Quality::bad;
-
     enum class StatusBit : uint16_t { kUsed = 1, kInTrack = 2, kKilled = 1 << 15 };
 
     CACellT() = default;
@@ -164,10 +161,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                        const float caThetaCutBarrel,
                                        const float caThetaCutForward,
                                        const float dcaCutInnerTriplet,
-                                       const float dcaCutOuterTriplet) const {
+                                       const float dcaCutOuterTriplet,
+                                       const float caThetaCutBarrelPixelBarrelStrip,
+                                       const float caThetaCutBarrelPixelForwardStrip,
+                                       const float caThetaCutBarrelStripForwardStrip,
+                                       const float caThetaCutBarrelStrip,
+                                       const float caThetaCutDefault,
+                                       const float dcaCutInnerTripletPixelStrip,
+                                       const float dcaCutOuterTripletPixelStrip,
+                                       const float dcaCutTripletStrip,
+                                       const float dcaCutTripletDefault) const {
       // detIndex of the layerStart for the Phase1 Pixel Detector:
       // [BPX1, BPX2, BPX3, BPX4,  FP1,  FP2,  FP3,  FN1,  FN2,  FN3, LAST_VALID]
-      // [   0,   96,  320,  672, 1184, 1296, 1408, 1520, 1632, 1744,       1856]
+      // [   0,   96,  320,  672, 1184, 1296, 1408, 1520, 1632, 1744,       1856] , 3392 TIB2
       auto ri = inner_r(hh);
       auto zi = inner_z(hh);
 
@@ -176,13 +182,42 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       auto r1 = otherCell.inner_r(hh);
       auto z1 = otherCell.inner_z(hh);
-      auto isBarrel = otherCell.outer_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
       // TODO tune CA cuts below (theta and dca)
-      bool aligned = areAlignedRZ(r1, z1, ri, zi, ro, zo, ptmin, isBarrel ? caThetaCutBarrel : caThetaCutForward);
+      // Distinguish caThetaCuts for different cases
+      float caThetaCut;
+
+      auto isOuterBarrelPixel = otherCell.outer_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
+      auto isInnerBarrelPixel = otherCell.inner_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
+      auto isOuterForwardPixel = otherCell.outer_detIndex(hh) >= TrackerTraits::last_barrel_detIndex && otherCell.outer_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+      auto isInnerForwardPixel = otherCell.inner_detIndex(hh) >= TrackerTraits::last_barrel_detIndex && otherCell.inner_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+      auto isOuterBarrelStrip =  otherCell.outer_detIndex(hh) >= TrackerTraits::numberOfPixelModules && otherCell.outer_detIndex(hh) < 3392;
+      auto isInnerBarrelStrip =  otherCell.inner_detIndex(hh) >= TrackerTraits::numberOfPixelModules && otherCell.inner_detIndex(hh) < 3392;
+      auto isOuterForwardStrip = otherCell.outer_detIndex(hh) >= 3392;
+      auto isInnerForwardStrip = otherCell.inner_detIndex(hh) >= 3392;
+      caThetaCut = (isInnerBarrelPixel && isOuterBarrelPixel) ? caThetaCutBarrel :
+             (isInnerBarrelPixel && isOuterForwardPixel) ? caThetaCutForward :
+             (isInnerBarrelPixel && isOuterBarrelStrip) ? caThetaCutBarrelPixelBarrelStrip :
+             (isInnerBarrelPixel && isOuterForwardStrip) ? caThetaCutBarrelPixelForwardStrip :
+             (isInnerBarrelStrip && isOuterForwardStrip) ? caThetaCutBarrelStripForwardStrip :
+             (isInnerBarrelStrip && isOuterBarrelStrip) ? caThetaCutBarrelStrip :
+             caThetaCutDefault;
+
+      auto isFirstInnerBarrelPixel = otherCell.inner_detIndex(hh) < TrackerTraits::last_bpix1_detIndex;
+      auto isBeyondFirstInnerBarrelPixel = otherCell.inner_detIndex(hh) > TrackerTraits::last_bpix1_detIndex && otherCell.inner_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+      float dcaCutTriplet;
+     
+      dcaCutTriplet = (isFirstInnerBarrelPixel && (isOuterBarrelStrip || isOuterForwardStrip)) ? dcaCutInnerTripletPixelStrip :
+                (isBeyondFirstInnerBarrelPixel && (isOuterBarrelStrip || isOuterForwardStrip)) ? dcaCutOuterTripletPixelStrip :
+                (isFirstInnerBarrelPixel && (isOuterBarrelPixel || isOuterForwardPixel)) ? dcaCutInnerTriplet :
+                (isBeyondFirstInnerBarrelPixel && (isOuterBarrelPixel || isOuterForwardPixel)) ? dcaCutOuterTriplet :
+                ((isInnerBarrelStrip || isInnerForwardStrip) && (isOuterBarrelStrip || isOuterForwardStrip)) ? dcaCutTripletStrip :
+                dcaCutTripletDefault;
+
+
+      bool aligned = areAlignedRZ(r1, z1, ri, zi, ro, zo, ptmin, caThetaCut);
       return (aligned && dcaCut(hh,
                                 otherCell,
-                                otherCell.inner_detIndex(hh) < TrackerTraits::last_bpix1_detIndex ? dcaCutInnerTriplet
-                                                                                                  : dcaCutOuterTriplet,
+                                dcaCutTriplet,
                                 hardCurvCut));
     }
 
@@ -316,7 +351,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               acc, hh, cells, cellTracks, foundNtuplets, apc, quality, tmpNtuplet, minHitsPerNtuplet, startAt0);
         }
         if (last) {  // if long enough save...
-          if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet - 1) {
+          if ((unsigned int)(tmpNtuplet.size()) >= minHitsPerNtuplet - 1){
 #ifdef ONLY_TRIPLETS_IN_HOLE
             // triplets accepted only pointing to the hole
             if (tmpNtuplet.size() >= 3 || (startAt0 && hole4(hh, cells[tmpNtuplet[0]])) ||
@@ -337,11 +372,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
               ALPAKA_ASSERT_ACC(nh < TrackerTraits::maxHitsOnTrack);
               hits[nh] = theOuterHitId;
               auto it = foundNtuplets.bulkFill(acc, apc, hits, nh + 1);
+	      
               if (it >= 0) {  // if negative is overflow....
                 for (auto c : tmpNtuplet)
                   cells[c].addTrack(acc, it, cellTracks);
                 quality[it] = bad;  // initialize to bad
               }
+	      else{
+		//printf("Going into overflow from bulkFill");
+	      }
             }
           }
         }

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -21,6 +21,8 @@
 #include "CAPixelDoublets.h"
 #include "CAPixelDoubletsAlgos.h"
 
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace {
 
@@ -46,6 +48,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           ->setComment("Cut on minimum curvature, used in DCA ntuplet selection");
       desc.add<double>("dcaCutInnerTriplet", 0.15f)->setComment("Cut on origin radius when the inner hit is on BPix1");
       desc.add<double>("dcaCutOuterTriplet", 0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
+      desc.add<double>("CAThetaCutBarrelPixelBarrelStrip",0.002f)->setComment("Cut on RZ alignement for Barrel");
+      desc.add<double>("CAThetaCutBarrelPixelForwardStrip",0.003f)->setComment("Cut on RZ alignment for Forward");
+      desc.add<double>("CAThetaCutBarrelStripForwardStrip",0.003f)->setComment("Cut on RZ alignment for Forward");
+      desc.add<double>("CAThetaCutBarrelStrip",0.002f)->setComment("Cut on RZ alignement for Barrel");
+      desc.add<double>("CAThetaCutDefault",0.003f)->setComment("Cut on RZ alignment for Default");
+      desc.add<double>("dcaCutInnerTripletPixelStrip",0.15f)->setComment("Cut on origin radius when the inner hit is on BPix1");
+      desc.add<double>("dcaCutOuterTripletPixelStrip",0.25f)->setComment("Cut on origin radius when the outer hit is on BPix1");
+      desc.add<double>("dcaCutTripletStrip",0.25f)->setComment("Cut on origin radius when the outer hit is on Strip");
+      desc.add<double>("dcaCutTripletDefault",0.25f)->setComment("Cut on origin radius default");
       desc.add<bool>("earlyFishbone", true);
       desc.add<bool>("lateFishbone", false);
       desc.add<bool>("fillStatistics", false);
@@ -61,6 +72,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       desc.add<bool>("doSharedHitCut", true)->setComment("Sharing hit nTuples cleaning");
       desc.add<bool>("dupPassThrough", false)->setComment("Do not reject duplicate");
       desc.add<bool>("useSimpleTripletCleaner", true)->setComment("use alternate implementation");
+      desc.add<bool>("useRemovers", true);
     }
 
     AlgoParams makeCommonParams(edm::ParameterSet const& cfg) {
@@ -73,7 +85,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                          cfg.getParameter<bool>("fillStatistics"),
                          cfg.getParameter<bool>("doSharedHitCut"),
                          cfg.getParameter<bool>("dupPassThrough"),
-                         cfg.getParameter<bool>("useSimpleTripletCleaner")});
+                         cfg.getParameter<bool>("useSimpleTripletCleaner"),
+	                 cfg.getParameter<bool>("useRemovers")});
     }
 
     //This is needed to have the partial specialization for isPhase1Topology/isPhase2Topology
@@ -90,7 +103,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                          (float)cfg.getParameter<double>("CAThetaCutForward"),
                                          (float)cfg.getParameter<double>("hardCurvCut"),
                                          (float)cfg.getParameter<double>("dcaCutInnerTriplet"),
-                                         (float)cfg.getParameter<double>("dcaCutOuterTriplet")}};
+                                         (float)cfg.getParameter<double>("dcaCutOuterTriplet"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelPixelBarrelStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelPixelForwardStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelStripForwardStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutDefault"),
+                                         (float)cfg.getParameter<double>("dcaCutInnerTripletPixelStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutOuterTripletPixelStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutTripletStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutTripletDefault")}};
       };
 
       static constexpr ::pixelTrack::QualityCutsT<TrackerTraits> makeQualityCuts(edm::ParameterSet const& pset) {
@@ -125,7 +147,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                          (float)cfg.getParameter<double>("CAThetaCutForward"),
                                          (float)cfg.getParameter<double>("hardCurvCut"),
                                          (float)cfg.getParameter<double>("dcaCutInnerTriplet"),
-                                         (float)cfg.getParameter<double>("dcaCutOuterTriplet")},
+                                         (float)cfg.getParameter<double>("dcaCutOuterTriplet"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelPixelBarrelStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelPixelForwardStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelStripForwardStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutBarrelStrip"),
+                                         (float)cfg.getParameter<double>("CAThetaCutDefault"),
+                                         (float)cfg.getParameter<double>("dcaCutInnerTripletPixelStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutOuterTripletPixelStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutTripletStrip"),
+                                         (float)cfg.getParameter<double>("dcaCutTripletDefault")},
                                         {(bool)cfg.getParameter<bool>("includeFarForwards")}};
       }
 
@@ -150,7 +181,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                       cfg.getParameter<bool>("idealConditions"),
                                       (float)cfg.getParameter<double>("cellZ0Cut"),
                                       (float)cfg.getParameter<double>("cellPtCut"),
-                                      cfg.getParameter<std::vector<int>>("phiCuts")};
+                                      cfg.getParameter<std::vector<int>>("phiCuts"),
+                                      cfg.getParameter<std::vector<double>>("minz"),
+                                      cfg.getParameter<std::vector<double>>("maxz"),
+                                      cfg.getParameter<std::vector<double>>("maxr")
+                                      };
     }
 
   }  // namespace
@@ -197,7 +232,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     fillDescriptionsCommon(desc);
 
     desc.add<unsigned int>("maxNumberOfDoublets", pixelTopology::Phase1::maxNumberOfDoublets);
-    desc.add<bool>("idealConditions", true);
+    desc.add<bool>("idealConditions", false);
     desc.add<bool>("includeJumpingForwardDoublets", false);
     desc.add<double>("cellZ0Cut", 12.0);
     desc.add<double>("cellPtCut", 0.5);
@@ -225,6 +260,60 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             "phiCuts",
             std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
         ->setComment("Cuts in phi for cells");
+        
+    desc.add<std::vector<double>>(
+           "minz", std::vector<double>(std::begin(phase1PixelTopology::minz), std::end(phase1PixelTopology::minz)))
+       ->setComment("Cuts in minz for cells");
+    desc.add<std::vector<double>>(
+           "maxz", std::vector<double>(std::begin(phase1PixelTopology::maxz), std::end(phase1PixelTopology::maxz)))
+       ->setComment("Cuts in maxz for cells");
+    desc.add<std::vector<double>>(
+           "maxr", std::vector<double>(std::begin(phase1PixelTopology::maxr), std::end(phase1PixelTopology::maxr)))
+       ->setComment("Cuts in maxr for cells");
+  }
+
+  
+  template <>
+  void CAHitNtupletGenerator<pixelTopology::Phase1Strip>::fillPSetDescription(edm::ParameterSetDescription& desc) {
+    fillDescriptionsCommon(desc);
+
+    desc.add<unsigned int>("maxNumberOfDoublets", pixelTopology::Phase1::maxNumberOfDoublets);
+    desc.add<bool>("idealConditions", false);
+    desc.add<bool>("includeJumpingForwardDoublets", false);
+    desc.add<double>("cellZ0Cut", 12.0);
+    desc.add<double>("cellPtCut", 0.5);
+
+    edm::ParameterSetDescription trackQualityCuts;
+    trackQualityCuts.add<double>("chi2MaxPt", 10.)->setComment("max pT used to determine the pT-dependent chi2 cut");
+    trackQualityCuts.add<std::vector<double>>("chi2Coeff", {0.9, 1.8})->setComment("chi2 at 1GeV and at ptMax above");
+    trackQualityCuts.add<double>("chi2Scale", 8.)
+        ->setComment(
+            "Factor to multiply the pT-dependent chi2 cut (currently: 8 for the broken line fit, ?? for the Riemann "
+            "fit)");
+    trackQualityCuts.add<double>("tripletMinPt", 1.0)->setComment("Min pT for triplets, in GeV");
+    trackQualityCuts.add<double>("tripletMaxTip", 0.3)->setComment("Max |Tip| for triplets, in cm");
+    trackQualityCuts.add<double>("tripletMaxZip", 12.)->setComment("Max |Zip| for triplets, in cm");
+    trackQualityCuts.add<double>("quadrupletMinPt", 0.5)->setComment("Min pT for quadruplets, in GeV");
+    trackQualityCuts.add<double>("quadrupletMaxTip", 0.5)->setComment("Max |Tip| for quadruplets, in cm");
+    trackQualityCuts.add<double>("quadrupletMaxZip", 12.)->setComment("Max |Zip| for quadruplets, in cm");
+    desc.add<edm::ParameterSetDescription>("trackQualityCuts", trackQualityCuts)
+        ->setComment(
+            "Quality cuts based on the results of the track fit:\n  - apply a pT-dependent chi2 cut;\n  - apply "
+            "\"region "
+            "cuts\" based on the fit results (pT, Tip, Zip).");
+    
+    desc.add<std::vector<int>>(
+           "phiCuts", std::vector<int>(std::begin(phase1PixelStripTopology::phicuts), std::end(phase1PixelStripTopology::phicuts)))
+       ->setComment("Cuts in phi for cells");
+    desc.add<std::vector<double>>(
+           "minz", std::vector<double>(std::begin(phase1PixelStripTopology::minz), std::end(phase1PixelStripTopology::minz)))
+       ->setComment("Cuts in minz for cells");
+    desc.add<std::vector<double>>(
+           "maxz", std::vector<double>(std::begin(phase1PixelStripTopology::maxz), std::end(phase1PixelStripTopology::maxz)))
+       ->setComment("Cuts in maxz for cells");
+    desc.add<std::vector<double>>(
+           "maxr", std::vector<double>(std::begin(phase1PixelStripTopology::maxr), std::end(phase1PixelStripTopology::maxr)))
+       ->setComment("Cuts in maxr for cells");
   }
 
   template <>
@@ -261,6 +350,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             "phiCuts",
             std::vector<int>(std::begin(phase1PixelTopology::phicuts), std::end(phase1PixelTopology::phicuts)))
         ->setComment("Cuts in phi for cells");
+         
+   desc.add<std::vector<double>>(
+           "minz", std::vector<double>(std::begin(phase1PixelTopology::minz), std::end(phase1PixelTopology::minz)))
+       ->setComment("Cuts in minz for cells");
+    desc.add<std::vector<double>>(
+           "maxz", std::vector<double>(std::begin(phase1PixelTopology::maxz), std::end(phase1PixelTopology::maxz)))
+       ->setComment("Cuts in maxz for cells");
+    desc.add<std::vector<double>>(
+           "maxr", std::vector<double>(std::begin(phase1PixelTopology::maxr), std::end(phase1PixelTopology::maxr)))
+       ->setComment("Cuts in maxr for cells");
   }
 
   template <>
@@ -285,14 +384,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             "Zip).");
 
     desc.add<std::vector<int>>(
-            "phiCuts",
-            std::vector<int>(std::begin(phase2PixelTopology::phicuts), std::end(phase2PixelTopology::phicuts)))
-        ->setComment("Cuts in phi for cells");
+           "phiCuts", std::vector<int>(std::begin(phase2PixelTopology::phicuts), std::end(phase2PixelTopology::phicuts)))
+       ->setComment("Cuts in phi for cells");
+    desc.add<std::vector<double>>(
+           "minz", std::vector<double>(std::begin(phase2PixelTopology::minz), std::end(phase2PixelTopology::minz)))
+       ->setComment("Cuts in minz for cells");
+    desc.add<std::vector<double>>(
+           "maxz", std::vector<double>(std::begin(phase2PixelTopology::maxz), std::end(phase2PixelTopology::maxz)))
+       ->setComment("Cuts in maxz for cells");
+    desc.add<std::vector<double>>(
+           "maxr", std::vector<double>(std::begin(phase2PixelTopology::maxr), std::end(phase2PixelTopology::maxr)))
+       ->setComment("Cuts in maxr for cells");
   }
 
   template <typename TrackerTraits>
   TracksSoACollection<TrackerTraits> CAHitNtupletGenerator<TrackerTraits>::makeTuplesAsync(
-      HitsOnDevice const& hits_d, ParamsOnDevice const* cpeParams, float bfield, Queue& queue) const {
+    //   HitsOnDevice const& hits_d, ParamsOnDevice const* cpeParams, float bfield, Queue& queue) const {
+      HitsOnDevice const& hits_d, FrameOnDevice const& frame, float bfield, Queue& queue) const {
     using HelixFit = HelixFit<TrackerTraits>;
     using TrackSoA = TracksSoACollection<TrackerTraits>;
     using GPUKernels = CAHitNtupletGeneratorKernels<TrackerTraits>;
@@ -315,10 +423,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     fitter.allocate(kernels.tupleMultiplicity(), tracks.view());
     if (m_params.useRiemannFit_) {
       fitter.launchRiemannKernels(
-          hits_d.view(), cpeParams, hits_d.view().metadata().size(), TrackerTraits::maxNumberOfQuadruplets, queue);
+          hits_d.view(), frame.view(), hits_d.view().metadata().size(), TrackerTraits::maxNumberOfQuadruplets, queue);
     } else {
       fitter.launchBrokenLineKernels(
-          hits_d.view(), cpeParams, hits_d.view().metadata().size(), TrackerTraits::maxNumberOfQuadruplets, queue);
+          hits_d.view(), frame.view(), hits_d.view().metadata().size(), TrackerTraits::maxNumberOfQuadruplets, queue);
     }
     kernels.classifyTuples(hits_d.view(), tracks.view(), queue);
 #ifdef GPU_DEBUG
@@ -329,7 +437,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     return tracks;
   }
 
+
   template class CAHitNtupletGenerator<pixelTopology::Phase1>;
   template class CAHitNtupletGenerator<pixelTopology::Phase2>;
   template class CAHitNtupletGenerator<pixelTopology::HIonPhase1>;
+  template class CAHitNtupletGenerator<pixelTopology::Phase1Strip>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.h
@@ -52,8 +52,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     using Params = caHitNtupletGenerator::ParamsT<TrackerTraits>;
     using Counters = caHitNtupletGenerator::Counters;
 
-    using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
-
+    //using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::base_traits_t<TrackerTraits>>;
+    using FrameOnDevice = FrameSoACollection;
   public:
     CAHitNtupletGenerator(const edm::ParameterSet& cfg);
 
@@ -68,7 +68,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // void endJob();
 
     TkSoADevice makeTuplesAsync(HitsOnDevice const& hits_d,
-                                ParamsOnDevice const* cpeParams,
+                                FrameOnDevice const& frame_d,
+                                //ParamsOnDevice const* cpeParams,
                                 float bfield,
                                 Queue& queue) const;
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -1,4 +1,5 @@
 // C++ headers
+
 #ifdef DUMP_GPU_TK_TUPLES
 #include <mutex>
 #endif
@@ -18,7 +19,8 @@
 #include "CAHitNtupletGeneratorKernelsImpl.h"
 
 //#define GPU_DEBUG
-//#define NTUPLE_DEBUG
+#define NTUPLE_DEBUG
+#define NTUPLE_DEBUGS
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -215,7 +217,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // remove duplicates (tracks that share a doublet)
     numberOfBlocks = cms::alpakatools::divide_up_by(3 * m_params.caParams_.maxNumberOfDoublets_ / 4, blockSize);
     workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
-
+    if(this->m_params.useRemovers_){
     alpaka::exec<Acc1D>(queue,
                         workDiv1D,
                         Kernel_earlyDuplicateRemover<TrackerTraits>{},
@@ -223,6 +225,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         this->device_nCells_.data(),
                         tracks_view,
                         this->m_params.dupPassThrough_);
+			}
 #ifdef GPU_DEBUG
     alpaka::wait(queue);
 #endif
@@ -391,13 +394,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // mark duplicates (tracks that share a doublet)
     numberOfBlocks = cms::alpakatools::divide_up_by(3 * m_params.caParams_.maxNumberOfDoublets_ / 4, blockSize);
     workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
-    alpaka::exec<Acc1D>(queue,
+    if(this->m_params.useRemovers_){
+      alpaka::exec<Acc1D>(queue,
                         workDiv1D,
                         Kernel_fastDuplicateRemover<TrackerTraits>{},
                         this->device_theCells_.data(),
                         this->device_nCells_.data(),
                         tracks_view,
                         this->m_params.dupPassThrough_);
+			}
 #ifdef GPU_DEBUG
     alpaka::wait(queue);
 #endif
@@ -425,6 +430,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       numberOfBlocks = cms::alpakatools::divide_up_by(3 * TrackerTraits::maxNumberOfQuadruplets / 4,
                                                       blockSize);  // TODO: Check if correct
       workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(numberOfBlocks, blockSize);
+      
       alpaka::exec<Acc1D>(queue,
                           workDiv1D,
                           Kernel_rejectDuplicate<TrackerTraits>{},
@@ -441,7 +447,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                           this->m_params.minHitsForSharingCut_,
                           this->m_params.dupPassThrough_,
                           this->device_hitToTuple_.data());
-
+      
       if (this->m_params.useSimpleTripletCleaner_) {
         // (typename HitToTuple{}::capacity(),
         numberOfBlocks = cms::alpakatools::divide_up_by(HitToTuple{}.capacity(), blockSize);
@@ -464,6 +470,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                             this->m_params.dupPassThrough_,
                             this->device_hitToTuple_.data());
       }
+
 #ifdef GPU_DEBUG
       alpaka::wait(queue);
 #endif
@@ -557,5 +564,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template class CAHitNtupletGeneratorKernels<pixelTopology::Phase1>;
   template class CAHitNtupletGeneratorKernels<pixelTopology::Phase2>;
   template class CAHitNtupletGeneratorKernels<pixelTopology::HIonPhase1>;
+  template class CAHitNtupletGeneratorKernels<pixelTopology::Phase1Strip>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.dev.cc
@@ -19,8 +19,8 @@
 #include "CAHitNtupletGeneratorKernelsImpl.h"
 
 //#define GPU_DEBUG
-#define NTUPLE_DEBUG
-#define NTUPLE_DEBUGS
+//#define NTUPLE_DEBUG
+//#define NTUPLE_DEBUGS
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
@@ -36,6 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const bool doSharedHitCut_;
       const bool dupPassThrough_;
       const bool useSimpleTripletCleaner_;
+      const bool useRemovers_;
     };
 
     //CAParams
@@ -48,6 +49,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const float hardCurvCut_;
       const float dcaCutInnerTriplet_;
       const float dcaCutOuterTriplet_;
+      const float CAThetaCutBarrelPixelBarrelStrip_;
+      const float CAThetaCutBarrelPixelForwardStrip_;
+      const float CAThetaCutBarrelStripForwardStrip_;
+      const float CAThetaCutBarrelStrip_;
+      const float CAThetaCutDefault_;
+      const float dcaCutInnerTripletPixelStrip_;
+      const float dcaCutOuterTripletPixelStrip_;
+      const float dcaCutTripletStrip_;
+      const float dcaCutTripletDefault_;
     };
 
     template <typename TrackerTraits, typename Enable = void>
@@ -60,15 +70,26 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     struct CAParamsT<TrackerTraits, pixelTopology::isPhase1Topology<TrackerTraits>> : public CACommon {
       /// Is is a starting layer pair?
       ALPAKA_FN_ACC ALPAKA_FN_INLINE bool startingLayerPair(int16_t pid) const {
-        return minHitsPerNtuplet_ > 3 ? pid < 3 : pid < 8 || pid > 12;
+        if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1Strip>) {
+         return (pid < 12 || pid == 37 || pid == 38 || pid == 34  || pid == 32 || pid == 18 || pid == 48);
+        }
+        else{
+          return minHitsPerNtuplet_ > 3 ? pid < 3 : pid < 8 || pid > 12;
+        }
       }
 
       /// Is this a pair with inner == 0?
       ALPAKA_FN_ACC ALPAKA_FN_INLINE bool startAt0(int16_t pid) const {
-        ALPAKA_ASSERT_ACC(
-            (pixelTopology::Phase1::layerPairs[pid * 2] == 0) ==
-            (pid < 3 || pid == 13 || pid == 15 || pid == 16));  // to be 100% sure it's working, may be removed
+        if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1Strip>) {
+        assert((pixelTopology::Phase1Strip::layerPairs[pid * 2] == 0) ==
+               (pid < 3 || pid == 8 || pid == 10 || pid == 11 || pid == 34 ));  // to be 100% sure it's working, may be removed
+        return pixelTopology::Phase1Strip::layerPairs[pid * 2] == 0;
+        }
+        else{
+           assert((pixelTopology::Phase1::layerPairs[pid * 2] == 0) ==
+               (pid < 3 || pid == 13 || pid == 15 || pid == 16));  // to be 100% sure it's working, may be removed
         return pixelTopology::Phase1::layerPairs[pid * 2] == 0;
+        }
       }
     };
 

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_PixelSeeding_plugins_alpaka_CAHitNtupletGeneratorKernelsImpl_h
 #define RecoTracker_PixelSeeding_plugins_alpaka_CAHitNtupletGeneratorKernelsImpl_h
 
-//#define GPU_DEBUG
-//#define NTUPLE_DEBUG
+#define GPU_DEBUG
+#define NTUPLE_DEBUG
 
 // C++ includes
 #include <cmath>
@@ -123,7 +123,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
       }
 #endif
 
-      if (cms::alpakatools::once_per_grid(acc)) {
+            if (cms::alpakatools::once_per_grid(acc)) {
+      #ifdef GPU_DEBUG
         if (apc->get().first >= TrackerTraits::maxNumberOfQuadruplets)
           printf("Tuples overflow\n");
         if (*nCells >= maxNumberOfDoublets)
@@ -134,13 +135,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
           printf("cellTracks overflow\n");
         if (int(hitToTuple->nOnes()) < nHits)
           printf("ERROR hitToTuple  overflow %d %d\n", hitToTuple->nOnes(), nHits);
-#ifdef GPU_DEBUG
         printf("size of cellNeighbors %d \n cellTracks %d \n hitToTuple %d \n",
                cellNeighbors->size(),
                cellTracks->size(),
                hitToTuple->size());
 #endif
-      }
+	}
 
       for (auto idx : cms::alpakatools::uniform_elements(acc, *nCells)) {
         auto const &thisCell = cells[idx];
@@ -198,14 +198,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
                                   TkSoAView<TrackerTraits> tracks_view,
                                   bool dupPassThrough) const {
       // quality to mark rejected
-      constexpr auto reject = Quality::edup;  /// cannot be loose
+      constexpr auto reject = pixelTrack::Quality::edup;  /// cannot be loose
       ALPAKA_ASSERT_ACC(nCells);
       for (auto idx : cms::alpakatools::uniform_elements(acc, *nCells)) {
         auto const &thisCell = cells[idx];
 
         if (thisCell.tracks().size() < 2)
           continue;
-
+	
         int8_t maxNl = 0;
 
         // find maxNl
@@ -221,7 +221,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
         for (auto it : thisCell.tracks()) {
           if (tracks_view[it].nLayers() < maxNl)
             tracks_view[it].quality() = reject;  // no race: simple assignment of the same constant
-        }
+	    }
       }
     }
   };
@@ -350,8 +350,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
         auto zi = thisCell.inner_z(hh);
         auto ro = thisCell.outer_r(hh);
         auto zo = thisCell.outer_z(hh);
-        auto isBarrel = thisCell.inner_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
-
+        float caThetaCut;
+        auto isOuterBarrelPixel = thisCell.outer_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
+        auto isInnerBarrelPixel = thisCell.inner_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
+        auto isOuterForwardPixel = thisCell.outer_detIndex(hh) >= TrackerTraits::last_barrel_detIndex && thisCell.outer_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+        auto isOuterBarrelStrip =  thisCell.outer_detIndex(hh) >= TrackerTraits::numberOfPixelModules && thisCell.outer_detIndex(hh) < 3392;
+        auto isInnerBarrelStrip =  thisCell.inner_detIndex(hh) >= TrackerTraits::numberOfPixelModules && thisCell.inner_detIndex(hh) < 3392;
+        auto isOuterForwardStrip = thisCell.outer_detIndex(hh) >= 3392;
+        caThetaCut = (isInnerBarrelPixel && isOuterBarrelPixel) ? params.CAThetaCutBarrel_ :
+             (isInnerBarrelPixel && isOuterForwardPixel) ? params.CAThetaCutForward_ :
+             (isInnerBarrelPixel && isOuterBarrelStrip) ? params.CAThetaCutBarrelPixelBarrelStrip_ :
+             (isInnerBarrelPixel && isOuterForwardStrip) ? params.CAThetaCutBarrelPixelForwardStrip_ :
+             (isInnerBarrelStrip && isOuterForwardStrip) ? params.CAThetaCutBarrelStripForwardStrip_ :
+             (isInnerBarrelStrip && isOuterBarrelStrip) ? params.CAThetaCutBarrelStrip_ :
+             params.CAThetaCutDefault_;
         // loop on inner cells
         for (uint32_t j : cms::alpakatools::independent_group_elements_x(acc, numberOfPossibleNeighbors)) {
           auto otherCell = (vi[j]);
@@ -366,12 +378,26 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
               ro,
               zo,
               params.ptmin_,
-              isBarrel ? params.CAThetaCutBarrel_ : params.CAThetaCutForward_);  // 2.f*thetaCut); // FIXME tune cuts
+              caThetaCut);  // 2.f*thetaCut); // FIXME tune cuts
+            auto isOuterBarrelPixel = oc.outer_detIndex(hh) < TrackerTraits::last_barrel_detIndex;
+            auto isOuterForwardPixel = oc.outer_detIndex(hh) >= TrackerTraits::last_barrel_detIndex && oc.outer_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+            auto isOuterBarrelStrip =  oc.outer_detIndex(hh) >= TrackerTraits::numberOfPixelModules && oc.outer_detIndex(hh) < 3392;
+            auto isInnerBarrelStrip =  oc.inner_detIndex(hh) >= TrackerTraits::numberOfPixelModules && oc.inner_detIndex(hh) < 3392;
+            auto isOuterForwardStrip = oc.outer_detIndex(hh) >= 3392;
+            auto isInnerForwardStrip = oc.inner_detIndex(hh) >= 3392;
+            auto isFirstInnerBarrelPixel = oc.inner_detIndex(hh) < TrackerTraits::last_bpix1_detIndex;
+            auto isBeyondFirstInnerBarrelPixel = oc.inner_detIndex(hh) > TrackerTraits::last_bpix1_detIndex && oc.inner_detIndex(hh) < TrackerTraits::numberOfPixelModules;
+            float dcaCutTriplet;
+            dcaCutTriplet = (isFirstInnerBarrelPixel && (isOuterBarrelStrip || isOuterForwardStrip)) ? params.dcaCutInnerTripletPixelStrip_ :
+                (isBeyondFirstInnerBarrelPixel && (isOuterBarrelStrip || isOuterForwardStrip)) ? params.dcaCutOuterTripletPixelStrip_ :
+                (isFirstInnerBarrelPixel && (isOuterBarrelPixel || isOuterForwardPixel)) ? params.dcaCutInnerTriplet_ :
+                (isBeyondFirstInnerBarrelPixel && (isOuterBarrelPixel || isOuterForwardPixel)) ? params.dcaCutOuterTriplet_ :
+                ((isInnerBarrelStrip || isInnerForwardStrip) && (isOuterBarrelStrip || isOuterForwardStrip)) ? params.dcaCutTripletStrip_ :
+                params.dcaCutTripletDefault_;
           if (aligned &&
               thisCell.dcaCut(hh,
                               oc,
-                              oc.inner_detIndex(hh) < TrackerTraits::last_bpix1_detIndex ? params.dcaCutInnerTriplet_
-                                                                                         : params.dcaCutOuterTriplet_,
+                              dcaCutTriplet,
                               params.hardCurvCut_)) {  // FIXME tune cuts
             oc.addOuterNeighbor(acc, cellIndex, *cellNeighbors);
             thisCell.setStatusBits(Cell::StatusBit::kUsed);
@@ -396,23 +422,21 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
       // recursive: not obvious to widen
 
       using Cell = CACellT<TrackerTraits>;
-
 #ifdef GPU_DEBUG
       if (cms::alpakatools::once_per_grid(acc))
         printf("starting producing ntuplets from %d cells \n", *nCells);
 #endif
-
       for (auto idx : cms::alpakatools::uniform_elements(acc, (*nCells))) {
         auto const &thisCell = cells[idx];
-
+	
         // cut by earlyFishbone
         if (thisCell.isKilled())
           continue;
-
+	
         // we require at least three hits
         if (thisCell.outerNeighbors().empty())
           continue;
-
+	
         auto pid = thisCell.layerPairId();
         bool doit = params.startingLayerPair(pid);
 
@@ -512,7 +536,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
 
         // if duplicate: not even fit
         if (tracks_view[it].quality() == Quality::edup)
-          continue;
+           continue;
 
         ALPAKA_ASSERT_ACC(tracks_view[it].quality() == Quality::bad);
 
@@ -888,9 +912,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
       }  // loop over hits
     }
   };
-
-  template <typename TrackerTraits>
-  class Kernel_simpleTripletCleaner {
+  
+template <typename TrackerTraits>
+class Kernel_simpleTripletCleaner {
   public:
     template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
     ALPAKA_FN_ACC void operator()(TAcc const &acc,
@@ -927,13 +951,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::caHitNtupletGeneratorKernels {
         // mark worse ambiguities
         for (auto ip = hitToTuple.begin(idx); ip != hitToTuple.end(idx); ++ip) {
           auto const it = *ip;
-          if (tracks_view[it].quality() > reject && reco::isTriplet(tracks_view, it) && it != im)
+          if (tracks_view[it].quality() > reject && tracks_view.hitIndices().size(it) < 4 && it != im)
             tracks_view[it].quality() = reject;  //no race:  simple assignment of the same constant
         }
 
       }  // loop over hits
     }
-  };
+};
+
 
   template <typename TrackerTraits>
   class Kernel_print_found_ntuplets {

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernelsImpl.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_PixelSeeding_plugins_alpaka_CAHitNtupletGeneratorKernelsImpl_h
 #define RecoTracker_PixelSeeding_plugins_alpaka_CAHitNtupletGeneratorKernelsImpl_h
 
-#define GPU_DEBUG
-#define NTUPLE_DEBUG
+//#define GPU_DEBUG
+//#define NTUPLE_DEBUG
 
 // C++ includes
 #include <cmath>

--- a/RecoTracker/PixelSeeding/plugins/alpaka/HelixFit.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/HelixFit.cc
@@ -18,4 +18,5 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template class HelixFit<pixelTopology::Phase1>;
   template class HelixFit<pixelTopology::Phase2>;
   template class HelixFit<pixelTopology::HIonPhase1>;
+  template class HelixFit<pixelTopology::Phase1Strip>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoTracker/PixelSeeding/plugins/alpaka/HelixFit.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/HelixFit.h
@@ -8,9 +8,11 @@
 #include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "RecoTracker/PixelTrackFitting/interface/alpaka/FitResult.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/alpaka/FrameSoACollection.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/FrameSoALayout.h"
 
 #include "CAStructures.h"
 
@@ -69,16 +71,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ~HelixFit() { deallocate(); }
 
     void setBField(double bField) { bField_ = bField; }
-    void launchRiemannKernels(const HitConstView &hv,
-                              ParamsOnDevice const *cpeParams,
-                              uint32_t nhits,
-                              uint32_t maxNumberOfTuples,
-                              Queue &queue);
-    void launchBrokenLineKernels(const HitConstView &hv,
-                                 ParamsOnDevice const *cpeParams,
-                                 uint32_t nhits,
-                                 uint32_t maxNumberOfTuples,
-                                 Queue &queue);
+    void launchRiemannKernels(const HitConstView &hv, const FrameSoAConstView &fr, uint32_t nhits, uint32_t maxNumberOfTuples, Queue &queue);
+    void launchBrokenLineKernels(const HitConstView &hv, const FrameSoAConstView &fr, uint32_t nhits, uint32_t maxNumberOfTuples, Queue &queue);
 
     void allocate(TupleMultiplicity const *tupleMultiplicity, OutputSoAView &helix_fit_results);
     void deallocate();

--- a/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
@@ -32,7 +32,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   TupleMultiplicity<TrackerTraits> const *__restrict__ tupleMultiplicity,
                                   uint32_t nHits,
                                   TrackingRecHitSoAConstView<TrackerTraits> hh,
-                                  pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const *__restrict__ cpeParams,
+                                  FrameSoAConstView fr,
+                                  // pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::base_traits_t<TrackerTraits>> const *__restrict__ cpeParams,
                                   double *__restrict__ phits,
                                   float *__restrict__ phits_ge,
                                   double *__restrict__ pfast_fit,
@@ -74,7 +75,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         for (unsigned int i = 0; i < hitsInFit; ++i) {
           auto hit = hitId[i];
           float ge[6];
-          cpeParams->detParams(hh[hit].detectorIndex()).frame.toGlobal(hh[hit].xerrLocal(), 0, hh[hit].yerrLocal(), ge);
+          fr.detFrame(hh.detectorIndex(hit)).toGlobal(hh[hit].xerrLocal(), 0, hh[hit].yerrLocal(), ge);
+          // cpeParams->detParams(hh[hit].detectorIndex()).frame.toGlobal(hh[hit].xerrLocal(), 0, hh[hit].yerrLocal(), ge);
 
           hits.col(i) << hh[hit].xGlobal(), hh[hit].yGlobal(), hh[hit].zGlobal();
           hits_ge.col(i) << ge[0], ge[1], ge[2], ge[3], ge[4], ge[5];
@@ -209,8 +211,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   };
 
   template <typename TrackerTraits>
+  // void HelixFit<TrackerTraits>::launchRiemannKernels(const TrackingRecHitSoAConstView<TrackerTraits> &hv,
+  //                                                    pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const *cpeParams,
   void HelixFit<TrackerTraits>::launchRiemannKernels(const TrackingRecHitSoAConstView<TrackerTraits> &hv,
-                                                     pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const *cpeParams,
+                                                     const FrameSoAConstView &fr,
+                                                    //  pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::base_traits_t<TrackerTraits>> const *cpeParams,
                                                      uint32_t nhits,
                                                      uint32_t maxNumberOfTuples,
                                                      Queue &queue) {
@@ -242,7 +247,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                           tupleMultiplicity_,
                           3,
                           hv,
-                          cpeParams,
+                          fr,
                           hitsDevice.data(),
                           hits_geDevice.data(),
                           fast_fit_resultsDevice.data(),
@@ -281,7 +286,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                           tupleMultiplicity_,
                           4,
                           hv,
-                          cpeParams,
+                          fr,
                           hitsDevice.data(),
                           hits_geDevice.data(),
                           fast_fit_resultsDevice.data(),
@@ -321,7 +326,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                             tupleMultiplicity_,
                             5,
                             hv,
-                            cpeParams,
+                            fr,
                             hitsDevice.data(),
                             hits_geDevice.data(),
                             fast_fit_resultsDevice.data(),
@@ -360,7 +365,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                             tupleMultiplicity_,
                             5,
                             hv,
-                            cpeParams,
+                            fr,
                             hitsDevice.data(),
                             hits_geDevice.data(),
                             fast_fit_resultsDevice.data(),
@@ -397,5 +402,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template class HelixFit<pixelTopology::Phase1>;
   template class HelixFit<pixelTopology::Phase2>;
   template class HelixFit<pixelTopology::HIonPhase1>;
+  template class HelixFit<pixelTopology::Phase1Strip>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoTracker/PixelTrackFitting/BuildFile.xml
+++ b/RecoTracker/PixelTrackFitting/BuildFile.xml
@@ -9,7 +9,9 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="DataFormats/TrackingRecHit"/>
+<use name="DataFormats/TrackingRecHitSoA"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/TrackSoA"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -89,7 +89,7 @@ PixelTrackProducerFromSoAT<TrackerTraits>::PixelTrackProducerFromSoAT(const edm:
     throw cms::Exception("PixelTrackConfiguration")
         << iConfig.getParameter<std::string>("minQuality") + " is not a pixelTrack::Quality";
   }
-  if (minQuality_ < pixelTrack::Quality::dup) {
+  if (minQuality_ < pixelTrack::Quality::edup) {
     throw cms::Exception("PixelTrackConfiguration")
         << iConfig.getParameter<std::string>("minQuality") + " not supported";
   }
@@ -107,7 +107,7 @@ void PixelTrackProducerFromSoAT<TrackerTraits>::fillDescriptions(edm::Configurat
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::InputTag>("trackSrc", edm::InputTag("pixelTracksSoA"));
-  desc.add<edm::InputTag>("pixelRecHitLegacySrc", edm::InputTag("siPixelRecHitsPreSplittingLegacy"));
+  desc.add<edm::InputTag>("pixelRecHitLegacySrc", edm::InputTag("siPixelRecHitsPreSplitting"));
   desc.add<int>("minNumberOfHits", 0);
   desc.add<std::string>("minQuality", "loose");
   descriptions.addWithDefaultLabel(desc);

--- a/RecoVertex/Configuration/python/RecoPixelVertexing_cff.py
+++ b/RecoVertex/Configuration/python/RecoPixelVertexing_cff.py
@@ -110,6 +110,12 @@ phase2_tracker.toReplaceWith(pixelVerticesAlpaka,_pixelVerticesAlpakaPhase2.clon
 (pp_on_AA & ~phase2_tracker).toReplaceWith(pixelVerticesAlpaka,_pixelVerticesAlpakaHIonPhase1.clone(doSplitting = False, maxVertices = 32))
 
 from RecoVertex.PixelVertexFinding.pixelVertexFromSoAAlpaka_cfi import pixelVertexFromSoAAlpaka as _pixelVertexFromSoAAlpaka
+# strip tracks
+from RecoVertex.PixelVertexFinding.pixelVertexProducerAlpakaPhase1Strip_cfi import pixelVertexProducerAlpakaPhase1Strip as _pixelVertexProducerAlpakaPhase1Strip
+from Configuration.ProcessModifiers.stripNtupletFit_cff import stripNtupletFit
+
+(alpaka & stripNtupletFit & ~phase2_tracker).toReplaceWith(pixelVerticesAlpaka, _pixelVertexProducerAlpakaPhase1Strip.clone())
+
 alpaka.toReplaceWith(pixelVertices, _pixelVertexFromSoAAlpaka.clone())
 
 # pixel vertex SoA producer with alpaka on the cpu, for validation

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
@@ -1,6 +1,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelStripTopology.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
@@ -107,9 +107,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using PixelVertexProducerAlpakaPhase1 = PixelVertexProducerAlpaka<pixelTopology::Phase1>;
   using PixelVertexProducerAlpakaPhase2 = PixelVertexProducerAlpaka<pixelTopology::Phase2>;
   using PixelVertexProducerAlpakaHIonPhase1 = PixelVertexProducerAlpaka<pixelTopology::HIonPhase1>;
+  using PixelVertexProducerAlpakaPhase1Strip = PixelVertexProducerAlpaka<pixelTopology::Phase1Strip>;
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 DEFINE_FWK_ALPAKA_MODULE(PixelVertexProducerAlpakaPhase1);
 DEFINE_FWK_ALPAKA_MODULE(PixelVertexProducerAlpakaPhase2);
 DEFINE_FWK_ALPAKA_MODULE(PixelVertexProducerAlpakaHIonPhase1);
+DEFINE_FWK_ALPAKA_MODULE(PixelVertexProducerAlpakaPhase1Strip);

--- a/RecoVertex/PixelVertexFinding/plugins/alpaka/vertexFinder.dev.cc
+++ b/RecoVertex/PixelVertexFinding/plugins/alpaka/vertexFinder.dev.cc
@@ -210,5 +210,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template class Producer<pixelTopology::Phase1>;
     template class Producer<pixelTopology::Phase2>;
     template class Producer<pixelTopology::HIonPhase1>;
+    template class Producer<pixelTopology::Phase1Strip>;
   }  // namespace vertexFinder
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
#### PR description:

This PR should introduce the usage of strips layers to the offline reco and HLT Cellular Automaton usage (same work done for 15_0_0_pre1): 
  - the strip addition and the changes in performance are expected only if using the customizer `customizeHLTforAlpakaStrip` for HLT and `stripNTupletFit` for offline reco, final geometry (`Geometry/CommonTopologies/interface/SimplePixelStripTopology.py`) pairs is still work in progress
  - little gain in performance for the CA applied to pixel only due to the removal of `minYsizeB1` and `minYsizeB2` cuts + generalization of `Kernel_simpleTripletCleaner`
  Test on TTbar PU EOR3 TRK DPG v7:
  http://uaf-3.t2.ucsd.edu/~bdanzi/plots_pixelsOnlyValidation_AllCases/plots_hlt_hltPixel/effandfakePtEtaPhi.png
#### PR validation:
Before submitting I was checking
- basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html), some of them still failing with exception like: 
```
A std::exception was thrown.
Connection on "frontier://(preferipfamily=0)(proxyconfigurl=http://grid-wpad/wpad.dat)(backupproxyurl=http://cmst0frontier.cern.ch:3128)(backupproxyurl\
=http://cmst0frontier1.cern.ch:3128)(backupproxyurl=http://cmst0frontier2.cern.ch:3128)(backupproxyurl=http://cmsbpfrontier.cern.ch:3128)(backupproxyur\
l=http://cmsbpfrontier1.cern.ch:3128)(backupproxyurl=http://cmsbpfrontier2.cern.ch:3128)(backupproxyurl=http://cmsbproxy.fnal.gov:3128)(serverurl=http:\
//cmsfrontier.cern.ch:8000/FrontierProd)(serverurl=http://cmsfrontier1.cern.ch:8000/FrontierProd)(serverurl=http://cmsfrontier2.cern.ch:8000/FrontierPr\
od)(serverurl=http://cmsfrontier3.cern.ch:8000/FrontierProd)(serverurl=http://cmsfrontier4.cern.ch:8000/FrontierProd)/CMS_CONDITIONS" cannot be establi\
shed ( CORAL : "ConnectionPool::getSessionFromNewConnection" from "CORAL/Services/ConnectionService" )
----- End Fatal Exception -------------------------------------------------
```
