### PR TITLE
Fit code for internal review/ next steps

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputTrackConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputTrackConverter.cc
@@ -1,0 +1,710 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Geometry/CommonTopologies/interface/GeomDetEnumerators.h"
+
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+#include "DataFormats/TrackReco/interface/SeedStopInfo.h"
+#include "DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/TrackFitters/interface/KFTrajectoryFitter.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
+#include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
+#include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
+
+#include "RecoTracker/MkFit/interface/MkFitEventOfHits.h"
+#include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
+#include "RecoTracker/MkFit/interface/MkFitSeedWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitOutputWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+// mkFit indludes
+#include "RecoTracker/MkFitCMS/interface/LayerNumberConverter.h"
+#include "RecoTracker/MkFitCore/interface/Track.h"
+#include "RecoTracker/MkFitCore/interface/HitStructures.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtra.h"
+
+//extra for DNN with cands
+#include "PhysicsTools/TensorFlow/interface/TfGraphRecord.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "PhysicsTools/TensorFlow/interface/TfGraphDefWrapper.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+namespace {
+  template <typename T>
+  bool isPhase1Barrel(T subdet) {
+    return subdet == PixelSubdetector::PixelBarrel || subdet == StripSubdetector::TIB ||
+           subdet == StripSubdetector::TOB;
+  }
+
+  template <typename T>
+  bool isPhase1Endcap(T subdet) {
+    return subdet == PixelSubdetector::PixelEndcap || subdet == StripSubdetector::TID ||
+           subdet == StripSubdetector::TEC;
+  }
+}  // namespace
+
+class MkFitOutputTrackConverter : public edm::global::EDProducer<> {
+public:
+  explicit MkFitOutputTrackConverter(edm::ParameterSet const& iConfig);
+  ~MkFitOutputTrackConverter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  void convertCandidates(const MkFitOutputWrapper& mkFitOutput,
+                         const mkfit::EventOfHits& eventOfHits,
+                         const MkFitClusterIndexToHit& pixelClusterIndexToHit,
+                         const MkFitClusterIndexToHit& stripClusterIndexToHit,
+                         const edm::View<TrajectorySeed>& seeds,
+                         const MagneticField& mf,
+                         const Propagator& propagatorAlong,
+                         const Propagator& propagatorOpposite,
+                         const MkFitGeometry& mkFitGeom,
+                         const TrackerTopology& tTopo,
+                         const TkClonerImpl& hitCloner,
+                         const std::vector<const DetLayer*>& detLayers,
+                         const mkfit::TrackVec& mkFitSeeds,
+                         const reco::BeamSpot* bs,
+                         reco::TrackCollection& trks,
+                         std::vector<int>& seedIndices,
+                         std::vector<edm::OwnVector<TrackingRecHit>>& hitsVecs) const;
+
+  std::pair<TrajectoryStateOnSurface, const GeomDet*> backwardFit(const FreeTrajectoryState& fts,
+                                                                  const edm::OwnVector<TrackingRecHit>& hits,
+                                                                  const Propagator& propagatorAlong,
+                                                                  const Propagator& propagatorOpposite,
+                                                                  const TkClonerImpl& hitCloner,
+                                                                  const bool isPhase1,
+                                                                  bool lastHitWasInvalid,
+                                                                  bool lastHitWasChanged) const;
+
+  std::pair<TrajectoryStateOnSurface, const GeomDet*> convertInnermostState(const FreeTrajectoryState& fts,
+                                                                            const edm::OwnVector<TrackingRecHit>& hits,
+                                                                            const Propagator& propagatorAlong,
+                                                                            const Propagator& propagatorOpposite) const;
+
+  const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
+  const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
+  const edm::EDGetTokenT<MkFitClusterIndexToHit> stripClusterIndexToHitToken_;
+  const edm::EDGetTokenT<MkFitSeedWrapper> mkfitSeedToken_;
+  const edm::EDGetTokenT<MkFitOutputWrapper> tracksToken_;
+  const edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::EDPutTokenT<reco::TrackCollection> putTrackToken_;
+  const edm::EDPutTokenT<TrackingRecHitCollection> putHitsToken_;
+  const edm::EDPutTokenT<reco::TrackExtraCollection> putExtraToken_;
+  const edm::EDPutTokenT<std::vector<SeedStopInfo>> putSeedStopInfoToken_;
+
+  const float qualityMaxInvPt_;
+  const float qualityMinTheta_;
+  const float qualityMaxRsq_;
+  const float qualityMaxZ_;
+  const float qualityMaxPosErrSq_;
+  const bool qualitySignPt_;
+
+  const bool doErrorRescale_;
+
+  const int algo_;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+};
+
+MkFitOutputTrackConverter::MkFitOutputTrackConverter(edm::ParameterSet const& iConfig)
+    : eventOfHitsToken_{consumes<MkFitEventOfHits>(iConfig.getParameter<edm::InputTag>("mkFitEventOfHits"))},
+      pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitPixelHits"))},
+      stripClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitStripHits"))},
+      mkfitSeedToken_{consumes<MkFitSeedWrapper>(iConfig.getParameter<edm::InputTag>("mkFitSeeds"))},
+      tracksToken_{consumes<MkFitOutputWrapper>(iConfig.getParameter<edm::InputTag>("tracks"))},
+      seedToken_{consumes<edm::View<TrajectorySeed>>(iConfig.getParameter<edm::InputTag>("seeds"))},
+      propagatorAlongToken_{
+          esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
+      propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
+          iConfig.getParameter<edm::ESInputTag>("propagatorOpposite"))},
+      mfToken_{esConsumes<MagneticField, IdealMagneticFieldRecord>()},
+      ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
+          iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
+      mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
+      tTopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
+      //putTrackToken_{produces<reco::TrackCollection>()},
+      //putHitsToken_{produces<TrackingRecHitCollection>()},
+      //putExtraToken_{produces<reco::TrackExtraCollection>()},
+      putSeedStopInfoToken_{produces<std::vector<SeedStopInfo>>()},
+      qualityMaxInvPt_{float(iConfig.getParameter<double>("qualityMaxInvPt"))},
+      qualityMinTheta_{float(iConfig.getParameter<double>("qualityMinTheta"))},
+      qualityMaxRsq_{float(pow(iConfig.getParameter<double>("qualityMaxR"), 2))},
+      qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
+      qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
+      qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
+      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
+      algo_{reco::TrackBase::algoByName(
+          TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
+      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))) {
+  produces<reco::TrackCollection>();
+  produces<TrackingRecHitCollection>();
+  produces<reco::TrackExtraCollection>();
+}
+
+void MkFitOutputTrackConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add("mkFitEventOfHits", edm::InputTag{"mkFitEventOfHits"});
+  desc.add("mkFitPixelHits", edm::InputTag{"mkFitSiPixelHits"});
+  desc.add("mkFitStripHits", edm::InputTag{"mkFitSiStripHits"});
+  desc.add("mkFitSeeds", edm::InputTag{"mkFitSeedConverter"});
+  desc.add("tracks", edm::InputTag{"mkFitProducer"});
+  desc.add("seeds", edm::InputTag{"initialStepSeeds"});
+  desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
+  desc.add("propagatorAlong", edm::ESInputTag{"", "PropagatorWithMaterial"});
+  desc.add("propagatorOpposite", edm::ESInputTag{"", "PropagatorWithMaterialOpposite"});
+
+  desc.add<double>("qualityMaxInvPt", 100)->setComment("max(1/pt) for converted tracks");
+  desc.add<double>("qualityMinTheta", 0.01)->setComment("lower bound on theta (or pi-theta) for converted tracks");
+  desc.add<double>("qualityMaxR", 120)->setComment("max(R) for the state position for converted tracks");
+  desc.add<double>("qualityMaxZ", 280)->setComment("max(|Z|) for the state position for converted tracks");
+  desc.add<double>("qualityMaxPosErr", 100)->setComment("max position error for converted tracks");
+  desc.add<bool>("qualitySignPt", true)->setComment("check sign of 1/pt for converted tracks");
+
+  desc.add<bool>("doErrorRescale", true)->setComment("rescale candidate error before final fit");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void MkFitOutputTrackConverter::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  edm::Handle<edm::View<TrajectorySeed>> hseeds;
+  iEvent.getByToken(seedToken_, hseeds);
+  const auto& seeds = *hseeds;
+  const auto& mkfitSeeds = iEvent.get(mkfitSeedToken_);
+
+  const auto& ttrhBuilder = iSetup.getData(ttrhBuilderToken_);
+  const auto* tkBuilder = dynamic_cast<TkTransientTrackingRecHitBuilder const*>(&ttrhBuilder);
+  if (!tkBuilder) {
+    throw cms::Exception("LogicError") << "TTRHBuilder must be of type TkTransientTrackingRecHitBuilder";
+  }
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
+  //beamspot for trk
+  const reco::BeamSpot* beamspot = &iEvent.get(bsToken_);
+
+  std::unique_ptr<reco::TrackCollection> trks(new reco::TrackCollection);
+  std::unique_ptr<TrackingRecHitCollection> hits(new TrackingRecHitCollection());
+  std::unique_ptr<reco::TrackExtraCollection> extras(new reco::TrackExtraCollection());
+
+  //reco::TrackCollection trks;
+  std::vector<int> seedIndices;
+  std::vector<edm::OwnVector<TrackingRecHit>> hitsVecs;
+
+  //reco::TrackExtraCollection extras;
+  //TrackingRecHitCollection hits;
+
+  // product references
+  reco::TrackExtraRefProd ref_trackextras = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
+  TrackingRecHitRefProd ref_rechits = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+
+  edm::Ref<reco::TrackExtraCollection>::key_type hidx = 0;
+  edm::Ref<reco::TrackExtraCollection>::key_type idx = 0;
+
+  convertCandidates(iEvent.get(tracksToken_),
+                    iEvent.get(eventOfHitsToken_).get(),
+                    iEvent.get(pixelClusterIndexToHitToken_),
+                    iEvent.get(stripClusterIndexToHitToken_),
+                    seeds,
+                    iSetup.getData(mfToken_),
+                    iSetup.getData(propagatorAlongToken_),
+                    iSetup.getData(propagatorOppositeToken_),
+                    iSetup.getData(mkFitGeomToken_),
+                    iSetup.getData(tTopoToken_),
+                    tkBuilder->cloner(),
+                    mkFitGeom.detLayers(),
+                    mkfitSeeds.seeds(),
+                    beamspot,
+                    *trks,
+                    seedIndices,
+                    hitsVecs);
+
+  int i = 0;
+  for (auto& trk : *trks) {
+    for (auto& h : hitsVecs[i])
+      hits->push_back(h);
+
+    reco::TrackExtra extra;
+
+    extra.setHits(ref_rechits, hidx, trk.numberOfValidHits());
+    hidx += trk.numberOfValidHits();
+
+    extra.setSeedRef(edm::RefToBase<TrajectorySeed>(hseeds, seedIndices[i]));
+
+    AlgebraicVector5 v = AlgebraicVector5(0, 0, 0, 0, 0);
+    reco::TrackExtra::TrajParams trajParams(trk.numberOfValidHits(), LocalTrajectoryParameters(v, 1.));
+    reco::TrackExtra::Chi2sFive chi2s(trk.numberOfValidHits(), 0);
+    extra.setTrajParams(std::move(trajParams), std::move(chi2s));
+
+    extras->push_back(extra);
+
+    trk.setExtra(reco::TrackExtraRef(ref_trackextras, idx++));
+
+    i++;
+  }
+
+  // Convert mkfit cands to cmssw tracks
+  //iEvent.emplace(putTrackToken_,trks);
+  //iEvent.emplace(putHitsToken_,hits);
+  //iEvent.emplace(putExtraToken_,extras);
+  iEvent.put(std::move(trks));
+  iEvent.put(std::move(extras));
+  iEvent.put(std::move(hits));
+
+  // TODO: SeedStopInfo is currently unfilled
+  iEvent.emplace(putSeedStopInfoToken_, seeds.size());
+}
+
+void MkFitOutputTrackConverter::convertCandidates(const MkFitOutputWrapper& mkFitOutput,
+                                                  const mkfit::EventOfHits& eventOfHits,
+                                                  const MkFitClusterIndexToHit& pixelClusterIndexToHit,
+                                                  const MkFitClusterIndexToHit& stripClusterIndexToHit,
+                                                  const edm::View<TrajectorySeed>& seeds,
+                                                  const MagneticField& mf,
+                                                  const Propagator& propagatorAlong,
+                                                  const Propagator& propagatorOpposite,
+                                                  const MkFitGeometry& mkFitGeom,
+                                                  const TrackerTopology& tTopo,
+                                                  const TkClonerImpl& hitCloner,
+                                                  const std::vector<const DetLayer*>& detLayers,
+                                                  const mkfit::TrackVec& mkFitSeeds,
+                                                  const reco::BeamSpot* bs,
+                                                  reco::TrackCollection& trks,
+                                                  std::vector<int>& seedIndices,
+                                                  std::vector<edm::OwnVector<TrackingRecHit>>& hitsVecs) const {
+  const auto& candidates = mkFitOutput.tracks();
+  trks.reserve(candidates.size());
+  seedIndices.reserve(candidates.size());
+  hitsVecs.reserve(candidates.size());
+
+  int candIndex = -1;
+  for (const auto& cand : candidates) {
+    ++candIndex;
+    LogTrace("MkFitOutputTrackConverter") << "Candidate " << candIndex << " pT " << cand.pT() << " eta "
+                                          << cand.momEta() << " phi " << cand.momPhi() << " chi2 " << cand.chi2();
+
+    // state: check for basic quality first
+    if (cand.state().invpT() > qualityMaxInvPt_ || (qualitySignPt_ && cand.state().invpT() < 0) ||
+        cand.state().theta() < qualityMinTheta_ || (M_PI - cand.state().theta()) < qualityMinTheta_ ||
+        cand.state().posRsq() > qualityMaxRsq_ || std::abs(cand.state().z()) > qualityMaxZ_ ||
+        (cand.state().errors.At(0, 0) + cand.state().errors.At(1, 1) + cand.state().errors.At(2, 2)) >
+            qualityMaxPosErrSq_) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Candidate " << candIndex << " failed state quality checks" << cand.state().parameters;
+      continue;
+    }
+
+    auto state = cand.state();  // copy because have to modify
+    state.convertFromCCSToGlbCurvilinear();
+    const auto& param = state.parameters;
+    const auto& err = state.errors;
+    AlgebraicSymMatrix55 cov;
+    for (int i = 0; i < 5; ++i) {
+      for (int j = i; j < 5; ++j) {
+        cov[i][j] = err.At(i, j);
+      }
+    }
+
+    auto fts = FreeTrajectoryState(
+        GlobalTrajectoryParameters(
+            GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
+        CurvilinearTrajectoryError(cov));
+    if (!fts.curvilinearError().posDef()) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Curvilinear error not pos-def\n"
+          << fts.curvilinearError().matrix() << "\ncandidate " << candIndex << "ignored";
+      continue;
+    }
+
+    //Sylvester's criterion, start from the smaller submatrix size
+    double det = 0;
+    if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Fail pos-def check sub2.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Fail pos-def check sub3.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Fail pos-def check sub4.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Det2(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Fail pos-def check det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    }
+
+    // hits
+    edm::OwnVector<TrackingRecHit> recHits;
+    // nTotalHits() gives sum of valid hits (nFoundHits()) and invalid/missing hits.
+    const int nhits = cand.nTotalHits();
+    //std::cout << candIndex << ": " << nhits << " " << cand.nFoundHits() << std::endl;
+    bool lastHitInvalid = false;
+    const auto isPhase1 = mkFitGeom.isPhase1();
+    for (int i = 0; i < nhits; ++i) {
+      const auto& hitOnTrack = cand.getHitOnTrack(i);
+      LogTrace("MkFitOutputTrackConverter") << " hit on layer " << hitOnTrack.layer << " index " << hitOnTrack.index;
+      if (hitOnTrack.index < 0) {
+        // See index-desc.txt file in mkFit for description of negative values
+        //
+        // In order to use the regular InvalidTrackingRecHit I'd need
+        // a GeomDet (and "unfortunately" that is needed in
+        // TrackProducer).
+        //
+        // I guess we could take the track state and propagate it to
+        // each layer to find the actual module the track crosses, and
+        // check whether it is active or not to be able to mark
+        // inactive hits
+        const auto* detLayer = detLayers.at(hitOnTrack.layer);
+        if (detLayer == nullptr) {
+          throw cms::Exception("LogicError") << "DetLayer for layer index " << hitOnTrack.layer << " is null!";
+        }
+        // In principle an InvalidTrackingRecHitNoDet could be
+        // inserted here, but it seems that it is best to deal with
+        // them in the TrackProducer.
+        lastHitInvalid = true;
+      } else {
+        auto const isPixel = eventOfHits[hitOnTrack.layer].is_pixel();
+        auto const& hits = isPixel ? pixelClusterIndexToHit.hits() : stripClusterIndexToHit.hits();
+
+        auto const& thit = static_cast<BaseTrackerRecHit const&>(*hits[hitOnTrack.index]);
+        if (isPhase1) {
+          if (thit.firstClusterRef().isPixel() || thit.detUnit()->type().isEndcap()) {
+            recHits.push_back(hits[hitOnTrack.index]->clone());
+          } else {
+            recHits.push_back(std::make_unique<SiStripRecHit1D>(
+                thit.localPosition(),
+                LocalError(thit.localPositionError().xx(), 0.f, std::numeric_limits<float>::max()),
+                *thit.det(),
+                thit.firstClusterRef()));
+          }
+        } else {
+          if (thit.firstClusterRef().isPixel()) {
+            recHits.push_back(hits[hitOnTrack.index]->clone());
+          } else if (thit.firstClusterRef().isPhase2()) {
+            recHits.push_back(std::make_unique<Phase2TrackerRecHit1D>(
+                thit.localPosition(),
+                LocalError(thit.localPositionError().xx(), 0.f, std::numeric_limits<float>::max()),
+                *thit.det(),
+                thit.firstClusterRef().cluster_phase2OT()));
+          }
+        }
+        LogTrace("MkFitOutputTrackConverter")
+            << "  pos " << recHits.back().globalPosition().x() << " " << recHits.back().globalPosition().y() << " "
+            << recHits.back().globalPosition().z() << " mag2 " << recHits.back().globalPosition().mag2() << " detid "
+            << recHits.back().geographicalId().rawId() << " cluster " << hitOnTrack.index;
+        lastHitInvalid = false;
+      }
+    }
+
+    const auto lastHitId = recHits.back().geographicalId();
+    // MkFit hits are *not* in the order of propagation, sort by 3D radius for now (as we don't have loopers)
+    // TODO: Improve the sorting (extract keys? maybe even bubble sort would work well as the hits are almost in the correct order)
+    recHits.sort([&tTopo, &isPhase1](const auto& a, const auto& b) {
+      //const GeomDetEnumerators::SubDetector asub = a.det()->subDetector();
+      //const GeomDetEnumerators::SubDetector bsub = b.det()->subDetector();
+      //const auto& apos = a.globalPosition();
+      //const auto& bpos = b.globalPosition();
+      // For Phase-1, can rely on subdetector index
+      if (isPhase1) {
+        const auto asub_ph1 = a.geographicalId().subdetId();
+        const auto bsub_ph1 = b.geographicalId().subdetId();
+        const auto& apos_ph1 = a.globalPosition();
+        const auto& bpos_ph1 = b.globalPosition();
+        if (asub_ph1 != bsub_ph1) {
+          // Subdetector order (BPix, FPix, TIB, TID, TOB, TEC) corresponds also the navigation
+          return asub_ph1 < bsub_ph1;
+        } else {
+          //if (GeomDetEnumerators::isBarrel(asub)) {
+          if (isPhase1Barrel(asub_ph1)) {
+            return apos_ph1.perp2() < bpos_ph1.perp2();
+          } else {
+            return std::abs(apos_ph1.z()) < std::abs(bpos_ph1.z());
+          }
+        }
+      }
+
+      // For Phase-2, can not rely uniquely on subdetector index
+      const GeomDetEnumerators::SubDetector asub = a.det()->subDetector();
+      const GeomDetEnumerators::SubDetector bsub = b.det()->subDetector();
+      const auto& apos = a.globalPosition();
+      const auto& bpos = b.globalPosition();
+      const auto aid = a.geographicalId().rawId();
+      const auto bid = b.geographicalId().rawId();
+      const auto asubid = a.geographicalId().subdetId();
+      const auto bsubid = b.geographicalId().subdetId();
+      if (GeomDetEnumerators::isBarrel(asub) || GeomDetEnumerators::isBarrel(bsub)) {
+        // For barrel tilted modules, or in case (only) one of the two modules is barrel, use 3D position
+        if ((asubid == StripSubdetector::TOB && tTopo.tobSide(aid) < 3) ||
+            (bsubid == StripSubdetector::TOB && tTopo.tobSide(bid) < 3) ||
+            !(GeomDetEnumerators::isBarrel(asub) && GeomDetEnumerators::isBarrel(bsub))) {
+          return apos.mag2() < bpos.mag2();
+        }
+        // For fully barrel comparisons and no tilt, use 2D position
+        else {
+          return apos.perp2() < bpos.perp2();
+        }
+      }
+      // For fully endcap comparisons, use z position
+      else {
+        return std::abs(apos.z()) < std::abs(bpos.z());
+      }
+    });
+
+    const bool lastHitChanged = (recHits.back().geographicalId() != lastHitId);  // TODO: make use of the bools
+
+    // seed
+    const auto seedIndex = cand.label();
+    LogTrace("MkFitOutputTrackConverter") << " from seed " << seedIndex << " seed hits";
+
+    // Rescale candidate error if candidate is already propagated to first layer,
+    // to be consistent with TransientInitialStateEstimator::innerState used in CkfTrackCandidateMakerBase
+    // Error is only rescaled for candidates propagated to first layer;
+    // otherwise, candidates undergo backwardFit where error is already rescaled
+    //if (mkFitOutput.propagatedToFirstLayer() && doErrorRescale_)
+    //fts.rescaleError(100.);
+    auto tsosDet = mkFitOutput.propagatedToFirstLayer()
+                       ? convertInnermostState(fts, recHits, propagatorAlong, propagatorOpposite)
+                       : backwardFit(fts,
+                                     recHits,
+                                     propagatorAlong,
+                                     propagatorOpposite,
+                                     hitCloner,
+                                     isPhase1,
+                                     lastHitInvalid,
+                                     lastHitChanged);  ///backward fit should be removed and not used here
+    if (!tsosDet.first.isValid()) {
+      edm::LogInfo("MkFitOutputTrackConverter")
+          << "Backward fit of candidate " << candIndex << " failed, ignoring the candidate";
+      continue;
+    }
+
+    // convert to persistent, from CkfTrackCandidateMakerBase
+    //auto pstate = trajectoryStateTransform::persistentState(tsosDet.first, tsosDet.second->geographicalId().rawId());
+
+    //to do
+
+    TrajectoryStateOnSurface tsosState = tsosDet.first;
+
+    //if (mkFitOutput.propagatedToFirstLayer() && doErrorRescale_)
+    //tsosState.rescaleError(1 / 100.f);
+
+    TSCBLBuilderNoMaterial tscblBuilder;
+
+    TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
+        tscblBuilder(*tsosState.freeState(), *bs);  //as in TrackProducerAlgorithm
+
+    if (!(tsAtClosestApproachTrackCand.isValid())) {
+      edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
+      continue;
+    }
+
+    auto const& stateAtPCA = tsAtClosestApproachTrackCand.trackStateAtPCA();
+    auto v0 = stateAtPCA.position();
+    auto p = stateAtPCA.momentum();
+    math::XYZPoint pos(v0.x(), v0.y(), v0.z());
+    math::XYZVector mom(p.x(), p.y(), p.z());
+
+    int ndof = -5;
+    for (auto const& recHit : recHits)
+      ndof += recHit.dimension();
+
+    //converted track
+    reco::Track trk(cand.chi2(),
+                    ndof,
+                    pos,
+                    mom,
+                    stateAtPCA.charge(),
+                    stateAtPCA.curvilinearError(),
+                    static_cast<reco::TrackBase::TrackAlgorithm>(algo_));
+    trk.appendHits(recHits.begin(), recHits.end(), tTopo);
+
+    trks.push_back(trk);
+
+    //need to return also seed indices and hits in some way
+    seedIndices.push_back(cand.label());
+    hitsVecs.push_back(recHits);
+  }
+}
+
+std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputTrackConverter::backwardFit(
+    const FreeTrajectoryState& fts,
+    const edm::OwnVector<TrackingRecHit>& hits,
+    const Propagator& propagatorAlong,
+    const Propagator& propagatorOpposite,
+    const TkClonerImpl& hitCloner,
+    const bool isPhase1,
+    bool lastHitWasInvalid,
+    bool lastHitWasChanged) const {
+  // First filter valid hits as in TransientInitialStateEstimator
+  TransientTrackingRecHit::ConstRecHitContainer firstHits;
+
+  for (int i = hits.size() - 1; i >= 0; --i) {
+    if (hits[i].det()) {
+      // TransientTrackingRecHit::ConstRecHitContainer has shared_ptr,
+      // and it is passed to backFitter below so it is really needed
+      // to keep the interface. Since we keep the ownership in hits,
+      // let's disable the deleter.
+      firstHits.emplace_back(&(hits[i]), edm::do_nothing_deleter{});
+    }
+  }
+
+  // Then propagate along to the surface of the last hit to get a TSOS
+  const auto& lastHitSurface = firstHits.front()->det()->surface();
+
+  const Propagator* tryFirst = &propagatorAlong;
+  const Propagator* trySecond = &propagatorOpposite;
+  if (lastHitWasInvalid || lastHitWasChanged) {
+    LogTrace("MkFitOutputTrackConverter") << "Propagating first opposite, then along, because lastHitWasInvalid? "
+                                          << lastHitWasInvalid << " or lastHitWasChanged? " << lastHitWasChanged;
+    std::swap(tryFirst, trySecond);
+  } else {
+    bool doSwitch = false;
+    const auto& surfacePos = lastHitSurface.position();
+    const auto& lastHitPos = firstHits.front()->globalPosition();
+    if (isPhase1) {
+      const auto lastHitSubdet = firstHits.front()->geographicalId().subdetId();
+      if (isPhase1Barrel(lastHitSubdet)) {
+        doSwitch = (surfacePos.perp2() < lastHitPos.perp2());
+      } else {
+        doSwitch = (surfacePos.z() < lastHitPos.z());
+      }
+    } else {
+      const auto lastHitSubdet = firstHits.front()->det()->subDetector();
+      if (GeomDetEnumerators::isBarrel(lastHitSubdet)) {
+        doSwitch = (surfacePos.perp2() < lastHitPos.perp2());
+      } else {
+        doSwitch = (surfacePos.z() < lastHitPos.z());
+      }
+    }
+    if (doSwitch) {
+      LogTrace("MkFitOutputTrackConverter")
+          << "Propagating first opposite, then along, because surface is inner than the hit; surface perp2 "
+          << surfacePos.perp() << " hit " << lastHitPos.perp2() << " surface z " << surfacePos.z() << " hit "
+          << lastHitPos.z();
+
+      std::swap(tryFirst, trySecond);
+    }
+  }
+
+  auto tsosDouble = tryFirst->propagateWithPath(fts, lastHitSurface);
+  if (!tsosDouble.first.isValid()) {
+    LogDebug("MkFitOutputTrackConverter") << "Propagating to startingState failed, trying in another direction next";
+    tsosDouble = trySecond->propagateWithPath(fts, lastHitSurface);
+  }
+  auto& startingState = tsosDouble.first;
+
+  if (!startingState.isValid()) {
+    edm::LogWarning("MkFitOutputTrackConverter")
+        << "startingState is not valid, FTS was\n"
+        << fts << " last hit surface surface:"
+        << "\n position " << lastHitSurface.position() << "\n phiSpan " << lastHitSurface.phiSpan().first << ","
+        << lastHitSurface.phiSpan().first << "\n rSpan " << lastHitSurface.rSpan().first << ","
+        << lastHitSurface.rSpan().first << "\n zSpan " << lastHitSurface.zSpan().first << ","
+        << lastHitSurface.zSpan().first;
+    return std::pair<TrajectoryStateOnSurface, const GeomDet*>();
+  }
+
+  // Then return back to the logic from TransientInitialStateEstimator
+  startingState.rescaleError(100.);
+
+  // avoid cloning
+  KFUpdator const aKFUpdator;
+  Chi2MeasurementEstimator const aChi2MeasurementEstimator(100., 3);
+  KFTrajectoryFitter backFitter(
+      &propagatorAlong, &aKFUpdator, &aChi2MeasurementEstimator, firstHits.size(), nullptr, &hitCloner);
+
+  // assume for now that the propagation in mkfit always alongMomentum
+  PropagationDirection backFitDirection = oppositeToMomentum;
+
+  // only direction matters in this context
+  TrajectorySeed fakeSeed(PTrajectoryStateOnDet(), edm::OwnVector<TrackingRecHit>(), backFitDirection);
+
+  // ignore loopers for now
+  Trajectory fitres = backFitter.fitOne(fakeSeed, firstHits, startingState, TrajectoryFitter::standard);
+
+  LogDebug("MkFitOutputTrackConverter") << "using a backward fit of :" << firstHits.size() << " hits, starting from:\n"
+                                        << startingState << " to get the estimate of the initial state of the track.";
+
+  if (!fitres.isValid()) {
+    edm::LogWarning("MkFitOutputTrackConverter") << "FitTester: first hits fit failed";
+    return std::pair<TrajectoryStateOnSurface, const GeomDet*>();
+  }
+
+  TrajectoryMeasurement const& firstMeas = fitres.lastMeasurement();
+
+  // magnetic field can be different!
+  TrajectoryStateOnSurface firstState(firstMeas.updatedState().localParameters(),
+                                      firstMeas.updatedState().localError(),
+                                      firstMeas.updatedState().surface(),
+                                      propagatorAlong.magneticField());
+
+  firstState.rescaleError(100.);
+
+  LogDebug("MkFitOutputTrackConverter") << "the initial state is found to be:\n:" << firstState
+                                        << "\n it's field pointer is: " << firstState.magneticField()
+                                        << "\n the pointer from the state of the back fit was: "
+                                        << firstMeas.updatedState().magneticField();
+
+  return std::make_pair(firstState, firstMeas.recHit()->det());
+}
+
+std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputTrackConverter::convertInnermostState(
+    const FreeTrajectoryState& fts,
+    const edm::OwnVector<TrackingRecHit>& hits,
+    const Propagator& propagatorAlong,
+    const Propagator& propagatorOpposite) const {
+  auto det = hits[0].det();
+  if (det == nullptr) {
+    throw cms::Exception("LogicError") << "Got nullptr from the first hit det()";
+  }
+
+  const auto& firstHitSurface = det->surface();
+
+  auto tsosDouble = propagatorAlong.propagateWithPath(fts, firstHitSurface);
+  if (!tsosDouble.first.isValid()) {
+    LogDebug("MkFitOutputTrackConverter") << "Propagating to startingState along momentum failed, trying opposite next";
+    tsosDouble = propagatorOpposite.propagateWithPath(fts, firstHitSurface);
+  }
+
+  return std::make_pair(tsosDouble.first, det);
+}
+
+DEFINE_FWK_MODULE(MkFitOutputTrackConverter);

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -17,6 +17,13 @@
 #include "RecoTracker/MkFit/interface/MkFitGeometry.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 
+//CPE
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
+
 // mkFit includes
 #include "RecoTracker/MkFitCMS/interface/LayerNumberConverter.h"
 #include "RecoTracker/MkFitCMS/interface/runFunctions.h"
@@ -52,6 +59,8 @@ private:
   edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> stripMaskToken_;
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
   const edm::ESGetToken<mkfit::IterationConfig, TrackerRecoGeometryRecord> mkFitIterConfigToken_;
+  const edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> pixelCPEToken_;
+  const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
   const edm::EDPutTokenT<MkFitOutputWrapper> putToken_;
   const float minGoodStripCharge_;
   const bool seedCleaning_;
@@ -69,6 +78,8 @@ MkFitProducer::MkFitProducer(edm::ParameterSet const& iConfig)
       seedToken_{consumes(iConfig.getParameter<edm::InputTag>("seeds"))},
       mkFitGeomToken_{esConsumes()},
       mkFitIterConfigToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("config"))},
+      pixelCPEToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("pixelCPE")))),
+      pixelClusterIndexToHitToken_{consumes(iConfig.getParameter<edm::InputTag>("mkFitPixelHits"))},
       putToken_{produces<MkFitOutputWrapper>()},
       minGoodStripCharge_{static_cast<float>(
           iConfig.getParameter<edm::ParameterSet>("minGoodStripCharge").getParameter<double>("value"))},
@@ -115,6 +126,8 @@ void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& description
       ->setComment("Valid values are: 'bestHit', 'standard', 'cloneEngine'");
   desc.add<edm::ESInputTag>("config", edm::ESInputTag(""))
       ->setComment("ESProduct that has the mkFit configuration parameters for this iteration");
+  desc.add<std::string>("pixelCPE", "PixelCPETemplateReco");
+  desc.add("mkFitPixelHits", edm::InputTag{"mkFitSiPixelHits"});
   desc.add("seedCleaning", true)->setComment("Clean seeds within mkFit");
   desc.add("removeDuplicates", true)->setComment("Run duplicate removal within mkFit");
   desc.add("backwardFitInCMSSW", false)
@@ -137,6 +150,9 @@ std::unique_ptr<mkfit::MkBuilderWrapper> MkFitProducer::beginStream(edm::StreamI
 }
 
 void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  const PixelClusterParameterEstimator* pixelCPE = &iSetup.getData(pixelCPEToken_);
+  const auto& hits = iEvent.get(pixelClusterIndexToHitToken_).hits();  //const MkFitClusterIndexToHit&
+
   const auto& pixelHits = iEvent.get(pixelHitsToken_);
   const auto& stripHits = iEvent.get(stripHitsToken_);
   const auto& eventOfHits = iEvent.get(eventOfHitsToken_);
@@ -185,6 +201,22 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
   auto seeds_mutable = seeds.seeds();
   mkfit::TrackVec tracks;
 
+  auto cpe = [&](int orig_hit_idx, float ltp_arr[6], float(&hit_arr)[5]) -> bool {
+    auto const& hit = dynamic_cast<SiPixelRecHit const&>(*hits[orig_hit_idx]);
+    LocalTrajectoryParameters ltp =
+        LocalTrajectoryParameters(ltp_arr[0], ltp_arr[1], ltp_arr[2], ltp_arr[3], ltp_arr[4], ltp_arr[5]);
+    const SiPixelCluster& clust = *hit.cluster();
+    auto&& params = pixelCPE->getParameters(clust, *hit.detUnit(), ltp);
+    //need to check validity and in case return false
+    //fill output corr;
+    hit_arr[0] = std::get<0>(params).x();
+    hit_arr[1] = std::get<0>(params).y();
+    hit_arr[2] = std::get<1>(params).xx();
+    hit_arr[3] = std::get<1>(params).xy();
+    hit_arr[4] = std::get<1>(params).yy();
+    return true;
+  };
+
   auto lambda = [&]() {
     mkfit::run_OneIteration(mkFitGeom.trackerInfo(),
                             mkFitIterConfig,
@@ -195,7 +227,8 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
                             tracks,
                             seedCleaning_,
                             not backwardFitInCMSSW_,
-                            removeDuplicates_);
+                            removeDuplicates_,
+                            cpe);
   };
 
   if (limitConcurrency_) {

--- a/RecoTracker/MkFitCMS/interface/runFunctions.h
+++ b/RecoTracker/MkFitCMS/interface/runFunctions.h
@@ -20,7 +20,8 @@ namespace mkfit {
                         TrackVec &out_tracks,
                         bool do_seed_clean,
                         bool do_backward_fit,
-                        bool do_remove_duplicates);
+                        bool do_remove_duplicates,
+                        cpe_func cpe_function);
 
 }  // end namespace mkfit
 #endif

--- a/RecoTracker/MkFitCMS/src/runFunctions.cc
+++ b/RecoTracker/MkFitCMS/src/runFunctions.cc
@@ -33,10 +33,11 @@ namespace mkfit {
                         TrackVec &out_tracks,
                         bool do_seed_clean,
                         bool do_backward_fit,
-                        bool do_remove_duplicates) {
+                        bool do_remove_duplicates,
+                        cpe_func cpe_function) {
     IterationMaskIfcCmssw it_mask_ifc(trackerInfo, hit_masks);
 
-    MkJob job({trackerInfo, itconf, eoh, eoh.refBeamSpot(), &it_mask_ifc});
+    MkJob job({trackerInfo, itconf, eoh, eoh.refBeamSpot(), &it_mask_ifc, cpe_function});
 
     builder.begin_event(&job, nullptr, __func__);
 
@@ -102,11 +103,16 @@ namespace mkfit {
     if (do_backward_fit && itconf.m_backward_search)
       builder.endBkwSearch();
 
-    builder.export_best_comb_cands(out_tracks, true);
+    builder.export_best_comb_cands(builder.ref_tracks_nc(), true);
 
     if (do_remove_duplicates && itconf.m_duplicate_cleaner) {
-      itconf.m_duplicate_cleaner(out_tracks, itconf);
+      itconf.m_duplicate_cleaner(builder.ref_tracks_nc(), itconf);
     }
+
+    if (itconf.m_track_algorithm == 4)  //should avoid this for InitialStepPreSplitting
+      builder.fittracks();
+
+    builder.export_tracks(out_tracks);
 
     builder.end_event();
     builder.release_memory();

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -562,6 +562,11 @@ namespace mkfit {
 
         builder.export_tracks(ev.fitTracks_);
       }
+
+      ////this would be the standalone but it's not working anymore with CPE
+      //builder.fittracks();
+      //builder.export_tracks(ev.fitTracks_);
+
       ev.resetCurrentSeedTracks();
 
       builder.end_event();

--- a/RecoTracker/MkFitCore/interface/FunctionTypes.h
+++ b/RecoTracker/MkFitCore/interface/FunctionTypes.h
@@ -39,6 +39,9 @@ namespace mkfit {
                                const bool inFindCandidates);
   using track_score_func = std::function<track_score_cf>;
 
+  using cpe_fc = bool(int orig_hit_idx, float ltp_arr[6], float (&hit_arr)[5]);
+  using cpe_func = std::function<cpe_fc>;
+
 }  // end namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -116,6 +116,17 @@ namespace mkfit {
     void backwardFit();
     void fit_cands(MkFinder *mkfndr, int start_cand, int end_cand, int region);
 
+    //refit
+
+    void fittracks();
+    void fit_tracks(MkFinder *mkfndr,
+                    int nFoundTracks,
+                    std::vector<int> inds,
+                    int start_trk,
+                    int end_trk,
+                    std::map<int, std::vector<int>> *remap = nullptr);
+    void check_tracks(std::vector<int> inds, int start_trk, int end_trk);
+
   private:
     void fit_one_seed_set(TrackVec &simtracks, int itrack, int end, MkFitter *mkfttr, const bool is_brl[]);
 

--- a/RecoTracker/MkFitCore/interface/MkJob.h
+++ b/RecoTracker/MkFitCore/interface/MkJob.h
@@ -15,6 +15,8 @@ namespace mkfit {
 
     const IterationMaskIfcBase *m_iter_mask_ifc = nullptr;
 
+    cpe_func m_cpe_corr_func = nullptr;
+
     bool m_in_fwd = true;
     void switch_to_backward() { m_in_fwd = false; }
 

--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -445,6 +445,18 @@ namespace mkfit {
 
     void addHitIdx(const HitOnTrack& hot, float chi2) { addHitIdx(hot.index, hot.layer, chi2); }
 
+    void removeHit(int posHitIdx) {
+      // negative index and keep hit
+      hitsOnTrk_[posHitIdx].index = -1;
+
+      //should remove it from the vector, but didn't work so far
+      //hitsOnTrk_.erase(hitsOnTrk_.begin() + posHitIdx);
+      //lastHitIdx_=lastHitIdx_-1;
+
+      //reduce nFoundHits_
+      nFoundHits_ = nFoundHits_ - 1;
+    }
+
     HitOnTrack getHitOnTrack(int posHitIdx) const { return hitsOnTrk_[posHitIdx]; }
 
     int getHitIdx(int posHitIdx) const { return hitsOnTrk_[posHitIdx].index; }

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -8,6 +8,8 @@
 
 #include "RecoTracker/MkFitCore/interface/cms_common_macros.h"
 
+// #include "RecoTracker/MkFitCore/interface/MkJob.h"
+
 namespace {
   using namespace mkfit;
   using idx_t = Matriplex::idx_t;
@@ -1295,6 +1297,73 @@ namespace mkfit {
 
   //------------------------------------------------------------------------------
 
+  void kalmanPropagateAndUpdateAndChi2Plane(
+      const MPlexLS& psErr,
+      const MPlexLV& psPar,
+      MPlexQI& Chg,
+      const MPlexHS& msErr,
+      const MPlexHV& msPar,
+      const MPlexHV& plNrm,
+      const MPlexHV& plDir,
+      const MPlexHV& plPnt,
+      MPlexLS& outErr,
+      MPlexLV& outPar,
+      MPlexQI& outFailFlag,
+      MPlexQF& outChi2,
+      const int N_proc,
+      const PropagationFlags& propFlags,
+      const bool propToHit,
+      const MPlexQI* noMatEffPtr,
+      const MPlexQI* doCPE,
+      cpe_func cpe_corr_func) {  //last args are const MkJob*,  const MPlexQI* noMatEffPtr, const MPlexQI* doCPE (?)
+    if (propToHit) {
+      MPlexLS propErr;
+      MPlexLV propPar;
+
+      propagateHelixToPlaneMPlex(
+          psErr, psPar, Chg, plPnt, plNrm, propErr, propPar, outFailFlag, N_proc, propFlags, noMatEffPtr);
+
+      kalmanOperationPlaneLocal(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
+                                propErr,
+                                propPar,
+                                Chg,
+                                msErr,
+                                msPar,
+                                plNrm,
+                                plDir,
+                                plPnt,
+                                outErr,
+                                outPar,
+                                outChi2,
+                                N_proc,
+                                doCPE,
+                                cpe_corr_func);
+
+    } else {
+      kalmanOperationPlaneLocal(KFO_Calculate_Chi2 | KFO_Update_Params | KFO_Local_Cov,
+                                psErr,
+                                psPar,
+                                Chg,
+                                msErr,
+                                msPar,
+                                plNrm,
+                                plDir,
+                                plPnt,
+                                outErr,
+                                outPar,
+                                outChi2,
+                                N_proc);
+    }
+    for (int n = 0; n < NN; ++n) {
+      if (outPar.At(n, 3, 0) < 0) {
+        Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
+        outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
+      }
+    }
+  }
+
+  //------------------------------------------------------------------------------
+
   void kalmanComputeChi2Plane(const MPlexLS& psErr,
                               const MPlexLV& psPar,
                               const MPlexQI& inChg,
@@ -1383,7 +1452,9 @@ namespace mkfit {
                                  MPlexLS& outErr,
                                  MPlexLV& outPar,
                                  MPlexQF& outChi2,
-                                 const int N_proc) {
+                                 const int N_proc,
+                                 const MPlexQI* doCPE,
+                                 cpe_func cpe_corr_func) {
 #ifdef DEBUG
     {
       dmutex_guard;
@@ -1474,6 +1545,27 @@ namespace mkfit {
 #pragma omp simd
     for (int n = 0; n < NN; ++n) {
       pzSign(n, 0, 0) = plo(n, 0, 2) > 0.f ? 1 : -1;
+    }
+
+    MPlex2V msPar_local;
+    MPlex2S msErr_local;
+
+    for (int n = 0; n < NN; ++n) {
+      if (doCPE && doCPE->constAt(n, 0, 0) >= 0 && cpe_corr_func) {
+        float ltp[6] = {lp(n, 0, 0), lp(n, 0, 1), lp(n, 0, 2), lp(n, 0, 3), lp(n, 0, 4), (float)pzSign(n, 0, 0)};
+        float lh[5] = {0, 0, 0, 0, 0};
+        int hit_idx = doCPE->constAt(n, 0, 0);
+        bool check = cpe_corr_func(hit_idx, ltp, lh);  //it's a boolean but need to introduce a safeguard if needed
+
+        if (!check)
+          continue;
+
+        msPar_local(n, 0, 0) = lh[0];
+        msPar_local(n, 0, 1) = lh[1];
+        msErr_local(n, 0, 0) = lh[2];
+        msErr_local(n, 0, 1) = lh[3];
+        msErr_local(n, 1, 1) = lh[4];
+      }
     }
 
     /*
@@ -1592,6 +1684,15 @@ namespace mkfit {
     }
     MPlex2V mslo;
     RotateResidualsOnPlane(rot, md, mslo);
+#pragma omp simd
+    //copy CPE pos for pixel hits if all ok
+    //need to add a CPE bool check
+    for (int n = 0; n < NN; ++n) {
+      if (doCPE && doCPE->constAt(n, 0, 0) >= 0 && cpe_corr_func) {
+        mslo(n, 0, 0) = msPar_local(n, 0, 0);
+        mslo(n, 0, 1) = msPar_local(n, 0, 1);
+      }
+    }
 
     MPlex2V res_loc;  //position residual in local coordinates
 #pragma omp simd
@@ -1604,6 +1705,15 @@ namespace mkfit {
     MPlex2H temp2Hmsl;
     ProjectResErr(rot, msErr, temp2Hmsl);
     ProjectResErrTransp(rot, temp2Hmsl, msErr_loc);
+#pragma omp simd
+    //copy CPE error for pixel hits if all ok
+    for (int n = 0; n < NN; ++n) {
+      if (doCPE && doCPE->constAt(n, 0, 0) >= 0 && cpe_corr_func) {
+        msErr_loc(n, 0, 0) = msErr_local(n, 0, 0);
+        msErr_loc(n, 0, 1) = msErr_local(n, 0, 1);
+        msErr_loc(n, 1, 1) = msErr_local(n, 1, 1);
+      }
+    }
 
     MPlex2S resErr_loc;  //covariance sum in local position coordinates
 #pragma omp simd

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -143,6 +143,25 @@ namespace mkfit {
                                      const PropagationFlags& propFlags,
                                      const bool propToHit);
 
+  void kalmanPropagateAndUpdateAndChi2Plane(const MPlexLS& psErr,
+                                            const MPlexLV& psPar,
+                                            MPlexQI& Chg,
+                                            const MPlexHS& msErr,
+                                            const MPlexHV& msPar,
+                                            const MPlexHV& plNrm,
+                                            const MPlexHV& plDir,
+                                            const MPlexHV& plPnt,
+                                            MPlexLS& outErr,
+                                            MPlexLV& outPar,
+                                            MPlexQI& outFailFlag,
+                                            MPlexQF& outChi2,
+                                            const int N_proc,
+                                            const PropagationFlags& propFlags,
+                                            const bool propToHit,
+                                            const MPlexQI* noMatEffPtr = nullptr,
+                                            const MPlexQI* doCPE = nullptr,
+                                            cpe_func cpe_corr_func = nullptr);
+
   void kalmanComputeChi2Plane(const MPlexLS& psErr,
                               const MPlexLV& psPar,
                               const MPlexQI& inChg,
@@ -195,7 +214,9 @@ namespace mkfit {
                                  MPlexLS& outErr,
                                  MPlexLV& outPar,
                                  MPlexQF& outChi2,
-                                 const int N_proc);
+                                 const int N_proc,
+                                 const MPlexQI* doCPE = nullptr,
+                                 cpe_func cpe_corr_func = nullptr);
 
 }  // end namespace mkfit
 #endif

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -19,6 +19,7 @@
 #endif
 
 //#define DEBUG
+// #define DEBUG_FIT
 #include "Debug.h"
 //#define DEBUG_FINAL_FIT
 
@@ -1404,4 +1405,217 @@ namespace mkfit {
     mkfndr->release();
   }
 
+  //==============================================================================
+  // ReFit
+  //==============================================================================
+
+  void MkBuilder::fit_tracks(MkFinder *mkfndr,
+                             int nFoundHits,
+                             std::vector<int> inds,
+                             int start_trk,
+                             int end_trk,
+                             std::map<int, std::vector<int>> *remap) {
+    //could be wrapped into some setup_fit
+    const TrackerInfo &ti = m_job->m_trk_info;
+    PropagationFlags my_flags = PropagationFlags(PF_use_param_b_field | PF_apply_material);
+    my_flags.tracker_info = &ti;
+    //clean at the end
+    mkfndr->refit_flags = &my_flags;
+    mkfndr->set_cpe(m_job->m_cpe_corr_func);
+
+    mkfndr->m_event = m_event;
+
+    int size_trks = (end_trk - start_trk);
+    int size_hits = size_trks * nFoundHits;
+
+    float chi2fwd[size_hits];
+    float chi2bkwd[size_hits];
+    int sortedIdxs[size_hits];
+    ;
+    int n_removed[(end_trk - start_trk)];
+
+    for (int ic = 0; ic < size_trks; ic++)
+      n_removed[ic] = 0;
+    for (int ic = 0; ic < size_hits; ic++) {
+      chi2fwd[ic] = 0;
+      chi2bkwd[ic] = 0;
+      sortedIdxs[ic] = 0;
+    }
+
+    for (int icand = start_trk; icand < end_trk; icand += NN) {
+      // size
+      const int end = std::min(icand + NN, end_trk);
+      // input candidate tracks
+      mkfndr->fwdFitInputTracks(m_tracks, inds, icand, end);
+      //prepare indices
+      std::vector<std::vector<int>> indices_R2 = mkfndr->reFitIndices(m_job->m_event_of_hits, end - icand, nFoundHits);
+      // fit the tracks from the input in fwd direction
+      mkfndr->fwdFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, indices_R2, chi2fwd);
+      // fwdFitOutput
+      mkfndr->reFitOutputTracks(m_tracks, inds, icand, end, nFoundHits);
+      // input candidate tracks
+      mkfndr->bkReFitInputTracks(m_tracks, inds, icand, end);
+      // fit the tracks from the input in bkw direction
+      mkfndr->bkReFitFitTracks(m_job->m_event_of_hits, end - icand, nFoundHits, indices_R2, chi2bkwd);
+      // fwdFitOutput
+      mkfndr->reFitOutputTracks(m_tracks, inds, icand, end, nFoundHits, true);
+
+      if (remap) {
+        for (int i = 0; i < end_trk - start_trk; i++) {
+          for (int j = 0; j < nFoundHits; j++) {
+            sortedIdxs[j + nFoundHits * i] = indices_R2[i][j];
+          }
+        }
+      }  //do the copy of indices ---- only if remap is there
+    }
+
+    //do the processing of the chi2
+    if (remap) {
+      for (int i = 0; i < end_trk - start_trk; i++) {
+        //sort by worst
+        std::map<float, int> scorerAndIdx;
+        for (int j = 0; j < nFoundHits; j++) {
+          //95% qunatiles for FWD and BWD didn't work
+          //float TF = 23.7 * j / nFoundHits + 0.8;
+          //float TB = 23.6 * (nFoundHits - 1 - j) / nFoundHits + 3.6;
+          float scorer =
+              (chi2fwd[j + nFoundHits * i]) +
+              (chi2bkwd[nFoundHits - 1 - j + nFoundHits * i]);  //simpler alternative to metric based on quantiles
+          scorerAndIdx[-scorer] = j;
+        }
+
+        int remove_i = 0;
+        for (auto idscore : scorerAndIdx) {
+          //if(idscore.first<0)
+          if ((m_tracks[inds[i + start_trk]].pT() > 1 && -idscore.first > 20 &&
+               chi2fwd[idscore.second + nFoundHits * i] > 8. &&
+               chi2bkwd[nFoundHits - 1 - idscore.second + nFoundHits * i] > 8) ||
+              (m_tracks[inds[i + start_trk]].pT() <= 1 && -idscore.first > 15 &&
+               chi2fwd[idscore.second + nFoundHits * i] > 7. &&
+               chi2bkwd[nFoundHits - 1 - idscore.second + nFoundHits * i] > 7)) {
+            if ((nFoundHits - remove_i) <= 3)
+              continue;  // 3 hits is the minimum...
+            remove_i++;
+            n_removed[i] += 1;
+            m_tracks[inds[i + start_trk]].removeHit(sortedIdxs[nFoundHits - 1 - idscore.second + nFoundHits * i]);
+          }
+        }
+      }
+
+      for (int i = 0; i < end_trk - start_trk; i++) {
+        if (n_removed[i] && (nFoundHits - n_removed[i]) > 2)
+          (*remap)[nFoundHits - n_removed[i]].push_back(inds[i + start_trk]);  // passed to refit
+      }
+    }
+
+    mkfndr->release();
+  }
+
+  void MkBuilder::check_tracks(std::vector<int> inds, int start_trk, int end_trk) {
+    for (int icand = start_trk; icand < end_trk; icand += NN) {
+      const int end = std::min(icand + NN, end_trk);
+
+      std::cout << "BEGIN CHECKs" << std::endl;
+      std::cout << " strt " << start_trk << " end " << end_trk << " end " << end_trk - start_trk << " NN " << NN
+                << std::endl;
+
+      for (int i = start_trk; i < end; ++i) {
+        const Track &trk = m_tracks[inds[i]];
+
+        std::cout << "trk pt " << trk.pT() << " trk eta " << trk.momEta() << " trk phi " << trk.momPhi() << std::endl;
+        std::cout << "trk nTotalHits " << trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+        std::cout << "END CHECK" << std::endl;
+      }
+    }
+  }
+
+  void MkBuilder::fittracks() {
+#ifdef DEBUG_FIT
+    std::cout << "here are N tracks " << m_tracks.size() << std::endl;
+#endif
+    int N = 0;
+
+    std::map<int, std::vector<int>> mapFoundHits;
+    std::map<int, std::vector<int>> remap;
+    for (auto &t : m_tracks) {
+#ifdef DEBUG_FIT
+      std::cout << "______________ " << std::endl;
+      std::cout << "track N " << N << " nhits " << t.nFoundHits() << std::endl;
+      std::cout << "trk pt " << t.pT() << " trk eta " << t.momEta() << std::endl;
+      std::cout << "trk nTotalHits " << t.nTotalHits() << " trk nFoundHits " << t.nFoundHits() << std::endl;
+      std::cout << "trk last l " << t.getLastFoundHitLyr() << " trk last idx " << t.getLastFoundHitIdx() << std::endl;
+      for (int i = 0; i < t.nTotalHits(); i++) {
+        std::cout << "index " << t.getHitIdx(i) << " layer " << t.getHitLyr(i) << std::endl;
+      }
+#endif
+      int foundh = t.nFoundHits();
+      if (mapFoundHits.count(foundh)) {
+        mapFoundHits[foundh].push_back(N);
+      } else
+        mapFoundHits[foundh] = {N};
+      N++;
+    }
+#ifdef DEBUG_FIT
+    int n = 0;
+    for (auto &m : mapFoundHits) {
+      std::cout << m.first << " the key " << std::endl;
+      for (auto i : m.second) {
+        std::cout << i << " index ";
+        n++;
+      }
+      std::cout << "\n";
+    }
+    std::cout << "total MAP " << n << std::endl;
+#endif
+    auto mkfndr = g_exe_ctx.m_finders.makeOrGet();
+    for (auto &m : mapFoundHits) {
+      int ntimes = m.second.size() / NN;
+#ifdef DEBUG_FIT
+      std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
+      std::cout << "ntimes " << ntimes << " size  " << m.second.size() << " extra " << m.second.size() - NN * ntimes
+                << std::endl;
+#endif
+      for (int i = 0; i < ntimes; i++) {
+#ifdef DEBUG_FIT
+        check_tracks(m.second, NN * i, NN * (i + 1));
+#endif
+        fit_tracks(mkfndr.get(), m.first, m.second, NN * i, NN * (i + 1), &remap);
+      }
+#ifdef DEBUG_FIT
+      check_tracks(m.second, NN * ntimes, m.second.size());
+#endif
+      fit_tracks(mkfndr.get(), m.first, m.second, NN * ntimes, m.second.size(), &remap);
+    }
+#ifdef DEBUG_FIT
+    n = 0;
+    for (auto &m : remap) {
+      std::cout << m.first << " REMAP the key " << std::endl;
+      for (auto i : m.second) {
+        std::cout << i << " index " << m_tracks[i].nTotalHits() << " ";
+        n++;
+      }
+      std::cout << "\n";
+      std::cout << "remap" << std::endl;
+    }
+    std::cout << "total REMAP " << n << std::endl;
+#endif
+    for (auto &m : remap) {
+      int ntimes = m.second.size() / NN;
+#ifdef DEBUG_FIT
+      std::cout << "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++" << std::endl;
+      std::cout << "ntimes " << ntimes << " size  " << m.second.size() << " extra " << m.second.size() - NN * ntimes
+                << std::endl;
+#endif
+      for (int i = 0; i < ntimes; i++) {
+#ifdef DEBUG_FIT
+        check_tracks(m.second, NN * i, NN * (i + 1));
+#endif
+        fit_tracks(mkfndr.get(), m.first, m.second, NN * i, NN * (i + 1));
+      }
+#ifdef DEBUG_FIT
+      check_tracks(m.second, NN * ntimes, m.second.size());
+#endif
+      fit_tracks(mkfndr.get(), m.first, m.second, NN * ntimes, m.second.size());
+    }
+  }
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -8,7 +8,10 @@
 #include "MatriplexPackers.h"
 #include "MiniPropagators.h"
 
-//#define DEBUG
+// #define DEBUG
+// #define DEBUG_FIT
+// #define DEBUG_FITi
+// #define DEBUG_FIT_BKW
 #include "Debug.h"
 
 #if defined(MKFIT_STANDALONE)
@@ -65,6 +68,10 @@ namespace mkfit {
     m_event = nullptr;
     m_current_region = -1;
     m_in_fwd = true;
+    //refit_flags
+    refit_flags = nullptr;
+    //cpe
+    m_cpe_corr_func = nullptr;
   }
 
   void MkFinder::begin_layer(const LayerOfHits &layer_of_hits) {
@@ -1982,6 +1989,66 @@ namespace mkfit {
     m_Err[iC].scale(100.0f);
   }
 
+
+  void MkFinder::fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end) {
+    // Uses HitOnTrack vector from Track directly + a local cursor array to current hit.
+#ifdef DEBUG_FIT_BKW
+    std::cout <<" -- fwdFitInputTracks " << std::endl;
+#endif
+    MatriplexTrackPacker mtp(&cands[inds[beg]]);
+
+    int itrack = 0;
+
+    for (int i = beg; i < end; ++i, ++itrack) {
+      const Track &trk = cands[inds[i]];
+      m_Chg(itrack, 0, 0) = trk.charge();
+      m_CurHit[itrack] = trk.nTotalHits() - 1; //I have to use in reverse... otherwise n hits unknown
+      m_HoTArr[itrack] = trk.getHitsOnTrackArray();
+#ifdef DEBUG_FIT
+      std::cout <<"trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      std::cout <<"trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+      mtp.addInput(trk);
+    }
+
+    m_Chi2.setVal(0);
+    mtp.pack(m_Err[iC], m_Par[iC]);
+    m_Err[iC].scale(100.0f);
+
+  }
+
+
+  void MkFinder::bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end) {
+    // Uses HitOnTrack vector from Track directly + a local cursor array to current hit.
+#ifdef DEBUG_FIT_BKW
+    std::cout <<" -- bkReFitInputTracks " << std::endl;
+#endif
+    MatriplexTrackPacker mtp(&cands[inds[beg]]);
+
+    int itrack = 0;
+
+    for (int i = beg; i < end; ++i, ++itrack) {
+      const Track &trk = cands[inds[i]];
+      m_Chg(itrack, 0, 0) = trk.charge();
+      m_CurHit[itrack] = trk.nTotalHits() - 1;
+      m_HoTArr[itrack] = trk.getHitsOnTrackArray();
+#ifdef DEBUG_FIT_BKW
+      std::cout <<"trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      std::cout <<"trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+      mtp.addInput(trk);
+    }
+
+    m_Chi2.setVal(0);
+
+    int index;
+    if (cands[inds[beg]].nFoundHits()%2==0)  index=iC;
+    else index = iP;
+
+    mtp.pack(m_Err[index], m_Par[index]);
+    m_Err[index].scale(100.0f);
+  }
+
   void MkFinder::bkFitInputTracks(EventOfCombCandidates &eocss, int beg, int end) {
     // Could as well use HotArrays from tracks directly + a local cursor array to last hit.
 
@@ -2031,6 +2098,33 @@ namespace mkfit {
       if (isFinite(trk.chi2())) {
         trk.setScore(getScoreCand(m_steering_params->m_track_scorer, trk));
       }
+    }
+  }
+
+  void MkFinder::reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw) {
+    // Only copy out track params / errors / chi2
+    if(bkw) nFoundHits=nFoundHits*2;
+    int iO;
+    if (nFoundHits%2==0) iO = iC;
+    else iO = iP;
+
+    int itrack = 0;
+    for (int i = beg; i < end; ++i, ++itrack) {
+      Track &trk = cands[inds[i]];
+      m_Err[iO].copyOut(itrack, trk.errors_nc().Array());
+      m_Par[iO].copyOut(itrack, trk.parameters_nc().Array());
+
+#ifdef DEBUG_FIT_BKW
+      if (bkw) std::cout <<"oout trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      if (bkw) std::cout <<"oout trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+
+#ifdef DEBUG_FIT
+      if (!bkw) std::cout <<"oout trk pt " <<trk.pT() << " trk eta " << trk.momEta() << std::endl;
+      if (!bkw) std::cout <<"oout trk nTotalHits " <<trk.nTotalHits() << " trk nFoundHits " << trk.nFoundHits() << std::endl;
+#endif
+
+      trk.setChi2(m_Chi2(itrack, 0, 0));
     }
   }
 
@@ -2441,6 +2535,468 @@ namespace mkfit {
       m_Chi2.add(tmp_chi2);
     }
   }
+
+  //------------------------------------------------------------------------------
+
+  std::vector<std::vector<int>> MkFinder::reFitIndices(const EventOfHits &eventofhits,
+                                                       const int N_proc,
+                                                       int nFoundHits) {
+    std::vector<std::vector<int>> indices_R2Z;
+
+    for (int i = 0; i < N_proc; ++i) {
+      std::vector<std::pair<float, float>> r2z;
+      std::vector<int> indices;
+
+      int local_m = m_CurHit[i];
+      while (local_m >= 0) {
+#ifdef DEBUG_FITi
+        std::cout << " i layer " << m_HoTArr[i][local_m].layer << " i index " << m_HoTArr[i][local_m].index
+                  << std::endl;
+#endif
+        if (m_HoTArr[i][local_m].index >= 0) {
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][local_m].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][local_m].index);
+
+          float x, y, z;
+          x = hit.posArray()[0];
+          y = hit.posArray()[1];
+          z = hit.posArray()[2];
+          float R2 = x * x + y * y;  // + z * z;
+#ifdef DEBUG_FIT
+          std::cout << "x " << x << " y " << y << " z " << z << std::endl;
+          std::cout << L.is_barrel() << " layer of hits is barrel ... " << m_HoTArr[i][local_m].layer << std::endl;
+          std::cout << R2 << " R2 -- z " << z << " index " << local_m << " i/Nproc " << i << " / " << N_proc
+                    << std::endl;
+#endif
+          int sign = L.is_barrel() > 0 ? 1 : -1;
+          r2z.push_back(std::make_pair(sign * R2, z));
+          indices.push_back(local_m);
+        }
+        local_m--;
+      }
+      //continue working with the track
+      std::vector<int> sorted_indices;
+      float z0 = r2z.back().second;
+      bool barrel_prev = false;
+      std::map<float, std::vector<int>> index_RorZ;
+
+      for (int i = 0; i < (int)indices.size(); i++) {
+        bool barrel = r2z[i].first > 0;
+        float sorting;
+#ifdef DEBUG_FIT
+        std::cout << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z0 << std::endl;
+#endif
+        if (barrel)
+          sorting = -std::fabs(r2z[i].first);
+        else
+          sorting = -std::fabs(r2z[i].second - z0);
+
+        if (i == 0) {
+          index_RorZ[sorting].push_back(indices[i]);
+        } else {
+          if (barrel == barrel_prev)  //add to segment in barrel or endcap
+          {
+            index_RorZ[sorting].push_back(indices[i]);
+          } else  //switch barrel to endcap
+          {
+            for (const auto &iRZ : index_RorZ)
+              for (auto iiRZ : iRZ.second)
+                sorted_indices.push_back(iiRZ);                      //push back indices sorted for segment
+            index_RorZ.erase(index_RorZ.begin(), index_RorZ.end());  //empty the map
+            index_RorZ[sorting].push_back(indices[i]);               //start new segment
+          }
+        }
+        barrel_prev = barrel;
+      }
+      for (const auto &iRZ : index_RorZ)  //final segment
+        for (auto iiRZ : iRZ.second)
+          sorted_indices.push_back(iiRZ);
+
+      if (indices.size() != sorted_indices.size()) {
+        std::cout << indices.size() << "  " << sorted_indices.size() << std::endl;
+        for (auto ii : indices) {
+          std::cout << " indices ii " << ii << std::endl;
+        }
+        for (auto ii : sorted_indices) {
+          std::cout << " indices ssii " << ii << std::endl;
+        }
+        for (int i = 0; i < (int)indices.size(); i++) {
+          std::cout << "R2 " << r2z[i].first << " z " << r2z[i].second << " z0 " << z0 << std::endl;
+        }
+      }
+#ifdef DEBUG_FIT
+      std::cout << " check_size " << (indices.size() == sorted_indices.size()) << std::endl;
+      for (auto ii : indices) {
+        std::cout << " indices ii " << ii << std::endl;
+      }
+      for (auto ii : sorted_indices) {
+        std::cout << " indices ssii " << ii << std::endl;
+      }
+#endif
+      indices_R2Z.push_back(sorted_indices);  //sorted_indices
+    }
+    return indices_R2Z;
+  }
+
+  void MkFinder::fwdFitFitTracks(const EventOfHits &eventofhits,
+                                 const int N_proc,
+                                 int nFoundHits,
+                                 std::vector<std::vector<int>> indices_R2Z,
+                                 float *chi2) {
+    MPlexQF outChi2(0.0f);
+    MPlexLV propPar;
+
+    MPlexHV norm, dir, pnt;
+
+    MPlexQI no_mat_effs;
+    MPlexQI do_cpe;
+
+    no_mat_effs.setVal(0);
+    do_cpe.setVal(-1);
+#ifdef DEBUG_FIT
+    const int DSLOT = 0;
+    printf("fit entry, track in slot %d\n", DSLOT);
+    print_par_err(iC, DSLOT);
+    print_par_err(iC, 1);
+    printf("\ninitial fit , track in slot %d --- (%g, %g, %g)\n",
+           DSLOT,
+           m_msPar(DSLOT, 0, 0),
+           m_msPar(DSLOT, 1, 0),
+           m_msPar(DSLOT, 2, 0));
+    printf(
+        "\ninitial fit , track in slot %d --- (%g, %g, %g)\n", 1, m_msPar(1, 0, 0), m_msPar(1, 1, 0), m_msPar(1, 2, 0));
+    printf(
+        "\ninitial fit , track in slot %d --- (%g, %g, %g)\n", 2, m_msPar(2, 0, 0), m_msPar(2, 1, 0), m_msPar(2, 2, 0));
+#endif
+
+    int i1 = iC;  //local copy
+    int i2 = iP;  //local copy
+
+    int hitIndex[N_proc];
+
+    for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+    {
+      hitIndex[i] = indices_R2Z[i].size();
+    }
+
+    for (int h = 0; h < nFoundHits; ++h)  //first loop over the group - need to use the mplex here
+    {
+#ifdef DEBUG_FIT
+      std::cout << "MY HIT " << h << " nFoundHits " << nFoundHits << std::endl;
+#endif
+      no_mat_effs.setVal(0);
+      do_cpe.setVal(-1);
+
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        auto &indices = indices_R2Z[i];
+        int index = indices[hitIndex[i] - 1];
+#ifdef DEBUG_FIT
+        std::cout << "DEBUG hitIndex " << hitIndex[i] << std::endl;
+        std::cout << "DEBUG i " << index << std::endl;
+        std::cout << "DEBUG i layer " << m_HoTArr[i][index].layer << std::endl;
+        std::cout << "DEBUG i index " << m_HoTArr[i][index].index << std::endl;
+#endif
+        if (m_HoTArr[i][index].index >= 0) {  //should be a redundant check
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][index].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][index].index);
+          if (L.is_pixel()) {
+            do_cpe[i] = m_HoTArr[i][index].index;
+          }  //hopefully ok to get the cluster
+#ifdef DEBUG_FIT
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          m_msErr.copyIn(i, hit.errArray());
+          m_msPar.copyIn(i, hit.posArray());
+#ifdef DEBUG_FIT
+          std::cout << "hit.posArray()[0] " << hit.posArray()[0] << " hit.posArray()[1] " << hit.posArray()[1]
+                    << " hit.posArray()[2] " << hit.posArray()[2] << std::endl;
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          unsigned int mid = hit.detIDinLayer();
+          const ModuleInfo &mi = L.layer_info().module_info(mid);
+          norm.At(i, 0, 0) = mi.zdir[0];
+          norm.At(i, 1, 0) = mi.zdir[1];
+          norm.At(i, 2, 0) = mi.zdir[2];
+          dir.At(i, 0, 0) = mi.xdir[0];
+          dir.At(i, 1, 0) = mi.xdir[1];
+          dir.At(i, 2, 0) = mi.xdir[2];
+          pnt.At(i, 0, 0) = mi.pos[0];
+          pnt.At(i, 1, 0) = mi.pos[1];
+          pnt.At(i, 2, 0) = mi.pos[2];
+#ifdef DEBUG_FIT
+          std::cout << "mi.pos[0] " << mi.pos[0] << " mi.pos[1] " << mi.pos[1] << " mi.pos[2] " << mi.pos[2]
+                    << std::endl;
+          std::cout << "pnt[0] " << pnt(i, 0, 0) << " pnt[1] " << pnt(i, 1, 0) << " pnt[2] " << pnt(i, 2, 0)
+                    << std::endl;
+          std::cout << "at the track " << i << " / " << N_proc << " check the material " << std::endl;
+#endif
+          if (hitIndex[i] < (int)indices.size() &&
+              m_HoTArr[i][index].layer == m_HoTArr[i][indices[hitIndex[i]]].layer) {
+            no_mat_effs[i] = 1;
+#ifdef DEBUG_FIT
+            std::cout << "at the hit " << index << " Remove the material because it was applied in hit "
+                      << indices[hitIndex[i]] << std::endl;
+            std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                      << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+#endif
+          }
+#ifdef DEBUG_FIT
+          else {
+            std::cout << "at the hit " << index << " Don't remove the material" << std::endl;
+            if (hitIndex[i] < (int)indices.size())
+              std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                        << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+          }
+#endif
+        }
+        hitIndex[i]--;
+      }  //end of track by track loop
+
+#ifdef DEBUG_FIT
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right before propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "tmp_chi2[i]" << outChi2[i] << std::endl;
+        std::cout << norm.At(i, 0, 0) << " " << norm.At(i, 1, 0) << " " << norm.At(i, 2, 0) << " "
+                  << "NORM" << std::endl;
+        std::cout << dir.At(i, 0, 0) << " " << dir.At(i, 1, 0) << " " << dir.At(i, 2, 0) << " "
+                  << "DIR" << std::endl;
+        std::cout << pnt.At(i, 0, 0) << " " << pnt.At(i, 1, 0) << " " << pnt.At(i, 2, 0) << " "
+                  << "PNT" << std::endl;
+        std::cout << "index / Nproc " << i << " material flag " << no_mat_effs[i] << std::endl;
+      }
+#endif
+
+      kalmanPropagateAndUpdateAndChi2Plane(m_Err[i1],
+                                           m_Par[i1],
+                                           m_Chg,
+                                           m_msErr,
+                                           m_msPar,
+                                           norm,
+                                           dir,
+                                           pnt,
+                                           m_Err[i2],
+                                           m_Par[i2],
+                                           m_FailFlag,
+                                           outChi2,
+                                           N_proc,
+                                           *refit_flags,
+                                           true,
+                                           &no_mat_effs,
+                                           &do_cpe,
+                                           m_cpe_corr_func);
+
+#ifdef DEBUG_FIT
+      std::cout << " i1 " << i1 << " iP " << iP << " iC " << iC << std::endl;
+      std::cout << "++++++++++++++++++++++++++\n" << std::endl;
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right after propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "tmp_chi2[i]" << outChi2[i] << std::endl;
+      }
+#endif
+      std::swap(i1, i2);
+
+      // update chi2
+      m_Chi2.add(outChi2);
+      for (int i = 0; i < N_proc; ++i) {
+        chi2[h + i * nFoundHits] = outChi2[i];
+      }
+    }  //end of loop over n hits
+  }  //end of fit func
+
+  void MkFinder::bkReFitFitTracks(const EventOfHits &eventofhits,
+                                  const int N_proc,
+                                  int nFoundHits,
+                                  std::vector<std::vector<int>> indices_R2Z,
+                                  float *chi2) {
+#ifdef DEBUG_FIT_BKW
+    std::cout << "bkReFitFitTracks " << nFoundHits << std::endl;
+#endif
+    MPlexQF outChi2;
+    MPlexLV propPar;
+
+    MPlexHV norm, dir, pnt;
+
+    MPlexQI no_mat_effs;
+    MPlexQI do_cpe;
+
+    no_mat_effs.setVal(0);
+    do_cpe.setVal(-1);
+
+    int i1, i2;
+    if (nFoundHits % 2 == 0) {
+      i1 = iC;
+      i2 = iP;
+    } else {
+      i1 = iP;
+      i2 = iC;
+    }
+
+    int hitIndex[N_proc];
+
+    for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+    {
+      hitIndex[i] = indices_R2Z[i].size();
+    }
+
+    for (int h = 0; h < nFoundHits; ++h)  //first loop over the group - need to use the mplex here
+    {
+#ifdef DEBUG_FIT_BKW
+      std::cout << "MY HIT " << h << " nFoundHits " << nFoundHits << std::endl;
+#endif
+      no_mat_effs.setVal(0);
+      do_cpe.setVal(-1);
+
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        auto indices = indices_R2Z[i];
+        std::reverse(indices.begin(), indices.end());
+        int index = indices[hitIndex[i] - 1];
+#ifdef DEBUG_FIT_BKW
+        std::cout << "DEBUG hitIndex " << hitIndex[i] << std::endl;
+        std::cout << "DEBUG i " << index << std::endl;
+        std::cout << "DEBUG i layer " << m_HoTArr[i][index].layer << std::endl;
+        std::cout << "DEBUG i index " << m_HoTArr[i][index].index << std::endl;
+#endif
+        if (m_HoTArr[i][index].index >= 0) {  //should be a redundant check
+          const LayerOfHits &L = eventofhits[m_HoTArr[i][index].layer];
+          const Hit &hit = L.refHit(m_HoTArr[i][index].index);
+          if (L.is_pixel()) {
+            do_cpe[i] = m_HoTArr[i][index].index;
+          }  //hopefully ok to get the cluster
+#ifdef DEBUG_FIT_BKW
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          m_msErr.copyIn(i, hit.errArray());
+          m_msPar.copyIn(i, hit.posArray());
+#ifdef DEBUG_FIT_BKW
+          std::cout << "hit.posArray()[0] " << hit.posArray()[0] << " hit.posArray()[1] " << hit.posArray()[1]
+                    << " hit.posArray()[2] " << hit.posArray()[2] << std::endl;
+          std::cout << "m_msPar " << m_msPar(i, 0, 0) << std::endl;
+#endif
+          unsigned int mid = hit.detIDinLayer();
+          const ModuleInfo &mi = L.layer_info().module_info(mid);
+          norm.At(i, 0, 0) = mi.zdir[0];
+          norm.At(i, 1, 0) = mi.zdir[1];
+          norm.At(i, 2, 0) = mi.zdir[2];
+          dir.At(i, 0, 0) = mi.xdir[0];
+          dir.At(i, 1, 0) = mi.xdir[1];
+          dir.At(i, 2, 0) = mi.xdir[2];
+          pnt.At(i, 0, 0) = mi.pos[0];
+          pnt.At(i, 1, 0) = mi.pos[1];
+          pnt.At(i, 2, 0) = mi.pos[2];
+#ifdef DEBUG_FIT_BKW
+          std::cout << "mi.pos[0] " << mi.pos[0] << " mi.pos[1] " << mi.pos[1] << " mi.pos[2] " << mi.pos[2]
+                    << std::endl;
+          std::cout << "pnt[0] " << pnt(i, 0, 0) << " pnt[1] " << pnt(i, 1, 0) << " pnt[2] " << pnt(i, 2, 0)
+                    << std::endl;
+          std::cout << "at the track " << i << " / " << N_proc << " check the material " << std::endl;
+#endif
+          if (hitIndex[i] < (int)indices.size() &&
+              m_HoTArr[i][index].layer == m_HoTArr[i][indices[hitIndex[i]]].layer) {
+            no_mat_effs[i] = 1;
+#ifdef DEBUG_FIT_BKW
+            std::cout << "at the hit " << index << " Remove the material because it was applied in hit "
+                      << indices[hitIndex[i]] << std::endl;
+            std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                      << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+#endif
+          }
+#ifdef DEBUG_FIT_BKW
+          else {
+            std::cout << "at the hit " << index << " Don't remove the material" << std::endl;
+            if (hitIndex[i] < (int)indices.size())
+              std::cout << "layers are " << m_HoTArr[i][index].layer << " and  "
+                        << m_HoTArr[i][indices[hitIndex[i]]].layer << std::endl;
+          }
+#endif
+        }
+        hitIndex[i]--;
+      }  //end of track by track loop
+
+#ifdef DEBUG_FIT_BKW
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right before propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "outChi2 " << outChi2[i] << std::endl;
+        std::cout << norm.At(i, 0, 0) << " " << norm.At(i, 1, 0) << " " << norm.At(i, 2, 0) << " "
+                  << "NORM" << std::endl;
+        std::cout << dir.At(i, 0, 0) << " " << dir.At(i, 1, 0) << " " << dir.At(i, 2, 0) << " "
+                  << "DIR" << std::endl;
+        std::cout << pnt.At(i, 0, 0) << " " << pnt.At(i, 1, 0) << " " << pnt.At(i, 2, 0) << " "
+                  << "PNT" << std::endl;
+      }
+#endif
+
+      kalmanPropagateAndUpdateAndChi2Plane(m_Err[i1],
+                                           m_Par[i1],
+                                           m_Chg,
+                                           m_msErr,
+                                           m_msPar,
+                                           norm,
+                                           dir,
+                                           pnt,
+                                           m_Err[i2],
+                                           m_Par[i2],
+                                           m_FailFlag,
+                                           outChi2,
+                                           N_proc,
+                                           *refit_flags,
+                                           true,
+                                           &no_mat_effs,
+                                           &do_cpe,
+                                           m_cpe_corr_func);
+
+#ifdef DEBUG_FIT_BKW
+      std::cout << " i1 " << i1 << " iP " << iP << " iC " << iC << std::endl;
+
+      std::cout << "++++++++++++++++++++++++++\n" << std::endl;
+      for (int i = 0; i < N_proc; ++i)  //loop over tracks in group
+      {
+        std::cout << "right after propagation at hit " << h << " index NP " << i + 1 << "/" << N_proc << std::endl;
+        std::cout << "update parameters" << std::endl;
+        std::cout << "propagated track parameters x=" << m_Par[i1].constAt(i, 0, 0)
+                  << " y=" << m_Par[i1].constAt(i, 1, 0) << " z=" << m_Par[i1].constAt(i, 2, 0) << std::endl;
+        std::cout << "               hit position x=" << m_msPar.constAt(i, 0, 0) << " y=" << m_msPar.constAt(i, 1, 0)
+                  << " z=" << m_msPar.constAt(i, 2, 0) << std::endl;
+        std::cout << "   updated track parameters x=" << m_Par[i2].constAt(i, 0, 0)
+                  << " y=" << m_Par[i2].constAt(i, 1, 0) << " z=" << m_Par[i2].constAt(i, 2, 0) << std::endl;
+        std::cout << "outChi2 " << outChi2[i] << std::endl;
+      }
+#endif
+      std::swap(i1, i2);
+
+      // update chi2
+      m_Chi2.add(outChi2);
+      for (int i = 0; i < N_proc; ++i) {
+        chi2[h + i * nFoundHits] = outChi2[i];
+      }
+
+    }  //end of loop over n hits
+  }  //end of fit func
 
   //------------------------------------------------------------------------------
 

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -175,6 +175,25 @@ namespace mkfit {
 
     //----------------------------------------------------------------------------
 
+    void fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
+    void fwdFitFitTracks(const EventOfHits &eventofhits,
+                         const int N_proc,
+                         int nFoundHits,
+                         std::vector<std::vector<int>> indices_R2Z,
+                         float *chi2);
+    void bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
+    void bkReFitFitTracks(const EventOfHits &eventofhits,
+                          const int N_proc,
+                          int nFoundHits,
+                          std::vector<std::vector<int>> indices_R2Z,
+                          float *chi2);
+    void reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw = false);
+    std::vector<std::vector<int>> reFitIndices(const EventOfHits &eventofhits, const int N_proc, int nFoundHits);
+
+    void set_cpe(cpe_func cpe_function) { m_cpe_corr_func = cpe_function; };
+
+    //----------------------------------------------------------------------------
+
   private:
     void copy_in(const Track &trk, const int mslot, const int tslot) {
       m_Err[tslot].copyIn(mslot, trk.errors().Array());
@@ -341,6 +360,8 @@ namespace mkfit {
     const SteeringParams *m_steering_params = nullptr;
     const std::vector<bool> *m_iteration_hit_mask = nullptr;
     const Event *m_event = nullptr;
+    const PropagationFlags *refit_flags = nullptr;
+    cpe_func m_cpe_corr_func = nullptr;
     int m_current_region = -1;
     bool m_in_fwd = true;
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -540,7 +540,7 @@ _trackValidatorSeedingBuilding = trackValidator.clone( # common for built tracks
 trackValidatorBuilding = _trackValidatorSeedingBuilding.clone(
     dirName = "Tracking/TrackBuilding/",
     doMVAPlots = True,
-    doResolutionPlotsForLabels = ['jetCoreRegionalStepTracks']
+    doResolutionPlotsForLabels = ['jetCoreRegionalStepTracks','initialStepTracks']
 )
 trackValidatorBuildingPreSplitting = trackValidatorBuilding.clone(
     associators = ["quickTrackAssociatorByHitsPreSplitting"],


### PR DESCRIPTION
#### PR description:

the structure is a bit more convoluted compared to the previous draft PR https://github.com/trackreco/cmssw/pull/154
due to the outlier rejection, CPE, conversion into the track format, while the core of the fit is very similar

- the core of the fit is still in mkFinder.cc (could replace the mkFitter file currently not used), with these functions

```
void fwdFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
void fwdFitFitTracks(const EventOfHits &eventofhits,
                     const int N_proc,
                     int nFoundHits,
                     std::vector<std::vector<int>> indices_R2Z,
                     float *chi2);
void bkReFitInputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end);
void bkReFitFitTracks(const EventOfHits &eventofhits,
                      const int N_proc,
                      int nFoundHits,
                      std::vector<std::vector<int>> indices_R2Z,
                      float *chi2);
void reFitOutputTracks(TrackVec &cands, std::vector<int> inds, int beg, int end, int nFoundHits, bool bkw = false);
std::vector<std::vector<int>> reFitIndices(const EventOfHits &eventofhits, const int N_proc, int nFoundHits);
```

- the fit is called by mkBuilder.cc, via the wrapper

```   
void fittracks();

```

- and the main function, which handles track batches

```
void fit_tracks(MkFinder *mkfndr,
                int nFoundTracks,
                std::vector<int> inds,
                int start_trk,
                int end_trk,
                std::map<int, std::vector<int>> *remap = nullptr);
```

- the function above also handles the outlier rejection by chi2 as it removes hits based on chi2 and remaps the tracks into the new groups by hit number if passed a map pointer (not sure this is the best way to handle this part of the code)

- the CPE lambda is defined in `RecoTracker/MkFit/plugins/MkFitProducer.cc`

- and called in `RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc`, where some modifications were needed in `kalmanOperationPlaneLocal`

- Exporting tracks for cmssw and producing hits and extras collection is done in `RecoTracker/MkFit/plugins/MkFitOutputTrackConverter.cc`, written by adjusting `RecoTracker/MkFit/plugins/MkFitOutputConverter.cc`. Trajectories are not produced at all, and the steps after the build can't work with the current MVA selection

- The fit is turned on in RecoTracker/MkFitCMS/src/runFunctions.cc at lines 106-116 (the condition is the algorithm number, so InitialStepPresplitting is also passed trough the fit for no reason in the current tests)
