### PR TITLE
fix the loop range

### DIFF
--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1547,7 +1547,7 @@ namespace mkfit {
                 bool hitExists = false;
                 int maxHits = m_NFoundHits(itrack, 0, 0);
                 if (layer_of_hits.is_pixel()) {
-                  for (int i = 0; i <= maxHits; ++i) {
+                  for (int i = 0; i < maxHits; ++i) {
                     if (i > 2)
                       break;
                     if (m_HoTArrs[itrack][i].layer == layer_of_hits.layer_id()) {
@@ -1758,7 +1758,7 @@ namespace mkfit {
               bool hitExists = false;
               int maxHits = m_NFoundHits(itrack, 0, 0);
               if (layer_of_hits.is_pixel()) {
-                for (int i = 0; i <= maxHits; ++i) {
+                for (int i = 0; i < maxHits; ++i) {
                   if (i > 2)
                     break;
                   if (ccand.hot(i).layer == layer_of_hits.layer_id()) {


### PR DESCRIPTION
possible solution to the reproducibility problem
I followed a reproducer proposed in https://github.com/cms-sw/cmssw/issues/48443#issuecomment-3020167594  using CMSSW_15_1_X_2025-06-29-0000
and found that the divergence starts in this `hitExists` check: the last hit is apparently random and sometimes the "random" hit layer matches with the current layer of hits.
After the change I don't see any differences in the tracks produced in the pixel doublet iteration


@osschar please check/confirm 

@mmasciov perhaps you can run MTV in your am?
I started with an early release to make this branch so that it can be used in 15_0 and 15_1 directly